### PR TITLE
Update .pa11y-ci config file structure for correct usage of standard,…

### DIFF
--- a/.pa11yci
+++ b/.pa11yci
@@ -6,6 +6,6 @@
     "urls": [
         "http://localhost:3000",
         "http://localhost:3000/#/results",
-        "http://localhost:3000/#/details/1"
+        "http://localhost:3000/#/details/00025003"
     ]
 }

--- a/.pa11yci
+++ b/.pa11yci
@@ -1,8 +1,11 @@
 {
+    "defaults": {
+        "wait": 2000,
+        "standard": "WCAG2AA"
+    },
     "urls": [
         "http://localhost:3000",
         "http://localhost:3000/#/results",
         "http://localhost:3000/#/details/1"
-    ],
-    "allowedStandards": "WCAG2AA"
+    ]
 }

--- a/.pa11yci
+++ b/.pa11yci
@@ -6,6 +6,6 @@
     "urls": [
         "http://localhost:3000",
         "http://localhost:3000/#/results",
-        "http://localhost:3000/#/details/00025003"
+        "http://localhost:3000/#/details/00011111"
     ]
 }


### PR DESCRIPTION
… apply wait to allow pages to load

Two problems with previous `.pa11y-ci` config file.
- `standard` needed to be wrapped in a `default` object
- `wait` needs to be applied to allow ajax requests to complete