### PR TITLE
Rename local storage helper’s “len” property to “count”

### DIFF
--- a/src/Components/FavoritesButton/FavoritesButton.jsx
+++ b/src/Components/FavoritesButton/FavoritesButton.jsx
@@ -9,7 +9,7 @@ class FavoritesButton extends Component {
     this.state = {
       saved: false,
       localStorageKey: null,
-      len: 0,
+      count: 0,
     };
   }
 
@@ -28,7 +28,7 @@ class FavoritesButton extends Component {
 
   getSaved() {
     const saved = localStorageFetchValue(this.state.localStorageKey, this.props.refKey);
-    this.setState({ saved: saved.exists, len: saved.len });
+    this.setState({ saved: saved.exists, count: saved.count });
   }
 
   getSavedState() {
@@ -36,7 +36,7 @@ class FavoritesButton extends Component {
   }
 
   exceedsLimit() {
-    return this.state.len >= this.props.limit;
+    return this.state.count >= this.props.limit;
   }
 
   toggleSaved() {

--- a/src/Components/ViewComparisonLink/ViewComparisonLink.jsx
+++ b/src/Components/ViewComparisonLink/ViewComparisonLink.jsx
@@ -7,10 +7,10 @@ import { localStorageFetchValue } from '../../utilities';
 class ViewComparisonLink extends Component {
 
   render() {
-    // does the compare key exists and is len > 0?
+    // does the compare key exists and is count > 0?
     const exists = () => {
       const retrievedKey = localStorageFetchValue('compare', null);
-      return !!retrievedKey.len;
+      return !!retrievedKey.count;
     };
     // if not, return null
     if (!exists()) {

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -9,7 +9,7 @@ export const ajax = url => (
 );
 
 export function localStorageFetchValue(key, value) {
-  const saved = { exists: true, len: 0 };
+  const saved = { exists: true, count: 0 };
   const retrievedKey = localStorage.getItem(key);
   let parsedKey = JSON.parse(retrievedKey);
   const arrayExists = Array.isArray(parsedKey);
@@ -17,7 +17,7 @@ export function localStorageFetchValue(key, value) {
     localStorage.setItem(key, JSON.stringify([]));
     parsedKey = JSON.parse(localStorage.getItem(key));
   }
-  saved.len = parsedKey.length;
+  saved.count = parsedKey.length;
   const refIsSaved = parsedKey.indexOf(value);
   if (refIsSaved !== -1) {
     saved.exists = true;

--- a/src/utilities.test.js
+++ b/src/utilities.test.js
@@ -56,10 +56,10 @@ describe('local storage', () => {
     localStorage.clear();
   });
 
-  it('should be able to fetch the length of an array', () => {
+  it('should be able to fetch the count of an array', () => {
     localStorage.setItem('key', JSON.stringify(['1', '2']));
     const retrieved = localStorageFetchValue('key', '1');
-    expect(retrieved.len).toBe(2);
+    expect(retrieved.count).toBe(2);
     localStorage.clear();
   });
 


### PR DESCRIPTION
Fixes #334 by renaming the `len` property to `count`, as `len` might be confused as a typo for `length`.