### PR TITLE
Configure the onNavigateTo and goBack functions to be required

### DIFF
--- a/src/Components/PositionDetails/PositionDetails.jsx
+++ b/src/Components/PositionDetails/PositionDetails.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import FavoritesButton from '../FavoritesButton/FavoritesButton';
-import { POSITION_DETAILS, EMPTY_FUNCTION } from '../../Constants/PropTypes';
+import { POSITION_DETAILS } from '../../Constants/PropTypes';
 import Share from '../Share/Share';
 import Loading from '../Loading/Loading';
 import PositionTitle from '../PositionTitle/PositionTitle';
@@ -32,14 +32,13 @@ PositionDetails.propTypes = {
   api: PropTypes.string.isRequired,
   isLoading: PropTypes.bool,
   hasErrored: PropTypes.bool,
-  goBack: PropTypes.func,
+  goBack: PropTypes.func.isRequired,
 };
 
 PositionDetails.defaultProps = {
   details: null,
   isLoading: true,
   hasErrored: false,
-  goBack: EMPTY_FUNCTION,
 };
 
 export default PositionDetails;

--- a/src/Components/PositionDetails/PositionDetails.test.jsx
+++ b/src/Components/PositionDetails/PositionDetails.test.jsx
@@ -10,7 +10,13 @@ describe('PositionDetailsComponent', () => {
 
   it('can receive props', () => {
     wrapper = shallow(
-      <PositionDetails api={api} details={detailsObject} isLoading={false} hasErrored={false} />,
+      <PositionDetails
+        api={api}
+        details={detailsObject}
+        isLoading={false}
+        hasErrored={false}
+        goBack={() => {}}
+      />,
     );
     expect(wrapper.instance().props.details.id).toBe(6);
   });
@@ -19,7 +25,13 @@ describe('PositionDetailsComponent', () => {
     Object.assign(detailsObject, { languages: [], post: null, is_overseas: false });
 
     wrapper = shallow(
-      <PositionDetails api={api} details={detailsObject} isLoading={false} hasErrored={false} />,
+      <PositionDetails
+        api={api}
+        details={detailsObject}
+        isLoading={false}
+        hasErrored={false}
+        goBack={() => {}}
+      />,
     );
     expect(wrapper.instance().props.details.languages.length).toBe(0);
   });
@@ -28,7 +40,13 @@ describe('PositionDetailsComponent', () => {
     Object.assign(detailsObject, { languages: [], is_overseas: true });
 
     wrapper = shallow(
-      <PositionDetails api={api} details={detailsObject} isLoading hasErrored={false} />,
+      <PositionDetails
+        api={api}
+        details={detailsObject}
+        isLoading
+        hasErrored={false}
+        goBack={() => {}}
+      />,
     );
     expect(wrapper.instance().props.details.languages.length).toBe(0);
   });

--- a/src/Components/PositionTitle/PositionTitle.jsx
+++ b/src/Components/PositionTitle/PositionTitle.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import FontAwesome from 'react-fontawesome';
 import PropTypes from 'prop-types';
-import { POSITION_DETAILS, EMPTY_FUNCTION } from '../../Constants/PropTypes';
+import { POSITION_DETAILS } from '../../Constants/PropTypes';
 
 class PositionTitle extends Component { // eslint-disable-line
   navBack(e) {
@@ -59,12 +59,11 @@ class PositionTitle extends Component { // eslint-disable-line
 
 PositionTitle.propTypes = {
   details: POSITION_DETAILS,
-  goBack: PropTypes.func,
+  goBack: PropTypes.func.isRequired,
 };
 
 PositionTitle.defaultProps = {
   details: null,
-  goBack: EMPTY_FUNCTION,
 };
 
 export default PositionTitle;

--- a/src/Components/PositionTitle/PositionTitle.test.jsx
+++ b/src/Components/PositionTitle/PositionTitle.test.jsx
@@ -10,14 +10,24 @@ describe('PositionTitleComponent', () => {
 
   it('can receive props', () => {
     wrapper = shallow(
-      <PositionTitle details={detailsObject} isLoading={false} hasErrored={false} />,
+      <PositionTitle
+        details={detailsObject}
+        isLoading={false}
+        hasErrored={false}
+        goBack={() => {}}
+      />,
     );
     expect(wrapper.instance().props.details.id).toBe(6);
   });
 
   it('matches snapshot', () => {
     wrapper = shallow(
-      <PositionTitle details={detailsObject} isLoading={false} hasErrored={false} />,
+      <PositionTitle
+        details={detailsObject}
+        isLoading={false}
+        hasErrored={false}
+        goBack={() => {}}
+      />,
     );
     expect(toJSON(wrapper)).toMatchSnapshot();
   });
@@ -95,7 +105,12 @@ describe('PositionTitleComponent', () => {
     Object.assign(detailsObject, { languages: [], post: null, is_overseas: false });
 
     wrapper = shallow(
-      <PositionTitle details={detailsObject} isLoading={false} hasErrored={false} />,
+      <PositionTitle
+        details={detailsObject}
+        isLoading={false}
+        hasErrored={false}
+        goBack={() => {}}
+      />,
     );
     expect(wrapper.instance().props.details.languages.length).toBe(0);
   });
@@ -104,7 +119,7 @@ describe('PositionTitleComponent', () => {
     Object.assign(detailsObject, { languages: [], is_overseas: true });
 
     wrapper = shallow(
-      <PositionTitle details={detailsObject} isLoading hasErrored={false} />,
+      <PositionTitle details={detailsObject} isLoading hasErrored={false} goBack={() => {}} />,
     );
     expect(wrapper.instance().props.details.languages.length).toBe(0);
   });

--- a/src/Containers/Compare/Compare.jsx
+++ b/src/Containers/Compare/Compare.jsx
@@ -5,7 +5,7 @@ import { push } from 'react-router-redux';
 import { withRouter } from 'react-router';
 import { comparisonsFetchData } from '../../actions/comparisons';
 import CompareList from '../../Components/CompareList/CompareList';
-import { COMPARE_LIST, EMPTY_FUNCTION } from '../../Constants/PropTypes';
+import { COMPARE_LIST } from '../../Constants/PropTypes';
 import { PUBLIC_ROOT } from '../../login/DefaultRoutes';
 
 class Results extends Component {
@@ -42,7 +42,7 @@ class Results extends Component {
 
 Results.propTypes = {
   api: PropTypes.string.isRequired,
-  onNavigateTo: PropTypes.func,
+  onNavigateTo: PropTypes.func.isRequired,
   match: PropTypes.shape({
     params: PropTypes.shape({
       ids: PropTypes.string,
@@ -59,7 +59,6 @@ Results.defaultProps = {
   comparisons: [],
   hasErrored: false,
   isLoading: true,
-  onNavigateTo: EMPTY_FUNCTION,
 };
 
 Results.contextTypes = {

--- a/src/Containers/Compare/Compare.test.jsx
+++ b/src/Containers/Compare/Compare.test.jsx
@@ -14,14 +14,14 @@ describe('Main', () => {
 
   it('is defined', () => {
     const compare = TestUtils.renderIntoDocument(<Provider store={mockStore({})}><MemoryRouter>
-      <Compare isAuthorized={() => true} api={api} />
+      <Compare isAuthorized={() => true} api={api} onNavigateTo={() => {}} />
     </MemoryRouter></Provider>);
     expect(compare).toBeDefined();
   });
 
   it('can handle authentication redirects', () => {
     const compare = TestUtils.renderIntoDocument(<Provider store={mockStore({})}><MemoryRouter>
-      <Compare isAuthorized={() => false} api={api} />
+      <Compare isAuthorized={() => false} api={api} onNavigateTo={() => {}} />
     </MemoryRouter></Provider>);
     expect(compare).toBeDefined();
   });

--- a/src/Containers/Home/Home.jsx
+++ b/src/Containers/Home/Home.jsx
@@ -49,7 +49,7 @@ class Home extends Component {
 
 Home.propTypes = {
   api: PropTypes.string.isRequired,
-  onNavigateTo: PropTypes.func,
+  onNavigateTo: PropTypes.func.isRequired,
   fetchData: PropTypes.func,
   isLoading: PropTypes.bool,
   items: ITEMS,
@@ -58,7 +58,6 @@ Home.propTypes = {
 
 Home.defaultProps = {
   items: [],
-  onNavigateTo: EMPTY_FUNCTION,
   fetchData: EMPTY_FUNCTION,
   hasErrored: false,
   isLoading: true,

--- a/src/Containers/Home/Home.test.jsx
+++ b/src/Containers/Home/Home.test.jsx
@@ -15,20 +15,24 @@ describe('Home', () => {
 
   it('is defined', () => {
     const home = TestUtils.renderIntoDocument(<Provider store={mockStore({})}><MemoryRouter>
-      <Home isAuthorized={() => true} api={api} />
+      <Home isAuthorized={() => true} api={api} onNavigateTo={() => {}} />
     </MemoryRouter></Provider>);
     expect(home).toBeDefined();
   });
 
   it('can handle authentication redirects', () => {
     const home = TestUtils.renderIntoDocument(<Provider store={mockStore({})}><MemoryRouter>
-      <Home isAuthorized={() => false} api={api} />
+      <Home isAuthorized={() => false} api={api} onNavigateTo={() => {}} />
     </MemoryRouter></Provider>);
     expect(home).toBeDefined();
   });
 
   it('can call the onChildSubmit function', () => {
-    const wrapper = shallow(<Home.WrappedComponent isAuthorized={() => true} api={api} />);
+    const wrapper = shallow(<Home.WrappedComponent
+      isAuthorized={() => true}
+      api={api}
+      onNavigateTo={() => {}}
+    />);
     wrapper.instance().onChildSubmit();
   });
 });

--- a/src/Containers/Position/Position.jsx
+++ b/src/Containers/Position/Position.jsx
@@ -46,7 +46,7 @@ Position.contextTypes = {
 
 Position.propTypes = {
   api: PropTypes.string.isRequired,
-  onNavigateTo: PropTypes.func,
+  onNavigateTo: PropTypes.func.isRequired,
   match: PropTypes.shape({
     params: PropTypes.shape({
       id: PropTypes.string,
@@ -62,7 +62,6 @@ Position.propTypes = {
 Position.defaultProps = {
   positionDetails: [],
   fetchData: EMPTY_FUNCTION,
-  onNavigateTo: EMPTY_FUNCTION,
   hasErrored: false,
   isLoading: true,
 };

--- a/src/Containers/Position/Position.test.jsx
+++ b/src/Containers/Position/Position.test.jsx
@@ -14,14 +14,14 @@ describe('Main', () => {
 
   it('is defined', () => {
     const position = TestUtils.renderIntoDocument(<Provider store={mockStore({})}><MemoryRouter>
-      <Position isAuthorized={() => true} api={api} />
+      <Position isAuthorized={() => true} api={api} onNavigateTo={() => {}} />
     </MemoryRouter></Provider>);
     expect(position).toBeDefined();
   });
 
   it('can handle authentication redirects', () => {
     const position = TestUtils.renderIntoDocument(<Provider store={mockStore({})}><MemoryRouter>
-      <Position isAuthorized={() => false} api={api} />
+      <Position isAuthorized={() => false} api={api} onNavigateTo={() => {}} />
     </MemoryRouter></Provider>);
     expect(position).toBeDefined();
   });

--- a/src/Containers/Post/Post.jsx
+++ b/src/Containers/Post/Post.jsx
@@ -5,7 +5,7 @@ import { withRouter } from 'react-router';
 import { push } from 'react-router-redux';
 import { postFetchData } from '../../actions/post';
 import PostDetails from '../../Components/PostDetails/PostDetails';
-import { POST_MISSION_DATA, EMPTY_FUNCTION } from '../../Constants/PropTypes';
+import { POST_MISSION_DATA } from '../../Constants/PropTypes';
 import { PUBLIC_ROOT } from '../../login/DefaultRoutes';
 
 class Post extends Component {
@@ -36,7 +36,7 @@ class Post extends Component {
 
 Post.propTypes = {
   api: PropTypes.string.isRequired,
-  onNavigateTo: PropTypes.func,
+  onNavigateTo: PropTypes.func.isRequired,
   match: PropTypes.shape({
     params: PropTypes.shape({
       id: PropTypes.string,
@@ -49,7 +49,6 @@ Post.propTypes = {
 
 Post.defaultProps = {
   post: {},
-  onNavigateTo: EMPTY_FUNCTION,
   isLoading: true,
 };
 

--- a/src/Containers/Post/Post.test.jsx
+++ b/src/Containers/Post/Post.test.jsx
@@ -14,14 +14,14 @@ describe('Main', () => {
 
   it('is defined', () => {
     const post = TestUtils.renderIntoDocument(<Provider store={mockStore({})}><MemoryRouter>
-      <Post isAuthorized={() => true} api={api} />
+      <Post isAuthorized={() => true} api={api} onNavigateTo={() => {}} />
     </MemoryRouter></Provider>);
     expect(post).toBeDefined();
   });
 
   it('can handle authentication redirects', () => {
     const post = TestUtils.renderIntoDocument(<Provider store={mockStore({})}><MemoryRouter>
-      <Post isAuthorized={() => false} api={api} />
+      <Post isAuthorized={() => false} api={api} onNavigateTo={() => {}} />
     </MemoryRouter></Provider>);
     expect(post).toBeDefined();
   });

--- a/src/Containers/Results/Results.jsx
+++ b/src/Containers/Results/Results.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { push } from 'react-router-redux';
 import { resultsFetchData } from '../../actions/results';
 import ResultsPage from '../../Components/ResultsPage/ResultsPage';
-import { POSITION_SEARCH_RESULTS, EMPTY_FUNCTION } from '../../Constants/PropTypes';
+import { POSITION_SEARCH_RESULTS } from '../../Constants/PropTypes';
 import { PUBLIC_ROOT } from '../../login/DefaultRoutes';
 
 class Results extends Component {
@@ -43,7 +43,7 @@ class Results extends Component {
 
 Results.propTypes = {
   api: PropTypes.string.isRequired,
-  onNavigateTo: PropTypes.func,
+  onNavigateTo: PropTypes.func.isRequired,
   fetchData: PropTypes.func.isRequired,
   hasErrored: PropTypes.bool.isRequired,
   isLoading: PropTypes.bool.isRequired,
@@ -55,7 +55,6 @@ Results.defaultProps = {
   results: { results: [] },
   hasErrored: false,
   isLoading: true,
-  onNavigateTo: EMPTY_FUNCTION,
 };
 
 Results.contextTypes = {

--- a/src/Containers/Results/Results.test.jsx
+++ b/src/Containers/Results/Results.test.jsx
@@ -15,21 +15,26 @@ describe('Main', () => {
 
   it('is defined', () => {
     const results = TestUtils.renderIntoDocument(<Provider store={mockStore({})}><MemoryRouter>
-      <Results isAuthorized={() => true} api={api} />
+      <Results isAuthorized={() => true} api={api} onNavigateTo={() => {}} />
     </MemoryRouter></Provider>);
     expect(results).toBeDefined();
   });
 
   it('can handle authentication redirects', () => {
     const results = TestUtils.renderIntoDocument(<Provider store={mockStore({})}><MemoryRouter>
-      <Results isAuthorized={() => false} api={api} />
+      <Results isAuthorized={() => false} api={api} onNavigateTo={() => {}} />
     </MemoryRouter></Provider>);
     expect(results).toBeDefined();
   });
 
   it('can call the onChildToggle function', () => {
     const wrapper = shallow(
-      <Results.WrappedComponent isAuthorized={() => true} fetchData={() => {}} api={api} />,
+      <Results.WrappedComponent
+        isAuthorized={() => true}
+        fetchData={() => {}}
+        api={api}
+        onNavigateTo={() => {}}
+      />,
     );
     expect(wrapper.instance().state.key).toBe(0);
     wrapper.instance().onChildToggle();


### PR DESCRIPTION
Sets the `propTypes` for onNavigateTo and goBack to be required since they are necessary for functionality. #332 