### PR TITLE
Add more thorough testing for TotalResults output possibilities

### DIFF
--- a/src/Components/TotalResults/TotalResults.jsx
+++ b/src/Components/TotalResults/TotalResults.jsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const TotalResults = ({ total, pageNumber, pageSize }) => (
-  <span id="total-results">
-    Viewing&nbsp;
-      {(pageNumber * pageSize) + 1} - {Math.min((pageSize * (pageNumber + 1)), total)} of {total}
-    &nbsp;results
+const TotalResults = ({ total, pageNumber, pageSize }) => {
+  const beginning = (pageNumber * pageSize) + 1;
+  const through = Math.min((pageSize * (pageNumber + 1)), total);
+  return (
+    <span id="total-results">
+    Viewing {beginning} - {through} of {total} results
   </span>
   );
+};
 
 TotalResults.propTypes = {
   total: PropTypes.number.isRequired, // total number of results

--- a/src/Components/TotalResults/TotalResults.test.jsx
+++ b/src/Components/TotalResults/TotalResults.test.jsx
@@ -7,8 +7,10 @@ describe('TotalResults', () => {
   let wrapper = null;
 
   const total = 103;
-  const pageNumber = 4;
+  const pageNumber = 0;
   const pageSize = 25;
+
+  const applyViewText = (beginning, through, totalNum) => `Viewing ${beginning} - ${through} of ${totalNum} results`;
 
   it('can receive props', () => {
     wrapper = shallow(
@@ -24,17 +26,43 @@ describe('TotalResults', () => {
     expect(toJSON(wrapper)).toMatchSnapshot();
   });
 
-  it('displays pager numbers and total results correctly when reaching the second to last page of the results', () => {
-    wrapper = shallow(
-      <TotalResults total={total} pageNumber={pageNumber - 1} pageSize={pageSize} />,
-    );
-    expect(wrapper.find('#total-results').text()).toBe('Viewing 76 - 100 of 103 results');
-  });
-
-  it('displays pager numbers and total results correctly when reaching the end of the results', () => {
+  it('displays pager numbers and total results correctly when on the first page of the results', () => {
     wrapper = shallow(
       <TotalResults total={total} pageNumber={pageNumber} pageSize={pageSize} />,
     );
-    expect(wrapper.find('#total-results').text()).toBe('Viewing 101 - 103 of 103 results');
+    expect(wrapper.find('#total-results').text()).toBe(applyViewText(1, 25, 103));
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+
+  it('displays pager numbers and total results correctly when on the second page of the results', () => {
+    wrapper = shallow(
+      <TotalResults total={total} pageNumber={pageNumber + 1} pageSize={pageSize} />,
+    );
+    expect(wrapper.find('#total-results').text()).toBe(applyViewText(26, 50, 103));
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+
+  it('displays pager numbers and total results correctly when on the third page of the results', () => {
+    wrapper = shallow(
+      <TotalResults total={total} pageNumber={pageNumber + 2} pageSize={pageSize} />,
+    );
+    expect(wrapper.find('#total-results').text()).toBe(applyViewText(51, 75, 103));
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+
+  it('displays pager numbers and total results correctly when reaching the second to last page of the results', () => {
+    wrapper = shallow(
+      <TotalResults total={total} pageNumber={pageNumber + 3} pageSize={pageSize} />,
+    );
+    expect(wrapper.find('#total-results').text()).toBe(applyViewText(76, 100, 103));
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+
+  it('displays pager numbers and total results correctly when reaching the last page of the results', () => {
+    wrapper = shallow(
+      <TotalResults total={total} pageNumber={pageNumber + 4} pageSize={pageSize} />,
+    );
+    expect(wrapper.find('#total-results').text()).toBe(applyViewText(101, 103, 103));
+    expect(toJSON(wrapper)).toMatchSnapshot();
   });
 });

--- a/src/Components/TotalResults/__snapshots__/TotalResults.test.jsx.snap
+++ b/src/Components/TotalResults/__snapshots__/TotalResults.test.jsx.snap
@@ -1,15 +1,85 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TotalResults displays pager numbers and total results correctly when on the first page of the results 1`] = `
+<span
+  id="total-results"
+>
+  Viewing 
+  1
+   - 
+  25
+   of 
+  103
+   results
+</span>
+`;
+
+exports[`TotalResults displays pager numbers and total results correctly when on the second page of the results 1`] = `
+<span
+  id="total-results"
+>
+  Viewing 
+  26
+   - 
+  50
+   of 
+  103
+   results
+</span>
+`;
+
+exports[`TotalResults displays pager numbers and total results correctly when on the third page of the results 1`] = `
+<span
+  id="total-results"
+>
+  Viewing 
+  51
+   - 
+  75
+   of 
+  103
+   results
+</span>
+`;
+
+exports[`TotalResults displays pager numbers and total results correctly when reaching the last page of the results 1`] = `
+<span
+  id="total-results"
+>
+  Viewing 
+  101
+   - 
+  103
+   of 
+  103
+   results
+</span>
+`;
+
+exports[`TotalResults displays pager numbers and total results correctly when reaching the second to last page of the results 1`] = `
+<span
+  id="total-results"
+>
+  Viewing 
+  76
+   - 
+  100
+   of 
+  103
+   results
+</span>
+`;
+
 exports[`TotalResults matches snapshot 1`] = `
 <span
   id="total-results"
 >
-  Viewing 
+  Viewing 
   1
    - 
   0
    of 
   103
-   results
+   results
 </span>
 `;


### PR DESCRIPTION
Tests against every possible display of `TotalResults` when there are 103 results. Also removes the `&nbsp;`s from the component since they fail against checks of text that uses the `space` key.