### PR TITLE
Use router context to access route parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "promise": "7.1.1",
     "react-dev-utils": "^3.0.0",
     "react-error-overlay": "^1.0.7",
+    "react-router-test-context": "^0.1.0",
     "react-test-renderer": "^15.6.1",
     "sass-loader": "^6.0.6",
     "style-loader": "0.17.0",

--- a/src/Containers/Details/Details.js
+++ b/src/Containers/Details/Details.js
@@ -4,6 +4,7 @@ import { ajax } from '../../utilities';
 import PositionDetails from '../../Components/PositionDetails/PositionDetails';
 
 class Details extends Component {
+
   constructor(props) {
     super(props);
     this.state = {
@@ -12,7 +13,7 @@ class Details extends Component {
   }
 
   componentWillMount() {
-    this.getDetails(this.props.match ? this.props.match.params.id : ''); // eslint-disable-line react/prop-types
+    this.getDetails(this.context.router.route.match.params.id);
   }
 
   getDetails(id) {
@@ -38,6 +39,10 @@ class Details extends Component {
     );
   }
 }
+
+Details.contextTypes = {
+  router: PropTypes.object,
+};
 
 Details.propTypes = {
   api: PropTypes.string.isRequired,

--- a/src/Containers/Details/Details.test.js
+++ b/src/Containers/Details/Details.test.js
@@ -1,13 +1,11 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-import TestUtils from 'react-dom/test-utils';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
+import createRouterContext from 'react-router-test-context';
 import Details from './Details';
 
 describe('DetailsComponent', () => {
-  let detailsItem = null;
-
   const id = '00003026';
   const idWithLang = '00003027';
 
@@ -40,7 +38,6 @@ describe('DetailsComponent', () => {
   };
 
   beforeEach(() => {
-    detailsItem = TestUtils.renderIntoDocument(<Details id={id} api={api} />);
     const mockAdapter = new MockAdapter(axios);
 
     mockAdapter.onGet('http://localhost:8000/api/v1/position/?position_number=00003026').reply(200, [
@@ -55,9 +52,12 @@ describe('DetailsComponent', () => {
   });
 
   it('is defined', (done) => {
+    const context = createRouterContext();
+    context.router.route.match.params.id = id;
+    const wrapper = shallow(<Details api={api} />, { context });
     const f = () => {
       setTimeout(() => {
-        expect(detailsItem).toBeDefined();
+        expect(wrapper).toBeDefined();
         done();
       }, 0);
     };
@@ -65,7 +65,9 @@ describe('DetailsComponent', () => {
   });
 
   it('can set state of details', (done) => {
-    const wrapper = shallow(<Details match={{ params: { id } }} api={api} />);
+    const context = createRouterContext();
+    context.router.route.match.params.id = id;
+    const wrapper = shallow(<Details api={api} />, { context });
 
     const f = () => {
       setTimeout(() => {
@@ -77,7 +79,9 @@ describe('DetailsComponent', () => {
   });
 
   it('can set state of details with languages', (done) => {
-    const wrapper = shallow(<Details match={{ params: { id: idWithLang } }} api={api} />);
+    const context = createRouterContext();
+    context.router.route.match.params.id = idWithLang;
+    const wrapper = shallow(<Details api={api} />, { context });
 
     const f = () => {
       setTimeout(() => {

--- a/src/Containers/Main/Main.test.jsx
+++ b/src/Containers/Main/Main.test.jsx
@@ -1,10 +1,34 @@
 import React from 'react';
 import TestUtils from 'react-dom/test-utils';
 import { MemoryRouter } from 'react-router-dom';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter'; // eslint-disable-line
 import Main from './Main';
 
 describe('Main', () => {
   const api = 'http://localhost:8000/api/v1';
+
+  beforeEach(() => {
+    const mockAdapter = new MockAdapter(axios);
+
+    const details = {
+      id: 4,
+      grade: '05',
+      skill: 'OFFICE MANAGEMENT (9017)',
+      bureau: '150000',
+      organization: 'FREETOWN SIERRA LEONE (FREETOWN)',
+      position_number: '00011111',
+      is_overseas: true,
+      create_date: '2006-09-20',
+      update_date: '2017-06-08',
+      languages: [],
+    };
+
+    mockAdapter.onGet('http://localhost:8000/api/v1/position/?position_number=00011111').reply(200, [
+      details,
+    ],
+    );
+  });
 
   it('is defined', () => {
     const main = TestUtils.renderIntoDocument(<MemoryRouter>


### PR DESCRIPTION
## fixes position number not getting passed to axios request on Details page

With the update to `<BrowserRouter>` in #181 , requests on the Details page broke due to inaccessible ID parameter. This PR accesses `this.context` to determine the `:id` route parameter.