### PR TITLE
Sprint 3 review updates

### DIFF
--- a/src/Components/CompareList/CompareList.jsx
+++ b/src/Components/CompareList/CompareList.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import { RESULTS, EMPTY_FUNCTION } from '../../Constants/PropTypes';
+import { POSITION_SEARCH_RESULTS, EMPTY_FUNCTION } from '../../Constants/PropTypes';
 import LanguageList from '../LanguageList/LanguageList';
 import * as AlertMessages from '../../Constants/AlertMessages';
 
@@ -55,7 +55,7 @@ class CompareList extends Component {
 }
 
 CompareList.propTypes = {
-  compare: RESULTS,
+  compare: POSITION_SEARCH_RESULTS,
   onToggle: PropTypes.func,
 };
 

--- a/src/Components/CompareList/CompareList.test.jsx
+++ b/src/Components/CompareList/CompareList.test.jsx
@@ -48,12 +48,12 @@ describe('CompareListComponent', () => {
     expect(compare).toBeDefined();
   });
 
-  it('is can receive props', () => {
+  it('can receive props', () => {
     wrapper = shallow(<CompareList compare={compareArray} />);
     expect(wrapper.instance().props.compare[0].id).toBe(6);
   });
 
-  it('is can call the onChildToggle function', () => {
+  it('can call the onChildToggle function', () => {
     wrapper = shallow(<CompareList compare={compareArray} />);
     wrapper.instance().onChildToggle();
     expect(wrapper).toBeDefined();

--- a/src/Components/FavoritesButton/FavoritesButton.jsx
+++ b/src/Components/FavoritesButton/FavoritesButton.jsx
@@ -36,11 +36,7 @@ class FavoritesButton extends Component {
   }
 
   exceedsLimit() {
-    let result = false;
-    if (this.state.len >= this.props.limit) {
-      result = true;
-    }
-    return result;
+    return this.state.len >= this.props.limit;
   }
 
   toggleSaved() {

--- a/src/Components/FavoritesButton/FavoritesButton.test.jsx
+++ b/src/Components/FavoritesButton/FavoritesButton.test.jsx
@@ -14,7 +14,7 @@ describe('FavoritesButton', () => {
     expect(favoritesButton).toBeDefined();
   });
 
-  it('it can accept different kinds of props', () => {
+  it('can accept different kinds of props', () => {
     const favoritesButtonCompare = shallow(
       <FavoritesButton refKey="0037" type="compare" />,
      );

--- a/src/Components/Filters/Filters.test.jsx
+++ b/src/Components/Filters/Filters.test.jsx
@@ -151,6 +151,22 @@ describe('FiltersComponent', () => {
     f();
   });
 
+  it('can call the createQueryString function to create multi-parameter query strings', (done) => {
+    wrapper = shallow(<Filters api={api} items={items} />, { context });
+    const f = () => {
+      setTimeout(() => {
+        wrapper.instance().changeText({ target: { value: 'info Tech' } });
+        wrapper.find('#S0010').simulate('change', (0, { target: { checked: true, value: '0010' } }));
+        wrapper.find('#S0020').simulate('change', (0, { target: { checked: true, value: '0020' } }));
+        wrapper.find('#TOD00').simulate('change', (0, { target: { checked: true, value: '2' } }));
+        wrapper.find('#R00').simulate('change', (0, { target: { checked: true, value: '2' } }));
+        expect(wrapper.instance().state.qString).toBe('organization__code__in=2&post__tour_of_duty__in=2&q=info%20Tech&skill__code__in=0010%2C0020');
+        done();
+      }, 0);
+    };
+    f();
+  });
+
   it('can check a checkbox', (done) => {
     wrapper = shallow(<Filters api={api} items={items} />, { context });
     const f = () => {

--- a/src/Components/Filters/Filters.test.jsx
+++ b/src/Components/Filters/Filters.test.jsx
@@ -206,16 +206,16 @@ describe('FiltersComponent', () => {
     wrapper = shallow(<Filters api={api} items={items} />, { context });
     const f = () => {
       setTimeout(() => {
-    // no filters are initially set, so should return true
+        // no filters are initially set, so should return true
         expect(wrapper.instance().shouldDisableSearch()).toBe(true);
-    // enable search filter
+        // enable search filter
         wrapper.find('#search-field').simulate('change', { target: { value: 'test' } });
-    // select a checkbox filter
+        // select a checkbox filter
         wrapper.find('#S0010').simulate('change', (0, { target: { checked: true, value: '0010' } }));
         expect(wrapper.instance().shouldDisableSearch()).toBe(false);
-    // remove the original search filter
+        // remove the original search filter
         wrapper.find('#search-field').simulate('change', { target: { value: '' } });
-    // one filter is selected, should return false
+        // one filter is selected, should return false
         expect(wrapper.instance().shouldDisableSearch()).toBe(true);
         done();
       }, 0);
@@ -227,11 +227,11 @@ describe('FiltersComponent', () => {
     wrapper = shallow(<Filters api={api} items={items} />, { context });
     const f = () => {
       setTimeout(() => {
-    // no filters are initially set, so should return true
+        // no filters are initially set, so should return true
         expect(wrapper.instance().shouldDisableSearch()).toBe(true);
-    // select a language filter
+        // select a language filter
         wrapper.find('#LAB').simulate('change', (1, { target: { checked: true, value: 'AB' } }));
-    // select a skill filter
+        // select a skill filter
         wrapper.find('#S0010').simulate('change', (0, { target: { checked: true, value: '0010' } }));
         expect(wrapper.instance().shouldDisableSearch()).toBe(false);
         done();
@@ -244,13 +244,13 @@ describe('FiltersComponent', () => {
     wrapper = shallow(<Filters api={api} items={items} />, { context });
     const f = () => {
       setTimeout(() => {
-    // change English written to 1
+        // change English written to 1
         wrapper.find('#Albanian-written-1').simulate('click', ('Albanian-written', '1', 1));
-    // change English spoken to 1
+        // change English spoken to 1
         wrapper.find('#Albanian-spoken-1').simulate('click', ('Albanian-written', '1', 1));
-    // English written should be 1
+        // English written should be 1
         expect(wrapper.instance().state.proficiency['Albanian-written']).toBe('1');
-    // English spoken should be 1
+        // English spoken should be 1
         expect(wrapper.instance().state.proficiency['Albanian-spoken']).toBe('1');
         done();
       }, 0);

--- a/src/Components/Loading/Loading.test.jsx
+++ b/src/Components/Loading/Loading.test.jsx
@@ -8,7 +8,7 @@ describe('Loading', () => {
     expect(loading).toBeDefined();
   });
 
-  it('is can take different props', () => {
+  it('can take different props', () => {
     let loading = null;
     loading = shallow(<Loading isLoading={false} hasErrored />);
     expect(loading).toBeDefined();

--- a/src/Components/PositionDetails/PositionDetails.test.jsx
+++ b/src/Components/PositionDetails/PositionDetails.test.jsx
@@ -24,7 +24,7 @@ describe('PositionDetailsComponent', () => {
   beforeEach(() => {
   });
 
-  it('is can receive props', () => {
+  it('can receive props', () => {
     wrapper = shallow(
       <PositionDetails api={api} details={detailsObject} isLoading={false} hasErrored={false} />,
     );

--- a/src/Components/PostMissionData/PostMissionData.test.jsx
+++ b/src/Components/PostMissionData/PostMissionData.test.jsx
@@ -32,13 +32,13 @@ describe('PostMissionDataComponent', () => {
     expect(postMissionData).toBeDefined();
   });
 
-  it('is can receive props', () => {
+  it('can receive props', () => {
     wrapper = shallow(<PostMissionData post={postObject} />);
     expect(wrapper.instance().props.post.id).toBe(100);
     expect(wrapper.instance().props.post.has_service_needs_differential).toBe(true);
   });
 
-  it('is can receive props with false values', () => {
+  it('can receive props with false values', () => {
     Object.assign(postObject, {
       languages: [],
       has_consumable_allowance: null,

--- a/src/Components/ResultsList/ResultsList.jsx
+++ b/src/Components/ResultsList/ResultsList.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import FavoritesButton from '../../Components/FavoritesButton/FavoritesButton';
-import { RESULTS, EMPTY_FUNCTION } from '../../Constants/PropTypes';
+import { POSITION_SEARCH_RESULTS, EMPTY_FUNCTION } from '../../Constants/PropTypes';
 import * as AlertMessages from '../../Constants/AlertMessages';
 
 class ResultsList extends Component {
@@ -53,7 +53,7 @@ class ResultsList extends Component {
 }
 
 ResultsList.propTypes = {
-  results: RESULTS,
+  results: POSITION_SEARCH_RESULTS,
   onToggle: PropTypes.func,
 };
 

--- a/src/Components/ResultsList/ResultsList.test.jsx
+++ b/src/Components/ResultsList/ResultsList.test.jsx
@@ -47,12 +47,12 @@ describe('ResultsListComponent', () => {
     expect(results).toBeDefined();
   });
 
-  it('is can receive props', () => {
+  it('can receive props', () => {
     wrapper = shallow(<ResultsList results={resultsArray} />);
     expect(wrapper.instance().props.results[0].id).toBe(6);
   });
 
-  it('is can call the onChildToggle function', () => {
+  it('can call the onChildToggle function', () => {
     wrapper = shallow(<ResultsList results={resultsArray} />);
     wrapper.instance().onChildToggle();
   });

--- a/src/Components/ResultsPage/ResultsPage.jsx
+++ b/src/Components/ResultsPage/ResultsPage.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ResultsList from '../ResultsList/ResultsList';
-import { RESULTS } from '../../Constants/PropTypes';
+import { POSITION_SEARCH_RESULTS } from '../../Constants/PropTypes';
 import ViewComparisonLink from '../ViewComparisonLink/ViewComparisonLink';
 import ResetComparisons from '../ResetComparisons/ResetComparisons';
 import ResetFiltersConnect from '../ResetFilters/ResetFiltersConnect';
@@ -56,7 +56,7 @@ class Results extends Component {
 Results.propTypes = {
   hasErrored: PropTypes.bool.isRequired,
   isLoading: PropTypes.bool.isRequired,
-  results: RESULTS,
+  results: POSITION_SEARCH_RESULTS,
 };
 
 Results.defaultProps = {

--- a/src/Components/ResultsPage/ResultsPage.test.jsx
+++ b/src/Components/ResultsPage/ResultsPage.test.jsx
@@ -39,17 +39,17 @@ describe('ResultsPageComponent', () => {
     expect(wrapper).toBeDefined();
   });
 
-  it('is can receive props', () => {
+  it('can receive props', () => {
     wrapper = shallow(<ResultsPage results={resultsArray} hasErrored isLoading={false} />);
     expect(wrapper.instance().props.results[0].id).toBe(6);
   });
 
-  it('is can receive props', () => {
+  it('can receive props', () => {
     wrapper = shallow(<ResultsPage hasErrored={false} isLoading={false} />);
     expect(wrapper).toBeDefined();
   });
 
-  it('is can call the onChildToggle function', () => {
+  it('can call the onChildToggle function', () => {
     wrapper = shallow(<ResultsPage results={resultsArray} />);
     wrapper.instance().onChildToggle();
     expect(wrapper).toBeDefined();

--- a/src/Components/Share/ShareButton/ShareButton.jsx
+++ b/src/Components/Share/ShareButton/ShareButton.jsx
@@ -51,7 +51,7 @@ class ShareButton extends Component {
         <input
           id="share-input"
           name="input-type-text"
-          type="text"
+          type="email"
           value={this.state.recipient}
           onChange={e => this.changeEmail(e)}
           placeholder="Recipient's email address"

--- a/src/Components/Share/ShareButton/ShareButton.jsx
+++ b/src/Components/Share/ShareButton/ShareButton.jsx
@@ -54,7 +54,7 @@ class ShareButton extends Component {
           type="text"
           value={this.state.recipient}
           onChange={e => this.changeEmail(e)}
-          placeholder="Receipient's email address"
+          placeholder="Recipient's email address"
         />
         <button className={(recipient.length && !isSending) ? null : 'usa-button-disabled'} disabled={recipient.length ? null : true} id="share-button">
           Share

--- a/src/Components/ViewComparisonLink/ViewComparisonLink.jsx
+++ b/src/Components/ViewComparisonLink/ViewComparisonLink.jsx
@@ -2,19 +2,14 @@ import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { EMPTY_FUNCTION } from '../../Constants/PropTypes';
+import { localStorageFetchValue } from '../../utilities';
 
 class ViewComparisonLink extends Component {
 
   render() {
     const exists = () => {
-      let result = false;
-      const retrievedKey = localStorage
-                            .getItem('compare');
-      const parsedKey = JSON.parse(retrievedKey);
-      if (parsedKey && parsedKey.length) {
-        result = true;
-      }
-      return result;
+      const retrievedKey = localStorageFetchValue('compare', null);
+      return !!retrievedKey.len;
     };
     let url = JSON.parse(localStorage.getItem('compare'));
     url = url ? `compare/${url.toString()}` : 'compare';

--- a/src/Constants/PropTypes.js
+++ b/src/Constants/PropTypes.js
@@ -41,7 +41,7 @@ export const POSITION_DETAILS = PropTypes.shape({
   languages: LANGUAGES,
 });
 
-export const RESULTS = PropTypes.arrayOf(
+export const POSITION_SEARCH_RESULTS = PropTypes.arrayOf(
   POSITION_DETAILS,
 );
 

--- a/src/Constants/PropTypes.test.js
+++ b/src/Constants/PropTypes.test.js
@@ -13,8 +13,8 @@ describe('AlertMessages', () => {
     expect(PropTypes.POSITION_DETAILS).toBeDefined();
   });
 
-  it('Should return RESULTS', () => {
-    expect(PropTypes.RESULTS).toBeDefined();
+  it('Should return POSITION_SEARCH_RESULTS', () => {
+    expect(PropTypes.POSITION_SEARCH_RESULTS).toBeDefined();
   });
 
   it('Should return FILTERS', () => {

--- a/src/Containers/Compare/Compare.jsx
+++ b/src/Containers/Compare/Compare.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import { comparisonsFetchData } from '../../actions/comparisons';
 import CompareList from '../../Components/CompareList/CompareList';
-import { RESULTS } from '../../Constants/PropTypes';
+import { POSITION_SEARCH_RESULTS } from '../../Constants/PropTypes';
 
 class Results extends Component {
   constructor(props) {
@@ -44,7 +44,7 @@ Results.propTypes = {
   fetchData: PropTypes.func.isRequired,
   hasErrored: PropTypes.bool.isRequired,
   isLoading: PropTypes.bool.isRequired,
-  comparisons: RESULTS,
+  comparisons: POSITION_SEARCH_RESULTS,
 };
 
 Results.defaultProps = {

--- a/src/Containers/Main/Main.test.jsx
+++ b/src/Containers/Main/Main.test.jsx
@@ -36,7 +36,7 @@ describe('Main', () => {
     </MemoryRouter>);
     expect(main).toBeDefined();
   });
-  it('is handles a position details route', () => {
+  it('handles a position details route', () => {
     const resultsArray = [
       { id: 6,
         grade: '05',
@@ -70,13 +70,13 @@ describe('Main', () => {
     </MemoryRouter>);
     expect(main).toBeDefined();
   });
-  it('is handles a position details route', () => {
+  it('handles a position details route', () => {
     const main = TestUtils.renderIntoDocument(<MemoryRouter initialEntries={['/details/00011111']}>
       <Main api={api} />
     </MemoryRouter>);
     expect(main).toBeDefined();
   });
-  it('is handles a post details route', () => {
+  it('handles a post details route', () => {
     const main = TestUtils.renderIntoDocument(<MemoryRouter initialEntries={['/post/00011111']}>
       <Main api={api} />
     </MemoryRouter>);

--- a/src/Containers/Results/Results.jsx
+++ b/src/Containers/Results/Results.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { resultsFetchData } from '../../actions/results';
 import ResultsPage from '../../Components/ResultsPage/ResultsPage';
-import { RESULTS } from '../../Constants/PropTypes';
+import { POSITION_SEARCH_RESULTS } from '../../Constants/PropTypes';
 
 class Results extends Component {
   constructor(props) {
@@ -40,7 +40,7 @@ Results.propTypes = {
   fetchData: PropTypes.func.isRequired,
   hasErrored: PropTypes.bool.isRequired,
   isLoading: PropTypes.bool.isRequired,
-  results: RESULTS,
+  results: POSITION_SEARCH_RESULTS,
 };
 
 Results.defaultProps = {

--- a/src/actions/comparisons.test.js
+++ b/src/actions/comparisons.test.js
@@ -51,7 +51,6 @@ describe('async actions', () => {
     const f = () => {
       setTimeout(() => {
         store.dispatch(actions.comparisonsFetchData('http://localhost:8000/api/v1/comparisons/'));
-    // .then(do something)
         store.dispatch(actions.comparisonsIsLoading());
         done();
       }, 0);

--- a/src/actions/filters.test.js
+++ b/src/actions/filters.test.js
@@ -60,7 +60,6 @@ describe('async actions', () => {
     const f = () => {
       setTimeout(() => {
         store.dispatch(actions.filtersFetchData(api, items, 't'));
-    // .then(do something)
         store.dispatch(actions.filtersIsLoading());
         done();
       }, 0);

--- a/src/actions/positionDetails.test.js
+++ b/src/actions/positionDetails.test.js
@@ -35,7 +35,6 @@ describe('async actions', () => {
     const f = () => {
       setTimeout(() => {
         store.dispatch(actions.positionDetailsFetchData('http://localhost:8000/api/v1/position/?position_number=00011111'));
-    // .then(do something)
         store.dispatch(actions.positionDetailsIsLoading());
         done();
       }, 0);

--- a/src/actions/post.test.js
+++ b/src/actions/post.test.js
@@ -36,7 +36,6 @@ describe('async actions', () => {
     const f = () => {
       setTimeout(() => {
         store.dispatch(actions.postFetchData('http://localhost:8000/api/v1/post/100'));
-    // .then(do something)
         store.dispatch(actions.postIsLoading());
         done();
       }, 0);

--- a/src/actions/results.test.js
+++ b/src/actions/results.test.js
@@ -51,7 +51,6 @@ describe('async actions', () => {
     const f = () => {
       setTimeout(() => {
         store.dispatch(actions.resultsFetchData('http://localhost:8000/api/v1/results/'));
-    // .then(do something)
         store.dispatch(actions.resultsIsLoading());
         done();
       }, 0);

--- a/src/actions/share.test.js
+++ b/src/actions/share.test.js
@@ -37,7 +37,6 @@ describe('async actions', () => {
     const f = () => {
       setTimeout(() => {
         store.dispatch(actions.shareSendData('http://localhost:8000/api/v1/share/', message));
-    // .then(do something)
         store.dispatch(actions.shareIsSending());
         done();
       }, 0);
@@ -58,7 +57,6 @@ describe('async actions', () => {
     const f = () => {
       setTimeout(() => {
         store.dispatch(actions.shareSendData('http://localhost:8000/api/v1/share/failure', message));
-    // .then(do something)
         store.dispatch(actions.shareIsSending());
         done();
       }, 0);

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -42,8 +42,7 @@ export function localStorageToggleValue(key, value) {
 }
 
 export function validStateEmail(email) {
-  const valid = (/@state.gov\s*$/.test(email));
-  return valid;
+  return /.+@state.gov$/.test(email.trim());
 }
 
 export default ajax;

--- a/src/utilities.test.js
+++ b/src/utilities.test.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
-import { ajax, validStateEmail } from './utilities';
+import { ajax, validStateEmail, localStorageFetchValue, localStorageToggleValue } from './utilities';
 
 const posts = [
   { id: 6, grade: '05', skill: 'OFFICE MANAGEMENT (9017)', bureau: '150000', organization: 'YAOUNDE CAMEROON (YAOUNDE)', position_number: '00025003', is_overseas: true, create_date: '2006-09-20', update_date: '2017-06-08', languages: [{ id: 1, language: 'French (FR)', written_proficiency: '2', spoken_proficiency: '2', representation: 'French (FR) 2/2' }] },
@@ -26,6 +26,46 @@ describe('ajax', () => {
       }, 0);
     };
     f();
+  });
+});
+
+describe('local storage', () => {
+  it('should be able to fetch the existence of a value when there is one values in the array', () => {
+    localStorage.setItem('key', JSON.stringify(['1']));
+    const retrieved = localStorageFetchValue('key', '1');
+    expect(retrieved.exists).toBe(true);
+    localStorage.clear();
+  });
+
+  it('should be able to fetch the existence of a value when there are multiple values in the array', () => {
+    localStorage.setItem('key', JSON.stringify(['1', '2']));
+    const retrieved = localStorageFetchValue('key', '1');
+    expect(retrieved.exists).toBe(true);
+    localStorage.clear();
+  });
+
+  it('should be able to fetch the existence of a value when that value is not in the array', () => {
+    localStorage.setItem('key', JSON.stringify(['2', '3']));
+    const retrieved = localStorageFetchValue('key', '1');
+    expect(retrieved.exists).toBe(false);
+    localStorage.clear();
+  });
+
+  it('should be able to fetch the length of an array', () => {
+    localStorage.setItem('key', JSON.stringify(['1', '2']));
+    const retrieved = localStorageFetchValue('key', '1');
+    expect(retrieved.len).toBe(2);
+    localStorage.clear();
+  });
+
+  it('should be able to toggle a value in the array', () => {
+    localStorage.setItem('key', JSON.stringify(['1', '2']));
+    let retrieved = localStorageFetchValue('key', '1');
+    expect(retrieved.exists).toBe(true);
+    localStorageToggleValue('key', '1');
+    retrieved = localStorageFetchValue('key', '1');
+    expect(retrieved.exists).toBe(false);
+    localStorage.clear();
   });
 });
 


### PR DESCRIPTION
Addresses Sprint 3 feedback provided by @jseppi in #234 . While not exhaustive, this PR addresses a majority of the feedback provided. Issues exist for any outstanding tasks.

This PR addresses:
- A typo of the word "recipient"
- The use of "email" input type for the position-sharing form #243 
- Proper verbiage for test names #244 
- Simplification of the exceedsLimit function, used for determining the number of favorites/comparisons to allow #251
- A more thorough State.gov email regular expression check #246 
- More thorough tests for the createQueryString function #250
- Removal of unnecessary comments in tests #263 
- Fixed indentation of comment lines
- Local storage utility tests #245 
- Use of the local storage utility for the ViewComparisonLink component #264 
- More descriptive PropType constant names #269 