### PR TITLE
Externalize mock objects to the __mocks__ folder

### DIFF
--- a/src/Components/CompareList/CompareList.test.jsx
+++ b/src/Components/CompareList/CompareList.test.jsx
@@ -3,44 +3,15 @@ import React from 'react';
 import TestUtils from 'react-dom/test-utils';
 import { MemoryRouter } from 'react-router-dom';
 import CompareList from './CompareList';
+import resultsObject from '../../__mocks__/resultsObject';
 
 describe('CompareListComponent', () => {
   let compare = null;
   let wrapper = null;
 
-  const compareArray = [
-    { id: 6,
-      grade: '05',
-      skill: 'OFFICE MANAGEMENT (9017)',
-      bureau: '150000',
-      organization: 'YAOUNDE CAMEROON (YAOUNDE)',
-      position_number: '00025003',
-      is_overseas: true,
-      create_date: '2006-09-20',
-      update_date: '2017-06-08',
-      post: { id: 162, tour_of_duty: '2YRR', code: 'LT6000000', location: 'MASERU, LESOTHO', cost_of_living_adjustment: 10, differential_rate: 15, danger_pay: 0, rest_relaxation_point: 'London', has_consumable_allowance: false, has_service_needs_differential: false },
-      languages: [
-        { id: 1, language: 'French (FR)', written_proficiency: '2', spoken_proficiency: '2', representation: 'French (FR) 2/2' },
-        { id: 1, language: 'German (GM)', written_proficiency: '2', spoken_proficiency: '2', representation: 'German (GM) 2/2' },
-      ],
-    },
-    { id: 60,
-      grade: '03',
-      skill: 'OFFICE MANAGEMENT (9017)',
-      bureau: '150000',
-      organization: 'YAOUNDE CAMEROON (YAOUNDE)',
-      position_number: '00025003',
-      is_overseas: true,
-      create_date: '2006-09-20',
-      update_date: '2017-06-08',
-      post: null,
-      languages: [],
-    },
-  ];
-
   beforeEach(() => {
     compare = TestUtils.renderIntoDocument(<MemoryRouter>
-      <CompareList compare={compareArray} />
+      <CompareList compare={resultsObject.results} />
     </MemoryRouter>);
   });
 
@@ -49,12 +20,12 @@ describe('CompareListComponent', () => {
   });
 
   it('can receive props', () => {
-    wrapper = shallow(<CompareList compare={compareArray} />);
+    wrapper = shallow(<CompareList compare={resultsObject.results} />);
     expect(wrapper.instance().props.compare[0].id).toBe(6);
   });
 
   it('can call the onChildToggle function', () => {
-    wrapper = shallow(<CompareList compare={compareArray} />);
+    wrapper = shallow(<CompareList compare={resultsObject.results} />);
     wrapper.instance().onChildToggle();
     expect(wrapper).toBeDefined();
   });

--- a/src/Components/PostDetails/PostDetails.test.jsx
+++ b/src/Components/PostDetails/PostDetails.test.jsx
@@ -3,23 +3,10 @@ import TestUtils from 'react-dom/test-utils';
 import createRouterContext from 'react-router-test-context';
 import { MemoryRouter } from 'react-router-dom';
 import PostDetails from './PostDetails';
+import postObject from '../../__mocks__/postObject';
 
 describe('PostComponent', () => {
   let post = null;
-
-  const postObject = {
-    id: 100,
-    tour_of_duty: '1Y2RR',
-    code: 'AF1000000',
-    location: 'HERAT, AFGHANISTAN',
-    cost_of_living_adjustment: 0,
-    differential_rate: 35,
-    danger_pay: 35,
-    rest_relaxation_point: 'London',
-    has_consumable_allowance: true,
-    has_service_needs_differential: true,
-    languages: [{ id: 1, language: 'French (FR)', written_proficiency: '2', spoken_proficiency: '2', representation: 'French (FR) 2/2' }],
-  };
 
   beforeEach(() => {
     const context = createRouterContext();

--- a/src/Components/PostMissionData/PostMissionData.test.jsx
+++ b/src/Components/PostMissionData/PostMissionData.test.jsx
@@ -3,24 +3,11 @@ import React from 'react';
 import TestUtils from 'react-dom/test-utils';
 import { MemoryRouter } from 'react-router-dom';
 import PostMissionData from './PostMissionData';
+import postObject from '../../__mocks__/postObject';
 
 describe('PostMissionDataComponent', () => {
   let postMissionData = null;
   let wrapper = null;
-
-  const postObject = {
-    id: 100,
-    tour_of_duty: '1Y2RR',
-    code: 'AF1000000',
-    location: 'HERAT, AFGHANISTAN',
-    cost_of_living_adjustment: 0,
-    differential_rate: 35,
-    danger_pay: 35,
-    rest_relaxation_point: 'London',
-    has_consumable_allowance: true,
-    has_service_needs_differential: true,
-    languages: [{ id: 1, language: 'French (FR)', written_proficiency: '2', spoken_proficiency: '2', representation: 'French (FR) 2/2' }],
-  };
 
   beforeEach(() => {
     postMissionData = TestUtils.renderIntoDocument(<MemoryRouter>

--- a/src/Components/ResultsCard/ResultsCard.test.jsx
+++ b/src/Components/ResultsCard/ResultsCard.test.jsx
@@ -3,56 +3,26 @@ import React from 'react';
 import TestUtils from 'react-dom/test-utils';
 import { MemoryRouter } from 'react-router-dom';
 import ResultsCard from './ResultsCard';
+import resultsObject from '../../__mocks__/resultsObject';
 
 describe('ResultsCardComponent', () => {
   let result = null;
   let wrapper = null;
 
-  const resultsArray = {
-    results: [
-      { id: 6,
-        grade: '05',
-        skill: 'OFFICE MANAGEMENT (9017)',
-        bureau: '150000',
-        organization: 'YAOUNDE CAMEROON (YAOUNDE)',
-        position_number: '00025003',
-        is_overseas: true,
-        create_date: '2006-09-20',
-        update_date: '2017-06-08',
-        post: { id: 162, tour_of_duty: '2YRR', code: 'LT6000000', location: 'MASERU, LESOTHO', cost_of_living_adjustment: 0, differential_rate: 15, danger_pay: 0, rest_relaxation_point: 'London', has_consumable_allowance: false, has_service_needs_differential: false },
-        languages: [
-        { id: 1, language: 'French (FR)', written_proficiency: '2', spoken_proficiency: '2', representation: 'French (FR) 2/2' },
-        ],
-      },
-      { id: 60,
-        grade: '03',
-        skill: 'OFFICE MANAGEMENT (9017)',
-        bureau: '150000',
-        organization: 'YAOUNDE CAMEROON (YAOUNDE)',
-        position_number: '00025003',
-        is_overseas: true,
-        create_date: '2006-09-20',
-        update_date: '2017-06-08',
-        post: null,
-        languages: [],
-      },
-    ],
-  };
-
   it('is defined', () => {
     result = TestUtils.renderIntoDocument(<MemoryRouter>
-      <ResultsCard result={resultsArray.results[0]} onToggle={() => {}} />
+      <ResultsCard result={resultsObject.results[0]} onToggle={() => {}} />
     </MemoryRouter>);
     expect(result).toBeDefined();
   });
 
   it('can receive props', () => {
-    wrapper = shallow(<ResultsCard result={resultsArray.results[0]} onToggle={() => {}} />);
+    wrapper = shallow(<ResultsCard result={resultsObject.results[0]} onToggle={() => {}} />);
     expect(wrapper.instance().props.result.id).toBe(6);
   });
 
   it('can receive different types of results', () => {
-    wrapper = shallow(<ResultsCard result={resultsArray.results[1]} onToggle={() => {}} />);
+    wrapper = shallow(<ResultsCard result={resultsObject.results[1]} onToggle={() => {}} />);
     expect(wrapper.instance().props.result.id).toBe(60);
   });
 });

--- a/src/Components/ResultsList/ResultsList.test.jsx
+++ b/src/Components/ResultsList/ResultsList.test.jsx
@@ -4,46 +4,15 @@ import React from 'react';
 import TestUtils from 'react-dom/test-utils';
 import { MemoryRouter } from 'react-router-dom';
 import ResultsList from './ResultsList';
+import resultsObject from '../../__mocks__/resultsObject';
 
 describe('ResultsListComponent', () => {
   let results = null;
   let wrapper = null;
 
-  const resultsArray = {
-    count: 2,
-    results: [
-      { id: 6,
-        grade: '05',
-        skill: 'OFFICE MANAGEMENT (9017)',
-        bureau: '150000',
-        organization: 'YAOUNDE CAMEROON (YAOUNDE)',
-        position_number: '00025003',
-        is_overseas: true,
-        create_date: '2006-09-20',
-        update_date: '2017-06-08',
-        post: { id: 162, tour_of_duty: '2YRR', code: 'LT6000000', location: 'MASERU, LESOTHO', cost_of_living_adjustment: 0, differential_rate: 15, danger_pay: 0, rest_relaxation_point: 'London', has_consumable_allowance: false, has_service_needs_differential: false },
-        languages: [
-        { id: 1, language: 'French (FR)', written_proficiency: '2', spoken_proficiency: '2', representation: 'French (FR) 2/2' },
-        ],
-      },
-      { id: 60,
-        grade: '03',
-        skill: 'OFFICE MANAGEMENT (9017)',
-        bureau: '150000',
-        organization: 'YAOUNDE CAMEROON (YAOUNDE)',
-        position_number: '00025003',
-        is_overseas: true,
-        create_date: '2006-09-20',
-        update_date: '2017-06-08',
-        post: null,
-        languages: [],
-      },
-    ],
-  };
-
   beforeEach(() => {
     results = TestUtils.renderIntoDocument(<MemoryRouter>
-      <ResultsList results={resultsArray} />
+      <ResultsList results={resultsObject} />
     </MemoryRouter>);
   });
 
@@ -52,12 +21,12 @@ describe('ResultsListComponent', () => {
   });
 
   it('can receive props', () => {
-    wrapper = shallow(<ResultsList results={resultsArray} />);
+    wrapper = shallow(<ResultsList results={resultsObject} />);
     expect(wrapper.instance().props.results.results[0].id).toBe(6);
   });
 
   it('can call the onChildToggle function', () => {
-    wrapper = shallow(<ResultsList results={resultsArray} />);
+    wrapper = shallow(<ResultsList results={resultsObject} />);
     // define the instance
     const instance = wrapper.instance();
     // spy the logout function

--- a/src/Components/ResultsPage/ResultsPage.test.jsx
+++ b/src/Components/ResultsPage/ResultsPage.test.jsx
@@ -3,48 +3,17 @@ import React from 'react';
 import sinon from 'sinon';
 import ResultsPage from './ResultsPage';
 import { POSITION_SEARCH_SORTS, POSITION_PAGE_SIZES } from '../../Constants/Sort';
+import resultsObject from '../../__mocks__/resultsObject';
 
 describe('ResultsPageComponent', () => {
   let wrapper = null;
-
-  const resultsArray = {
-    count: 2,
-    results: [
-      { id: 6,
-        grade: '05',
-        skill: 'OFFICE MANAGEMENT (9017)',
-        bureau: '150000',
-        organization: 'YAOUNDE CAMEROON (YAOUNDE)',
-        position_number: '00025003',
-        is_overseas: true,
-        create_date: '2006-09-20',
-        update_date: '2017-06-08',
-        post: { id: 162, tour_of_duty: '2YRR', code: 'LT6000000', location: 'MASERU, LESOTHO', cost_of_living_adjustment: 0, differential_rate: 15, danger_pay: 0, rest_relaxation_point: 'London', has_consumable_allowance: false, has_service_needs_differential: false },
-        languages: [
-        { id: 1, language: 'French (FR)', written_proficiency: '2', spoken_proficiency: '2', representation: 'French (FR) 2/2' },
-        ],
-      },
-      { id: 60,
-        grade: '03',
-        skill: 'OFFICE MANAGEMENT (9017)',
-        bureau: '150000',
-        organization: 'YAOUNDE CAMEROON (YAOUNDE)',
-        position_number: '00025003',
-        is_overseas: true,
-        create_date: '2006-09-20',
-        update_date: '2017-06-08',
-        post: null,
-        languages: [],
-      },
-    ],
-  };
 
   const defaultSort = '';
   const defaultPageSize = 10;
 
   it('is defined', () => {
     wrapper = shallow(<ResultsPage
-      results={resultsArray}
+      results={resultsObject}
       hasErrored
       isLoading={false}
       sortBy={POSITION_SEARCH_SORTS}
@@ -58,7 +27,7 @@ describe('ResultsPageComponent', () => {
 
   it('can receive props', () => {
     wrapper = shallow(<ResultsPage
-      results={resultsArray}
+      results={resultsObject}
       hasErrored
       isLoading={false}
       sortBy={POSITION_SEARCH_SORTS}
@@ -85,7 +54,7 @@ describe('ResultsPageComponent', () => {
 
   it('can call the onChildToggle function', () => {
     wrapper = shallow(<ResultsPage
-      results={resultsArray}
+      results={resultsObject}
       sortBy={POSITION_SEARCH_SORTS}
       defaultSort={defaultSort}
       pageSizes={POSITION_PAGE_SIZES}
@@ -98,7 +67,7 @@ describe('ResultsPageComponent', () => {
 
   it('can call the queryParamUpdate function', () => {
     wrapper = shallow(<ResultsPage
-      results={resultsArray}
+      results={resultsObject}
       sortBy={POSITION_SEARCH_SORTS}
       defaultSort={defaultSort}
       pageSizes={POSITION_PAGE_SIZES}

--- a/src/__mocks__/postObject.js
+++ b/src/__mocks__/postObject.js
@@ -1,0 +1,15 @@
+const postObject = {
+  id: 100,
+  tour_of_duty: '1Y2RR',
+  code: 'AF1000000',
+  location: 'HERAT, AFGHANISTAN',
+  cost_of_living_adjustment: 0,
+  differential_rate: 35,
+  danger_pay: 35,
+  rest_relaxation_point: 'London',
+  has_consumable_allowance: true,
+  has_service_needs_differential: true,
+  languages: [{ id: 1, language: 'French (FR)', written_proficiency: '2', spoken_proficiency: '2', representation: 'French (FR) 2/2' }],
+};
+
+export default postObject;

--- a/src/__mocks__/resultsObject.js
+++ b/src/__mocks__/resultsObject.js
@@ -1,0 +1,34 @@
+const resultsObject = {
+  count: 2,
+  results: [
+    { id: 6,
+      grade: '05',
+      skill: 'OFFICE MANAGEMENT (9017)',
+      bureau: '150000',
+      organization: 'YAOUNDE CAMEROON (YAOUNDE)',
+      position_number: '00025003',
+      is_overseas: true,
+      create_date: '2006-09-20',
+      update_date: '2017-06-08',
+      post: { id: 162, tour_of_duty: '2YRR', code: 'LT6000000', location: 'MASERU, LESOTHO', cost_of_living_adjustment: 0, differential_rate: 15, danger_pay: 0, rest_relaxation_point: 'London', has_consumable_allowance: false, has_service_needs_differential: false },
+      languages: [
+        { id: 1, language: 'French (FR)', written_proficiency: '2', spoken_proficiency: '2', representation: 'French (FR) 2/2' },
+        { id: 1, language: 'German (GM)', written_proficiency: '2', spoken_proficiency: '2', representation: 'German (GM) 2/2' },
+      ],
+    },
+    { id: 60,
+      grade: '03',
+      skill: 'OFFICE MANAGEMENT (9017)',
+      bureau: '150000',
+      organization: 'YAOUNDE CAMEROON (YAOUNDE)',
+      position_number: '00025003',
+      is_overseas: true,
+      create_date: '2006-09-20',
+      update_date: '2017-06-08',
+      post: null,
+      languages: [],
+    },
+  ],
+};
+
+export default resultsObject;


### PR DESCRIPTION
Moves common objects and arrays into the `__mocks__` folder for re-use across tests.