### PR TITLE
API Fixes

### DIFF
--- a/src/Components/CompareList/CompareList.jsx
+++ b/src/Components/CompareList/CompareList.jsx
@@ -36,7 +36,7 @@ class CompareList extends Component {
                 <br />
                   Language: <LanguageList languages={result.languages} />
                 <br />
-                  Post: {result.post ? <Link to={`/post/${result.post.id}`}>{result.post.description}</Link> : SystemMessages.NO_POST }
+                  Post: {result.post ? <Link to={`/post/${result.post.id}`}>{result.post.location}</Link> : SystemMessages.NO_POST }
                 <br />
                   Post Differential: {result.post ?
                     result.post.differential_rate : SystemMessages.NO_POST_DIFFERENTIAL}

--- a/src/Components/CompareList/CompareList.test.jsx
+++ b/src/Components/CompareList/CompareList.test.jsx
@@ -18,7 +18,7 @@ describe('CompareListComponent', () => {
       is_overseas: true,
       create_date: '2006-09-20',
       update_date: '2017-06-08',
-      post: { id: 162, tour_of_duty: '2YRR', code: 'LT6000000', description: 'MASERU, LESOTHO', cost_of_living_adjustment: 10, differential_rate: 15, danger_pay: 0, rest_relaxation_point: 'London', has_consumable_allowance: false, has_service_needs_differential: false },
+      post: { id: 162, tour_of_duty: '2YRR', code: 'LT6000000', location: 'MASERU, LESOTHO', cost_of_living_adjustment: 10, differential_rate: 15, danger_pay: 0, rest_relaxation_point: 'London', has_consumable_allowance: false, has_service_needs_differential: false },
       languages: [
         { id: 1, language: 'French (FR)', written_proficiency: '2', spoken_proficiency: '2', representation: 'French (FR) 2/2' },
         { id: 1, language: 'German (GM)', written_proficiency: '2', spoken_proficiency: '2', representation: 'German (GM) 2/2' },

--- a/src/Components/PositionDetailsItem/PositionDetailsItem.jsx
+++ b/src/Components/PositionDetailsItem/PositionDetailsItem.jsx
@@ -21,7 +21,7 @@ const PositionDetailsItem = ({ details }) => (
               title="POST"
               description={
                 details.post && details.post.id ?
-                  <Link to={`/post/${details.post.id}`}>{details.post.description}</Link>
+                  <Link to={`/post/${details.post.id}`}>{details.post.location}</Link>
                   : SystemMessages.NO_POST
               }
             />

--- a/src/Components/PositionDetailsItem/__snapshots__/PositionDetailsItem.test.jsx.snap
+++ b/src/Components/PositionDetailsItem/__snapshots__/PositionDetailsItem.test.jsx.snap
@@ -29,9 +29,7 @@ exports[`PositionDetailsItem matches snapshot 1`] = `
               <Link
                 replace={false}
                 to="/post/162"
-              >
-                MASERU, LESOTHO
-              </Link>
+              />
             }
             title="POST"
           />

--- a/src/Components/PositionDetailsItem/__snapshots__/PositionDetailsItem.test.jsx.snap
+++ b/src/Components/PositionDetailsItem/__snapshots__/PositionDetailsItem.test.jsx.snap
@@ -29,7 +29,9 @@ exports[`PositionDetailsItem matches snapshot 1`] = `
               <Link
                 replace={false}
                 to="/post/162"
-              />
+              >
+                MASERU, LESOTHO
+              </Link>
             }
             title="POST"
           />

--- a/src/Components/PostDetails/PostDetails.test.jsx
+++ b/src/Components/PostDetails/PostDetails.test.jsx
@@ -11,7 +11,7 @@ describe('PostComponent', () => {
     id: 100,
     tour_of_duty: '1Y2RR',
     code: 'AF1000000',
-    description: 'HERAT, AFGHANISTAN',
+    location: 'HERAT, AFGHANISTAN',
     cost_of_living_adjustment: 0,
     differential_rate: 35,
     danger_pay: 35,

--- a/src/Components/PostMissionData/PostMissionData.jsx
+++ b/src/Components/PostMissionData/PostMissionData.jsx
@@ -20,7 +20,7 @@ const PostMissionData = ({ post }) => (
         Language: <LanguageList languages={post.language} />
         <br />
         R&R Alignment: {post.rest_relaxation_point ?
-          post.rest_relaxation_point : SystemMessages.NO_RR}
+          post.rest_relaxation_point : SystemMessages.NO_REST_RELAXATION}
         <br />
         Danger Pay: {post.danger_pay}
         <br />

--- a/src/Components/PostMissionData/PostMissionData.jsx
+++ b/src/Components/PostMissionData/PostMissionData.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { POST_MISSION_DATA } from '../../Constants/PropTypes';
+import * as SystemMessages from '../../Constants/SystemMessages';
 import LanguageList from '../LanguageList/LanguageList';
 
 const PostMissionData = ({ post }) => (
@@ -18,7 +19,8 @@ const PostMissionData = ({ post }) => (
         <br />
         Language: <LanguageList languages={post.language} />
         <br />
-        R&R Alignment: {post.rest_relaxation_point}
+        R&R Alignment: {post.rest_relaxation_point ?
+          post.rest_relaxation_point : SystemMessages.NO_RR}
         <br />
         Danger Pay: {post.danger_pay}
         <br />

--- a/src/Components/PostMissionData/PostMissionData.jsx
+++ b/src/Components/PostMissionData/PostMissionData.jsx
@@ -6,7 +6,7 @@ const PostMissionData = ({ post }) => (
   <div className="usa-grid-full">
     <div>
       <p>
-        Location: {post.description}
+        Location: {post.location}
         <br />
         Tour of duty: {post.tour_of_duty}
         <br />

--- a/src/Components/PostMissionData/PostMissionData.test.jsx
+++ b/src/Components/PostMissionData/PostMissionData.test.jsx
@@ -12,7 +12,7 @@ describe('PostMissionDataComponent', () => {
     id: 100,
     tour_of_duty: '1Y2RR',
     code: 'AF1000000',
-    description: 'HERAT, AFGHANISTAN',
+    location: 'HERAT, AFGHANISTAN',
     cost_of_living_adjustment: 0,
     differential_rate: 35,
     danger_pay: 35,

--- a/src/Components/ResultsList/ResultsList.jsx
+++ b/src/Components/ResultsList/ResultsList.jsx
@@ -30,7 +30,7 @@ class ResultsList extends Component {
                 <br />
                   Organization: {result.organization}
                 <br />
-                  Post: {result.post ? <Link to={`/post/${result.post.id}`}>{result.post.description}</Link> : SystemMessages.NO_POST }
+                  Post: {result.post ? <Link to={`/post/${result.post.id}`}>{result.post.location}</Link> : SystemMessages.NO_POST }
                 <br />
                   Post Differential: {result.post
                     ? result.post.differential_rate : SystemMessages.NO_POST_DIFFERENTIAL}

--- a/src/Components/ResultsList/ResultsList.test.jsx
+++ b/src/Components/ResultsList/ResultsList.test.jsx
@@ -18,7 +18,7 @@ describe('ResultsListComponent', () => {
       is_overseas: true,
       create_date: '2006-09-20',
       update_date: '2017-06-08',
-      post: { id: 162, tour_of_duty: '2YRR', code: 'LT6000000', description: 'MASERU, LESOTHO', cost_of_living_adjustment: 0, differential_rate: 15, danger_pay: 0, rest_relaxation_point: 'London', has_consumable_allowance: false, has_service_needs_differential: false },
+      post: { id: 162, tour_of_duty: '2YRR', code: 'LT6000000', location: 'MASERU, LESOTHO', cost_of_living_adjustment: 0, differential_rate: 15, danger_pay: 0, rest_relaxation_point: 'London', has_consumable_allowance: false, has_service_needs_differential: false },
       languages: [
         { id: 1, language: 'French (FR)', written_proficiency: '2', spoken_proficiency: '2', representation: 'French (FR) 2/2' },
       ],

--- a/src/Components/ResultsPage/ResultsPage.test.jsx
+++ b/src/Components/ResultsPage/ResultsPage.test.jsx
@@ -15,7 +15,7 @@ describe('ResultsPageComponent', () => {
       is_overseas: true,
       create_date: '2006-09-20',
       update_date: '2017-06-08',
-      post: { id: 162, tour_of_duty: '2YRR', code: 'LT6000000', description: 'MASERU, LESOTHO', cost_of_living_adjustment: 0, differential_rate: 15, danger_pay: 0, rest_relaxation_point: 'London', has_consumable_allowance: false, has_service_needs_differential: false },
+      post: { id: 162, tour_of_duty: '2YRR', code: 'LT6000000', location: 'MASERU, LESOTHO', cost_of_living_adjustment: 0, differential_rate: 15, danger_pay: 0, rest_relaxation_point: 'London', has_consumable_allowance: false, has_service_needs_differential: false },
       languages: [
         { id: 1, language: 'French (FR)', written_proficiency: '2', spoken_proficiency: '2', representation: 'French (FR) 2/2' },
       ],

--- a/src/Constants/SystemMessages.js
+++ b/src/Constants/SystemMessages.js
@@ -6,3 +6,4 @@ export const NO_COLA = 'None listed';
 export const NO_TOUR_OF_DUTY = 'None listed';
 export const NO_BUREAU = 'None listed';
 export const NO_ORG = 'None listed';
+export const NO_RR = 'None listed';

--- a/src/Constants/SystemMessages.js
+++ b/src/Constants/SystemMessages.js
@@ -6,4 +6,4 @@ export const NO_COLA = 'None listed';
 export const NO_TOUR_OF_DUTY = 'None listed';
 export const NO_BUREAU = 'None listed';
 export const NO_ORG = 'None listed';
-export const NO_RR = 'None listed';
+export const NO_REST_RELAXATION = 'None listed';

--- a/src/Containers/Post/Post.jsx
+++ b/src/Containers/Post/Post.jsx
@@ -21,7 +21,7 @@ class Post extends Component {
   getPost(id) {
     const query = id;
     const api = this.props.api;
-    this.props.fetchData(`${api}/post/${query}/`);
+    this.props.fetchData(`${api}/orgpost/${query}/`);
   }
 
   render() {

--- a/src/__mocks__/detailsObject.js
+++ b/src/__mocks__/detailsObject.js
@@ -8,7 +8,7 @@ const detailsObject = {
   is_overseas: true,
   create_date: '2006-09-20',
   update_date: '2017-06-08',
-  post: { id: 162, tour_of_duty: '2YRR', code: 'LT6000000', description: 'MASERU, LESOTHO', cost_of_living_adjustment: 0, differential_rate: 15, danger_pay: 0, rest_relaxation_point: 'London', has_consumable_allowance: false, has_service_needs_differential: false },
+  post: { id: 162, tour_of_duty: '2YRR', code: 'LT6000000', location: 'MASERU, LESOTHO', cost_of_living_adjustment: 0, differential_rate: 15, danger_pay: 0, rest_relaxation_point: 'London', has_consumable_allowance: false, has_service_needs_differential: false },
   languages: [{ id: 1, language: 'French (FR)', written_proficiency: '2', spoken_proficiency: '2', representation: 'French (FR) 2/2' }],
 };
 

--- a/src/actions/comparisons.test.js
+++ b/src/actions/comparisons.test.js
@@ -21,7 +21,7 @@ describe('async actions', () => {
         is_overseas: true,
         create_date: '2006-09-20',
         update_date: '2017-06-08',
-        post: { id: 162, tour_of_duty: '2YRR', code: 'LT6000000', description: 'MASERU, LESOTHO', cost_of_living_adjustment: 0, differential_rate: 15, danger_pay: 0, rest_relaxation_point: 'London', has_consumable_allowance: false, has_service_needs_differential: false },
+        post: { id: 162, tour_of_duty: '2YRR', code: 'LT6000000', location: 'MASERU, LESOTHO', cost_of_living_adjustment: 0, differential_rate: 15, danger_pay: 0, rest_relaxation_point: 'London', has_consumable_allowance: false, has_service_needs_differential: false },
         languages: [
           { id: 1, language: 'French (FR)', written_proficiency: '2', spoken_proficiency: '2', representation: 'French (FR) 2/2' },
         ],

--- a/src/actions/post.test.js
+++ b/src/actions/post.test.js
@@ -25,7 +25,7 @@ describe('async actions', () => {
       languages: [{ id: 1, language: 'French (FR)', written_proficiency: '2', spoken_proficiency: '2', representation: 'French (FR) 2/2' }],
     };
 
-    mockAdapter.onGet('http://localhost:8000/api/v1/post/100').reply(200,
+    mockAdapter.onGet('http://localhost:8000/api/v1/orgpost/100').reply(200,
       post,
     );
   });
@@ -35,7 +35,7 @@ describe('async actions', () => {
 
     const f = () => {
       setTimeout(() => {
-        store.dispatch(actions.postFetchData('http://localhost:8000/api/v1/post/100'));
+        store.dispatch(actions.postFetchData('http://localhost:8000/api/v1/orgpost/100'));
         store.dispatch(actions.postIsLoading());
         done();
       }, 0);

--- a/src/actions/post.test.js
+++ b/src/actions/post.test.js
@@ -15,7 +15,7 @@ describe('async actions', () => {
       id: 100,
       tour_of_duty: '1Y2RR',
       code: 'AF1000000',
-      description: 'HERAT, AFGHANISTAN',
+      location: 'HERAT, AFGHANISTAN',
       cost_of_living_adjustment: 0,
       differential_rate: 35,
       danger_pay: 35,

--- a/src/actions/results.test.js
+++ b/src/actions/results.test.js
@@ -21,7 +21,7 @@ describe('async actions', () => {
         is_overseas: true,
         create_date: '2006-09-20',
         update_date: '2017-06-08',
-        post: { id: 162, tour_of_duty: '2YRR', code: 'LT6000000', description: 'MASERU, LESOTHO', cost_of_living_adjustment: 0, differential_rate: 15, danger_pay: 0, rest_relaxation_point: 'London', has_consumable_allowance: false, has_service_needs_differential: false },
+        post: { id: 162, tour_of_duty: '2YRR', code: 'LT6000000', location: 'MASERU, LESOTHO', cost_of_living_adjustment: 0, differential_rate: 15, danger_pay: 0, rest_relaxation_point: 'London', has_consumable_allowance: false, has_service_needs_differential: false },
         languages: [
           { id: 1, language: 'French (FR)', written_proficiency: '2', spoken_proficiency: '2', representation: 'French (FR) 2/2' },
         ],


### PR DESCRIPTION
Update front-end based on API changes made in https://github.com/18F/State-TalentMAP-API/pull/69 , including the use of `/orgpost` instead of `/post`, and some property name changes made to the API such as the Post `location` property instead of `description`.