### PR TITLE
Use a div instead of a form to wrap the SelectForm

### DIFF
--- a/src/Components/SelectForm/SelectForm.jsx
+++ b/src/Components/SelectForm/SelectForm.jsx
@@ -29,7 +29,7 @@ class SelectForm extends Component {
       ),
     );
     return (
-      <form className="usa-form">
+      <div className="usa-form">
         <label htmlFor={id}>{label}</label>
         <select
           name={id}
@@ -41,7 +41,7 @@ class SelectForm extends Component {
             optionList
           }
         </select>
-      </form>
+      </div>
     );
   }
 }

--- a/src/Components/SelectForm/__snapshots__/SelectForm.test.jsx.snap
+++ b/src/Components/SelectForm/__snapshots__/SelectForm.test.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SelectForm matches snapshot 1`] = `
-<form
+<div
   className="usa-form"
 >
   <label
@@ -47,5 +47,5 @@ exports[`SelectForm matches snapshot 1`] = `
       Bureau (A - Z)
     </option>
   </select>
-</form>
+</div>
 `;


### PR DESCRIPTION
WCAG2AA enforces that `<form>`s have a submit button. Because the SelectForm performs changes on option selection and not on form submission, the following error was reported by pa11y

```
This form does not contain a submit button, which creates issues for those who cannot submit the form using the keyboard. Submit buttons are INPUT elements with type attribute \"submit\" or \"image\", or BUTTON elements with type \"submit\" or omitted/invalid.
```

This PR changes the SelectForm wrapper from a `form` to a `div`.