### PR TITLE
Fix uncaught sharing errors

### DIFF
--- a/src/actions/share.js
+++ b/src/actions/share.js
@@ -33,7 +33,7 @@ export function shareSendData(url, data) {
             })
             .then(share => dispatch(shareSuccess(share)))
             .catch((err) => {
-              dispatch(shareHasErrored(err.response.data.message));
+              dispatch(shareHasErrored(err.response.data.message || 'An error occurred trying to share this position.'));
               dispatch(shareIsSending(false));
               dispatch(shareSuccess(false));
               return err.response.data.message;


### PR DESCRIPTION
An uncaught error occurs if the user's token has expired and they try to share a position. This is a temporary fix for https://github.com/18F/State-TalentMAP/issues/313 until token expiration checks are implemented in https://github.com/18F/State-TalentMAP-API/issues/52