### PR TITLE
Externalize search results cards into their own component

### DIFF
--- a/src/Components/ResultsCard/ResultsCard.jsx
+++ b/src/Components/ResultsCard/ResultsCard.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import FavoritesButton from '../../Components/FavoritesButton/FavoritesButton';
+import { POSITION_DETAILS } from '../../Constants/PropTypes';
+import * as SystemMessages from '../../Constants/SystemMessages';
+
+const ResultsCard = ({ result, onToggle }) => (
+  <div id={result.id} className="usa-grid-full" style={{ backgroundColor: '#F2F2F2', marginTop: '10px', marginBottom: '10px', padding: '15px 30px' }}>
+    <div className="usa-width-one-half">
+      <Link to={`/details/${result.position_number}`}>
+        <h3> Position Number: {result.position_number} </h3>
+      </Link>
+      <p>
+          Grade: {result.grade}
+        <br />
+          Skill: {result.skill}
+        <br />
+          Bureau: {result.bureau}
+        <br />
+          Organization: {result.organization}
+        <br />
+          Post: {result.post ? <Link to={`/post/${result.post.id}`}>{result.post.location}</Link> : SystemMessages.NO_POST }
+        <br />
+          Post Differential: {result.post
+            ? result.post.differential_rate : SystemMessages.NO_POST_DIFFERENTIAL}
+      </p>
+    </div>
+    <div className="usa-width-one-half" style={{ textAlign: 'right', paddingTop: '25px' }}>
+      <FavoritesButton refKey={result.position_number} type="fav" />
+      <FavoritesButton
+        refKey={result.position_number}
+        type="compare"
+        onToggle={onToggle}
+        limit={2}
+      />
+    </div>
+  </div>
+);
+
+ResultsCard.propTypes = {
+  result: POSITION_DETAILS.isRequired,
+  onToggle: PropTypes.func.isRequired,
+};
+
+export default ResultsCard;

--- a/src/Components/ResultsCard/ResultsCard.test.jsx
+++ b/src/Components/ResultsCard/ResultsCard.test.jsx
@@ -1,12 +1,11 @@
 import { shallow } from 'enzyme';
-import sinon from 'sinon';
 import React from 'react';
 import TestUtils from 'react-dom/test-utils';
 import { MemoryRouter } from 'react-router-dom';
-import ResultsList from './ResultsList';
+import ResultsCard from './ResultsCard';
 
-describe('ResultsListComponent', () => {
-  let results = null;
+describe('ResultsCardComponent', () => {
+  let result = null;
   let wrapper = null;
 
   const resultsArray = {
@@ -40,28 +39,20 @@ describe('ResultsListComponent', () => {
     ],
   };
 
-  beforeEach(() => {
-    results = TestUtils.renderIntoDocument(<MemoryRouter>
-      <ResultsList results={resultsArray} />
-    </MemoryRouter>);
-  });
-
   it('is defined', () => {
-    expect(results).toBeDefined();
+    result = TestUtils.renderIntoDocument(<MemoryRouter>
+      <ResultsCard result={resultsArray.results[0]} onToggle={() => {}} />
+    </MemoryRouter>);
+    expect(result).toBeDefined();
   });
 
   it('can receive props', () => {
-    wrapper = shallow(<ResultsList results={resultsArray} />);
-    expect(wrapper.instance().props.results.results[0].id).toBe(6);
+    wrapper = shallow(<ResultsCard result={resultsArray.results[0]} onToggle={() => {}} />);
+    expect(wrapper.instance().props.result.id).toBe(6);
   });
 
-  it('can call the onChildToggle function', () => {
-    wrapper = shallow(<ResultsList results={resultsArray} />);
-    // define the instance
-    const instance = wrapper.instance();
-    // spy the logout function
-    const handleClickSpy = sinon.spy(instance, 'onChildToggle');
-    wrapper.instance().onChildToggle();
-    sinon.assert.calledOnce(handleClickSpy);
+  it('can receive different types of results', () => {
+    wrapper = shallow(<ResultsCard result={resultsArray.results[1]} onToggle={() => {}} />);
+    expect(wrapper.instance().props.result.id).toBe(60);
   });
 });

--- a/src/Components/ResultsList/ResultsList.jsx
+++ b/src/Components/ResultsList/ResultsList.jsx
@@ -1,9 +1,7 @@
 import React, { Component } from 'react';
-import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import FavoritesButton from '../../Components/FavoritesButton/FavoritesButton';
+import ResultsCard from '../../Components/ResultsCard/ResultsCard';
 import { POSITION_SEARCH_RESULTS, EMPTY_FUNCTION } from '../../Constants/PropTypes';
-import * as SystemMessages from '../../Constants/SystemMessages';
 
 class ResultsList extends Component {
 
@@ -16,36 +14,7 @@ class ResultsList extends Component {
     return (
       <div>
         { this.props.results.results.map(result => (
-          <div key={result.id} id={result.id} className="usa-grid-full" style={{ backgroundColor: '#F2F2F2', marginTop: '10px', marginBottom: '10px', padding: '15px 30px' }}>
-            <div className="usa-width-one-half">
-              <Link to={`/details/${result.position_number}`}>
-                <h3> Position Number: {result.position_number} </h3>
-              </Link>
-              <p>
-                  Grade: {result.grade}
-                <br />
-                  Skill: {result.skill}
-                <br />
-                  Bureau: {result.bureau}
-                <br />
-                  Organization: {result.organization}
-                <br />
-                  Post: {result.post ? <Link to={`/post/${result.post.id}`}>{result.post.location}</Link> : SystemMessages.NO_POST }
-                <br />
-                  Post Differential: {result.post
-                    ? result.post.differential_rate : SystemMessages.NO_POST_DIFFERENTIAL}
-              </p>
-            </div>
-            <div className="usa-width-one-half" style={{ textAlign: 'right', paddingTop: '25px' }}>
-              <FavoritesButton refKey={result.position_number} type="fav" />
-              <FavoritesButton
-                refKey={result.position_number}
-                type="compare"
-                onToggle={() => this.onChildToggle()}
-                limit={2}
-              />
-            </div>
-          </div>
+          <ResultsCard key={result.id} result={result} onToggle={() => this.onChildToggle()} />
           ))}
       </div>
     );


### PR DESCRIPTION
Externalizes the search results cards into their own component. The ResultsList component then simply `map`s this new component instead of handling the presentation as well. #333 