### PR TITLE
Migrating from HashRouter to BrowserRouter

### DIFF
--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -1,25 +1,11 @@
 import React from 'react';
-import { Switch, Route, HashRouter } from 'react-router-dom';
 
-import Home from '../../Containers/Home/Home';
-import Results from '../../Containers/Results/Results';
-import Details from '../../Containers/Details/Details';
+import Main from '../../Containers/Main/Main';
 
-const api = 'http://localhost:8000/api/v1';
-
-const App = () => (
-  <HashRouter>
-    <main>
-      <Switch>
-        <Route exact path="/" component={() => <Home api={api} />} />
-        <Route
-          path="/results"
-          component={props => <Results {...props} api={api} />}
-        />
-        <Route path="/details/:id" component={props => <Details {...props} api={api} />} />
-      </Switch>
-    </main>
-  </HashRouter>
+const App = props => (
+  <div>
+    <Main {...props} />
+  </div>
 );
 
 export default App;

--- a/src/Components/App/App.test.js
+++ b/src/Components/App/App.test.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { MemoryRouter } from 'react-router-dom';
 import App from './App';
 
 it('renders without crashing', () => {
   const div = document.createElement('div');
-  ReactDOM.render(<App />, div);
+  ReactDOM.render(<MemoryRouter><App api={'http://localhost:8000/api/v1'} /></MemoryRouter>, div);
   global.document.getElementById = id => id === 'root' && div;
 });

--- a/src/Components/ResultsList/ResultsList.js
+++ b/src/Components/ResultsList/ResultsList.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 import FavoritesButton from '../../Components/FavoritesButton/FavoritesButton';
 
 class ResultsList extends Component {
@@ -13,9 +14,9 @@ class ResultsList extends Component {
         { this.props.results.map((result, i) => (
           <div key={result.id} id={result.id} className="usa-grid-full" style={{ backgroundColor: '#DFDFDF', marginTop: '10px', marginBottom: '10px', padding: '15px 30px' }}>
             <div className="usa-width-one-half">
-              <a href={`/details/${result.position_number}`}>
+              <Link to={`/details/${result.position_number}`}>
                 <h3> Position Number: {result.position_number} </h3>
-              </a>
+              </Link>
               <p>
                   Grade: {result.grade}
                 <br />

--- a/src/Components/ResultsList/ResultsList.js
+++ b/src/Components/ResultsList/ResultsList.js
@@ -13,7 +13,7 @@ class ResultsList extends Component {
         { this.props.results.map((result, i) => (
           <div key={result.id} id={result.id} className="usa-grid-full" style={{ backgroundColor: '#DFDFDF', marginTop: '10px', marginBottom: '10px', padding: '15px 30px' }}>
             <div className="usa-width-one-half">
-              <a href={`/#/details/${result.position_number}`}>
+              <a href={`/details/${result.position_number}`}>
                 <h3> Position Number: {result.position_number} </h3>
               </a>
               <p>

--- a/src/Components/ResultsList/ResultsList.test.js
+++ b/src/Components/ResultsList/ResultsList.test.js
@@ -1,6 +1,7 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 import TestUtils from 'react-dom/test-utils';
+import { MemoryRouter } from 'react-router-dom';
 import ResultsList from './ResultsList';
 
 describe('ResultsListComponent', () => {
@@ -13,7 +14,9 @@ describe('ResultsListComponent', () => {
   ];
 
   beforeEach(() => {
-    results = TestUtils.renderIntoDocument(<ResultsList results={resultsArray} />);
+    results = TestUtils.renderIntoDocument(<MemoryRouter>
+      <ResultsList results={resultsArray} />
+    </MemoryRouter>);
   });
 
   it('is defined', () => {

--- a/src/Containers/Details/Details.js
+++ b/src/Containers/Details/Details.js
@@ -28,7 +28,7 @@ class Details extends Component {
   render() {
     const { details } = this.state;
     return (
-      <div id="main-content">
+      <div>
         {Object.keys(details).length ?
           <PositionDetails details={details} />
           :

--- a/src/Containers/Home/Home.js
+++ b/src/Containers/Home/Home.js
@@ -132,7 +132,7 @@ class Home extends Component {
     const enableSearch = this.shouldDisableSearch() ? 'hidden' : '';
     const disableSearch = this.shouldDisableSearch() ? '' : 'hidden';
     return (
-      <div id="main-content" className="home">
+      <div className="home">
         <br />
         <div className="page-container">
           <div className="usa-grid">

--- a/src/Containers/Home/Home.js
+++ b/src/Containers/Home/Home.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import queryString from 'query-string';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 import Wrapper from '../../Components/Wrapper/Wrapper';
 import { ajax } from '../../utilities';
 
@@ -149,11 +150,11 @@ class Home extends Component {
                     name="search"
                   />
                   <div id="enabled-search" className={enableSearch}>
-                    <a href={`/results?${qString}`}>
+                    <Link to={`/results?${qString}`}>
                       <button type="submit">
                         <span className="usa-search-submit-text">Search</span>
                       </button>
-                    </a>
+                    </Link>
                   </div>
                   <div id="disabled-search" className={disableSearch}>
                     <button className="usa-button-disabled" disabled="true" type="submit">

--- a/src/Containers/Home/Home.js
+++ b/src/Containers/Home/Home.js
@@ -149,7 +149,7 @@ class Home extends Component {
                     name="search"
                   />
                   <div id="enabled-search" className={enableSearch}>
-                    <a href={`/#/results?${qString}`}>
+                    <a href={`/results?${qString}`}>
                       <button type="submit">
                         <span className="usa-search-submit-text">Search</span>
                       </button>

--- a/src/Containers/Home/Home.test.js
+++ b/src/Containers/Home/Home.test.js
@@ -10,7 +10,6 @@ import Home from './Home';
 const api = 'http://localhost:8000/api/v1';
 
 describe('HomeComponent', () => {
-
   const filters = [
     [
           { id: 2, code: '0010', description: 'EXECUTIVE (PAS)' },

--- a/src/Containers/Home/Home.test.js
+++ b/src/Containers/Home/Home.test.js
@@ -2,6 +2,7 @@ import { shallow } from 'enzyme';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-dom/test-utils';
+import { MemoryRouter } from 'react-router-dom';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import Home from './Home';
@@ -9,7 +10,6 @@ import Home from './Home';
 const api = 'http://localhost:8000/api/v1';
 
 describe('HomeComponent', () => {
-  let home = null;
 
   const filters = [
     [
@@ -27,8 +27,6 @@ describe('HomeComponent', () => {
   ];
 
   beforeEach(() => {
-    home = TestUtils.renderIntoDocument(<Home api={api} location={{}} />);
-
     const mockAdapter = new MockAdapter(axios);
 
     mockAdapter.onGet('http://localhost:8000/api/v1/position/grades/').reply(200, [
@@ -47,10 +45,13 @@ describe('HomeComponent', () => {
 
   it('renders without crashing', () => {
     const div = document.createElement('div');
-    ReactDOM.render(<Home api={api} />, div);
+    ReactDOM.render(<MemoryRouter><Home api={api} /></MemoryRouter>, div);
   });
 
   it('is defined', () => {
+    const home = TestUtils.renderIntoDocument(<MemoryRouter>
+      <Home api={api} location={{}} />
+    </MemoryRouter>);
     expect(home).toBeDefined();
   });
 

--- a/src/Containers/Main/Main.jsx
+++ b/src/Containers/Main/Main.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Switch, Route } from 'react-router-dom';
+
+import Home from '../../Containers/Home/Home';
+import Results from '../../Containers/Results/Results';
+import Details from '../../Containers/Details/Details';
+
+const Main = props => (
+  <main id="main-content">
+    <Switch {...props}>
+      <Route exact path="/" component={() => <Home {...props} />} />
+      <Route
+        path="/results"
+        component={() => <Results {...props} />}
+      />
+      <Route path="/details/:id" component={() => <Details {...props} />} />
+    </Switch>
+  </main>
+);
+
+export default Main;

--- a/src/Containers/Main/Main.test.jsx
+++ b/src/Containers/Main/Main.test.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import TestUtils from 'react-dom/test-utils';
+import { MemoryRouter } from 'react-router-dom';
+import Main from './Main';
+
+describe('Main', () => {
+  const api = 'http://localhost:8000/api/v1';
+
+  it('is defined', () => {
+    const main = TestUtils.renderIntoDocument(<MemoryRouter>
+      <Main api={api} />
+    </MemoryRouter>);
+    expect(main).toBeDefined();
+  });
+  it('is handles a position details route', () => {
+    const resultsArray = [
+     { id: 6, grade: '05', skill: 'OFFICE MANAGEMENT (9017)', bureau: '150000', organization: 'YAOUNDE CAMEROON (YAOUNDE)', position_number: '00025003', is_overseas: true, create_date: '2006-09-20', update_date: '2017-06-08', languages: [{ id: 1, language: 'French (FR)', written_proficiency: '2', spoken_proficiency: '2', representation: 'French (FR) 2/2' }] },
+     { id: 80, grade: '05', skill: 'INFORMATION MANAGEMENT (2880)', bureau: '110000', organization: 'SAO PAULO BRAZIL (SAO PAULO)', position_number: '55115002', is_overseas: true, create_date: '2006-09-20', update_date: '2017-06-08', languages: [{ id: 22, language: 'Portuguese (PY)', written_proficiency: '1', spoken_proficiency: '1', representation: 'Portuguese (PY) 1/1' }] },
+    ];
+    const main = TestUtils.renderIntoDocument(<MemoryRouter initialEntries={['/results']}>
+      <Main api={api} results={resultsArray} />
+    </MemoryRouter>);
+    expect(main).toBeDefined();
+  });
+  it('is handles a position details route', () => {
+    const main = TestUtils.renderIntoDocument(<MemoryRouter initialEntries={['/details/00011111']}>
+      <Main api={api} />
+    </MemoryRouter>);
+    expect(main).toBeDefined();
+  });
+});

--- a/src/Containers/Results/Results.js
+++ b/src/Containers/Results/Results.js
@@ -30,7 +30,7 @@ class Results extends Component {
   render() {
     const { results } = this.state;
     return (
-      <div id="main-content">
+      <div>
         {results.length ?
           <ResultsList results={results} />
           :

--- a/src/Containers/Results/Results.js
+++ b/src/Containers/Results/Results.js
@@ -13,7 +13,7 @@ class Results extends Component {
 
   componentWillMount() {
     if (!this.props.results) { // eslint-disable-line react/prop-types
-      this.getPosts(this.props.location.search); // eslint-disable-line react/prop-types
+      this.getPosts(window.location.search); // eslint-disable-line react/prop-types
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { BrowserRouter } from 'react-router-dom';
 import './sass/styles.scss';
 import App from './Components/App/App';
 
 require('../node_modules/uswds/dist/js/uswds.min.js');
 
 ReactDOM.render((
-  <App />
+  <BrowserRouter>
+    <App api={'http://localhost:8000/api/v1'} />
+  </BrowserRouter>
 ), document.getElementById('root') || document.createElement('div'));


### PR DESCRIPTION
- Migrating application to use `BrowserRouter` instead of `HashRouter`
  - Remove hash from routes
- Creating `Main` container
  - This closes #169 
- Updated unit tests to use `MemoryRouter`