### PR TITLE
Use redux and the router to handle passing history between routes

### DIFF
--- a/src/Components/PositionDetails/PositionDetails.jsx
+++ b/src/Components/PositionDetails/PositionDetails.jsx
@@ -8,13 +8,13 @@ import PositionTitle from '../PositionTitle/PositionTitle';
 import PositionDetailsItem from '../PositionDetailsItem/PositionDetailsItem';
 import PositionAdditionalDetails from '../PositionAdditionalDetails/PositionAdditionalDetails';
 
-const PositionDetails = ({ details, api, isLoading, hasErrored, goBack }) => {
+const PositionDetails = ({ details, api, isLoading, hasErrored, goBackLink }) => {
   const isReady = details && !isLoading && !hasErrored;
   return (
     <div>
       { isReady &&
       <div>
-        <PositionTitle details={details} goBack={goBack} />
+        <PositionTitle details={details} goBackLink={goBackLink} />
         <PositionDetailsItem details={details} />
         <PositionAdditionalDetails />
         <div className="usa-grid">
@@ -32,7 +32,7 @@ PositionDetails.propTypes = {
   api: PropTypes.string.isRequired,
   isLoading: PropTypes.bool,
   hasErrored: PropTypes.bool,
-  goBack: PropTypes.func.isRequired,
+  goBackLink: PropTypes.node.isRequired,
 };
 
 PositionDetails.defaultProps = {

--- a/src/Components/PositionDetails/PositionDetails.test.jsx
+++ b/src/Components/PositionDetails/PositionDetails.test.jsx
@@ -2,6 +2,7 @@ import { shallow } from 'enzyme';
 import React from 'react';
 import PositionDetails from './PositionDetails';
 import detailsObject from '../../__mocks__/detailsObject';
+import goBackLink from '../../__mocks__/goBackLink';
 
 describe('PositionDetailsComponent', () => {
   let wrapper = null;
@@ -15,7 +16,7 @@ describe('PositionDetailsComponent', () => {
         details={detailsObject}
         isLoading={false}
         hasErrored={false}
-        goBack={() => {}}
+        goBackLink={goBackLink}
       />,
     );
     expect(wrapper.instance().props.details.id).toBe(6);
@@ -30,7 +31,7 @@ describe('PositionDetailsComponent', () => {
         details={detailsObject}
         isLoading={false}
         hasErrored={false}
-        goBack={() => {}}
+        goBackLink={goBackLink}
       />,
     );
     expect(wrapper.instance().props.details.languages.length).toBe(0);
@@ -45,7 +46,7 @@ describe('PositionDetailsComponent', () => {
         details={detailsObject}
         isLoading
         hasErrored={false}
-        goBack={() => {}}
+        goBackLink={goBackLink}
       />,
     );
     expect(wrapper.instance().props.details.languages.length).toBe(0);

--- a/src/Components/PositionTitle/PositionTitle.jsx
+++ b/src/Components/PositionTitle/PositionTitle.jsx
@@ -4,30 +4,20 @@ import PropTypes from 'prop-types';
 import { POSITION_DETAILS } from '../../Constants/PropTypes';
 
 class PositionTitle extends Component { // eslint-disable-line
-  navBack(e) {
-    const { goBack } = this.props;
-    if (e.keyCode === 13 || e === 'click') {
-      goBack();
-    }
-  }
   render() {
-    const { details } = this.props;
+    const { details, goBackLink } = this.props;
     return (
       <div className="position-details-header" style={{ overflow: 'hidden', backgroundColor: '#F2F2F2' }}>
         <div className="usa-grid" style={{ overflow: 'hidden' }}>
           <div className="usa-width-one-half">
             <div className="position-details-header-back">
-              <a
-                role="link"
-                tabIndex="0"
-                className="back-link"
-                onKeyDown={(e) => { this.navBack(e); }}
-                onClick={() => { this.navBack('click'); }}
-              >
+              { goBackLink && // if goBackLink is defined, render...
+              <div>
                 <FontAwesome name="arrow-left" />
-              &nbsp;
-              Go back
-            </a>
+                &nbsp;
+                {goBackLink}
+              </div>
+              }
             </div>
             <div className="position-details-header-title">
               <strong>Position Number: {details.position_number}</strong>
@@ -59,7 +49,7 @@ class PositionTitle extends Component { // eslint-disable-line
 
 PositionTitle.propTypes = {
   details: POSITION_DETAILS,
-  goBack: PropTypes.func.isRequired,
+  goBackLink: PropTypes.node.isRequired,
 };
 
 PositionTitle.defaultProps = {

--- a/src/Components/PositionTitle/PositionTitle.jsx
+++ b/src/Components/PositionTitle/PositionTitle.jsx
@@ -1,51 +1,46 @@
-import React, { Component } from 'react';
+import React from 'react';
 import FontAwesome from 'react-fontawesome';
 import PropTypes from 'prop-types';
 import { POSITION_DETAILS } from '../../Constants/PropTypes';
 
-class PositionTitle extends Component { // eslint-disable-line
-  render() {
-    const { details, goBackLink } = this.props;
-    return (
-      <div className="position-details-header" style={{ overflow: 'hidden', backgroundColor: '#F2F2F2' }}>
-        <div className="usa-grid" style={{ overflow: 'hidden' }}>
-          <div className="usa-width-one-half">
-            <div className="position-details-header-back">
-              { goBackLink && // if goBackLink is defined, render...
-              <div>
-                <FontAwesome name="arrow-left" />
+const PositionTitle = ({ details, goBackLink }) => (
+  <div className="position-details-header" style={{ overflow: 'hidden', backgroundColor: '#F2F2F2' }}>
+    <div className="usa-grid" style={{ overflow: 'hidden' }}>
+      <div className="usa-width-one-half">
+        <div className="position-details-header-back">
+          { goBackLink && // if goBackLink is defined, render...
+          <div>
+            <FontAwesome name="arrow-left" />
                 &nbsp;
-                {goBackLink}
-              </div>
+            {goBackLink}
+          </div>
               }
-            </div>
-            <div className="position-details-header-title">
-              <strong>Position Number: {details.position_number}</strong>
-            </div>
-            <p className="position-details-header-body">
-              <strong>Description: </strong>
+        </div>
+        <div className="position-details-header-title">
+          <strong>Position Number: {details.position_number}</strong>
+        </div>
+        <p className="position-details-header-body">
+          <strong>Description: </strong>
               Lorem Ipsum is simply dummy text of the printing and typesetting industry.
               Lorem Ipsum has been the industry standard dummy text
               ever since the 1500s, when an unknown printer
               took a galley of type and scrambled it to make...
           </p>
-            <div className="usa-width-one-half position-details-header-body">
-              <strong>Post website:</strong> <a href="https://www.state.gov">www.state.gov</a>
-            </div>
-            <div className="usa-width-one-half position-details-header-body">
-              <strong>Point of Contact:</strong> <a href="tel:222-222-2222">222-222-2222</a>
-            </div>
-          </div>
+        <div className="usa-width-one-half position-details-header-body">
+          <strong>Post website:</strong> <a href="https://www.state.gov">www.state.gov</a>
         </div>
-        <img
-          className="position-details-header-image"
-          alt="department of state seal"
-          src="/assets/img/dos-seal-bw.png"
-        />
+        <div className="usa-width-one-half position-details-header-body">
+          <strong>Point of Contact:</strong> <a href="tel:222-222-2222">222-222-2222</a>
+        </div>
       </div>
-    );
-  }
-}
+    </div>
+    <img
+      className="position-details-header-image"
+      alt="department of state seal"
+      src="/assets/img/dos-seal-bw.png"
+    />
+  </div>
+);
 
 PositionTitle.propTypes = {
   details: POSITION_DETAILS,

--- a/src/Components/PositionTitle/PositionTitle.test.jsx
+++ b/src/Components/PositionTitle/PositionTitle.test.jsx
@@ -1,9 +1,9 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-import sinon from 'sinon';
 import toJSON from 'enzyme-to-json';
 import PositionTitle from './PositionTitle';
 import detailsObject from '../../__mocks__/detailsObject';
+import goBackLink from '../../__mocks__/goBackLink';
 
 describe('PositionTitleComponent', () => {
   let wrapper = null;
@@ -14,7 +14,7 @@ describe('PositionTitleComponent', () => {
         details={detailsObject}
         isLoading={false}
         hasErrored={false}
-        goBack={() => {}}
+        goBackLink={goBackLink}
       />,
     );
     expect(wrapper.instance().props.details.id).toBe(6);
@@ -26,79 +26,10 @@ describe('PositionTitleComponent', () => {
         details={detailsObject}
         isLoading={false}
         hasErrored={false}
-        goBack={() => {}}
+        goBackLink={goBackLink}
       />,
     );
     expect(toJSON(wrapper)).toMatchSnapshot();
-  });
-
-  it('can click the back link', () => {
-    // function property to navigate back
-    const goBackSpy = sinon.spy();
-    wrapper = shallow(
-      <PositionTitle
-        details={detailsObject}
-        goBack={goBackSpy}
-        isLoading={false}
-        hasErrored={false}
-      />,
-    );
-    // define the instance
-    const instance = wrapper.instance();
-    // function that handles going back
-    const handleClickSpy = sinon.spy(instance, 'navBack');
-    // click the link in the title to go back
-    wrapper.find('[role="link"]').simulate('click');
-    // check that navBack was called
-    sinon.assert.calledOnce(handleClickSpy);
-    // check that goBack prop was called
-    sinon.assert.calledOnce(goBackSpy);
-  });
-
-  it('can press enter on the back link', () => {
-    // function property to navigate back
-    const goBackSpy = sinon.spy();
-    wrapper = shallow(
-      <PositionTitle
-        details={detailsObject}
-        goBack={goBackSpy}
-        isLoading={false}
-        hasErrored={false}
-      />,
-    );
-    // define the instance
-    const instance = wrapper.instance();
-    // function that handles going back
-    const handleClickSpy = sinon.spy(instance, 'navBack');
-    // press enter on the link in the title to go back
-    wrapper.find('[role="link"]').simulate('keydown', { keyCode: 13 });
-    // check that navBack was called
-    sinon.assert.calledOnce(handleClickSpy);
-    // check that goBack prop was called
-    sinon.assert.calledOnce(goBackSpy);
-  });
-
-  it('can press (space) on the back link', () => {
-    // function property to navigate back
-    const goBackSpy = sinon.spy();
-    wrapper = shallow(
-      <PositionTitle
-        details={detailsObject}
-        goBack={goBackSpy}
-        isLoading={false}
-        hasErrored={false}
-      />,
-    );
-    // define the instance
-    const instance = wrapper.instance();
-    // function that handles going back
-    const handleClickSpy = sinon.spy(instance, 'navBack');
-    // press enter on the link in the title to go back
-    wrapper.find('[role="link"]').simulate('keydown', { keyCode: 32 });
-    // check that navBack was called
-    sinon.assert.calledOnce(handleClickSpy);
-    // check that goBack prop was not called
-    sinon.assert.notCalled(goBackSpy);
   });
 
   it('handles different props and different position objects', () => {
@@ -109,7 +40,7 @@ describe('PositionTitleComponent', () => {
         details={detailsObject}
         isLoading={false}
         hasErrored={false}
-        goBack={() => {}}
+        goBackLink={goBackLink}
       />,
     );
     expect(wrapper.instance().props.details.languages.length).toBe(0);
@@ -119,7 +50,12 @@ describe('PositionTitleComponent', () => {
     Object.assign(detailsObject, { languages: [], is_overseas: true });
 
     wrapper = shallow(
-      <PositionTitle details={detailsObject} isLoading hasErrored={false} goBack={() => {}} />,
+      <PositionTitle
+        details={detailsObject}
+        isLoading
+        hasErrored={false}
+        goBackLink={goBackLink}
+      />,
     );
     expect(wrapper.instance().props.details.languages.length).toBe(0);
   });

--- a/src/Components/PositionTitle/__snapshots__/PositionTitle.test.jsx.snap
+++ b/src/Components/PositionTitle/__snapshots__/PositionTitle.test.jsx.snap
@@ -24,18 +24,18 @@ exports[`PositionTitleComponent matches snapshot 1`] = `
       <div
         className="position-details-header-back"
       >
-        <a
-          className="back-link"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          role="link"
-          tabIndex="0"
-        >
+        <div>
           <FontAwesome
             name="arrow-left"
           />
-            Go back
-        </a>
+           
+          <Link
+            replace={false}
+            to="/"
+          >
+            text
+          </Link>
+        </div>
       </div>
       <div
         className="position-details-header-title"

--- a/src/Constants/PropTypes.js
+++ b/src/Constants/PropTypes.js
@@ -106,4 +106,11 @@ export const USER_PROFILE = PropTypes.shape({
   ),
 });
 
+export const ROUTER_LOCATIONS = PropTypes.arrayOf(PropTypes.shape({
+  pathname: PropTypes.string,
+  search: PropTypes.string,
+  hash: PropTypes.string,
+  key: PropTypes.string,
+}));
+
 export const EMPTY_FUNCTION = () => {};

--- a/src/Containers/Position/Position.jsx
+++ b/src/Containers/Position/Position.jsx
@@ -4,8 +4,9 @@ import { connect } from 'react-redux';
 import { push } from 'react-router-redux';
 import { withRouter } from 'react-router';
 import { positionDetailsFetchData } from '../../actions/positionDetails';
+import { getLastRouteLink } from '../../actions/routerLocations';
 import PositionDetails from '../../Components/PositionDetails/PositionDetails';
-import { POSITION_DETAILS, EMPTY_FUNCTION } from '../../Constants/PropTypes';
+import { POSITION_DETAILS, EMPTY_FUNCTION, ROUTER_LOCATIONS } from '../../Constants/PropTypes';
 import { PUBLIC_ROOT } from '../../login/DefaultRoutes';
 
 class Position extends Component {
@@ -25,7 +26,7 @@ class Position extends Component {
   }
 
   render() {
-    const { positionDetails, isLoading, hasErrored } = this.props;
+    const { positionDetails, isLoading, hasErrored, routerLocations } = this.props;
     return (
       <div>
         <PositionDetails
@@ -33,7 +34,7 @@ class Position extends Component {
           details={positionDetails[0]}
           isLoading={isLoading}
           hasErrored={hasErrored}
-          goBack={this.context.router.history.goBack}
+          goBackLink={getLastRouteLink(routerLocations)}
         />
       </div>
     );
@@ -57,6 +58,7 @@ Position.propTypes = {
   isLoading: PropTypes.bool,
   positionDetails: PropTypes.arrayOf(POSITION_DETAILS),
   isAuthorized: PropTypes.func.isRequired,
+  routerLocations: ROUTER_LOCATIONS,
 };
 
 Position.defaultProps = {
@@ -64,12 +66,14 @@ Position.defaultProps = {
   fetchData: EMPTY_FUNCTION,
   hasErrored: false,
   isLoading: true,
+  routerLocations: [],
 };
 
 const mapStateToProps = (state, ownProps) => ({
   positionDetails: state.positionDetails,
   hasErrored: state.positionDetailsHasErrored,
   isLoading: state.positionDetailsIsLoading,
+  routerLocations: state.routerLocations,
   id: ownProps,
 });
 

--- a/src/Containers/Position/Position.test.jsx
+++ b/src/Containers/Position/Position.test.jsx
@@ -5,6 +5,7 @@ import { MemoryRouter } from 'react-router-dom';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import Position from './Position';
+import routerLocations from '../../__mocks__/routerLocations';
 
 const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
@@ -14,14 +15,24 @@ describe('Main', () => {
 
   it('is defined', () => {
     const position = TestUtils.renderIntoDocument(<Provider store={mockStore({})}><MemoryRouter>
-      <Position isAuthorized={() => true} api={api} onNavigateTo={() => {}} />
+      <Position
+        isAuthorized={() => true}
+        api={api}
+        onNavigateTo={() => {}}
+        routerLocations={routerLocations}
+      />
     </MemoryRouter></Provider>);
     expect(position).toBeDefined();
   });
 
   it('can handle authentication redirects', () => {
     const position = TestUtils.renderIntoDocument(<Provider store={mockStore({})}><MemoryRouter>
-      <Position isAuthorized={() => false} api={api} onNavigateTo={() => {}} />
+      <Position
+        isAuthorized={() => false}
+        api={api}
+        onNavigateTo={() => {}}
+        routerLocations={routerLocations}
+      />
     </MemoryRouter></Provider>);
     expect(position).toBeDefined();
   });

--- a/src/Containers/Routes/Routes.test.jsx
+++ b/src/Containers/Routes/Routes.test.jsx
@@ -5,7 +5,6 @@ import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import Routes from './Routes';
-import routerLocations from '../../__mocks__/routerLocations';
 
 const middlewares = [thunk];
 const mockStore = configureStore(middlewares);

--- a/src/Containers/Routes/Routes.test.jsx
+++ b/src/Containers/Routes/Routes.test.jsx
@@ -5,6 +5,7 @@ import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import Routes from './Routes';
+import routerLocations from '../../__mocks__/routerLocations';
 
 const middlewares = [thunk];
 const mockStore = configureStore(middlewares);

--- a/src/__mocks__/goBackLink.jsx
+++ b/src/__mocks__/goBackLink.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const goBackLink = (<Link to="/">text</Link>);
+
+export default goBackLink;

--- a/src/__mocks__/routerLocations.js
+++ b/src/__mocks__/routerLocations.js
@@ -1,0 +1,6 @@
+const routerLocations = [
+  { pathname: '/results', search: '?page=1&q=german', hash: '', key: 'xvwp1n' },
+  { pathname: '/details/55360000', search: '', hash: '', key: '5n07nr' },
+];
+
+export default routerLocations;

--- a/src/actions/routerLocations.jsx
+++ b/src/actions/routerLocations.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+// map paths to readable link text
+export function mapRoutesToNames(route) {
+  const preText = 'Go back';
+  switch (route) {
+    case '/results':
+      return `${preText} to search results`;
+    case '/':
+      return `${preText} to the home page`;
+    case '/details':
+      return `${preText} to position details`;
+    case '/post':
+      return `${preText} to post details`;
+    default: // else, just return generic "Go back" text
+      return preText;
+  }
+}
+
+// get the full object for the most recently visited route
+export function getLastRoute(routerLocations) {
+  if (!routerLocations || routerLocations.length <= 1) {
+    return false;
+  }
+  // else, return the pathname
+  const lastLocation = routerLocations[routerLocations.length - 2];
+  return lastLocation;
+}
+
+// return just the name of that route, using the mapping
+export function getLastRouteName(routerLocations) {
+  const path = getLastRoute(routerLocations).pathname;
+  if (path) { return mapRoutesToNames(path); }
+  return false;
+}
+
+// return the full route, including the pathname and any search parameters
+export function getLastRouteLink(routerLocations) {
+  const text = getLastRouteName(routerLocations);
+  const lastLocation = getLastRoute(routerLocations);
+  if (!text || !lastLocation) {
+    return false;
+  }
+  const navigateTo = `${lastLocation.pathname}${lastLocation.search}`;
+  return (<Link to={navigateTo}>{text}</Link>);
+}

--- a/src/actions/routerLocations.test.jsx
+++ b/src/actions/routerLocations.test.jsx
@@ -1,0 +1,26 @@
+import * as actions from './routerLocations';
+import routerLocations from '../__mocks__/routerLocations';
+
+describe('routerLocations', () => {
+  it('maps routes to names', () => {
+    ['/results', '/', '/details', '/post', 'fakeroute'].map(route => (
+      expect(actions.mapRoutesToNames(route)).toBeDefined()
+    ));
+  });
+
+  it('can get the last route', () => {
+    expect(actions.getLastRoute(routerLocations)).toBe(routerLocations[routerLocations.length - 2]);
+  });
+
+  it('will not return a route if there is no history', () => {
+    expect(actions.getLastRoute([])).toBe(false);
+  });
+
+  it('can get the last route name', () => {
+    expect(actions.getLastRouteName(routerLocations)).toBe('Go back to search results');
+  });
+
+  it('can get the Link element for last route', () => {
+    expect(actions.getLastRouteLink(routerLocations)).toBeDefined();
+  });
+});

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -10,6 +10,7 @@ import { share, shareHasErrored, shareIsSending } from './share';
 import { positionDetails, positionDetailsHasErrored, positionDetailsIsLoading } from './positionDetails';
 import { comparisons, comparisonsHasErrored, comparisonsIsLoading } from './comparisons';
 import { userProfile, userProfileHasErrored, userProfileIsLoading } from './userProfile';
+import routerLocations from './routerLocations';
 
 
 export default combineReducers({
@@ -37,5 +38,6 @@ export default combineReducers({
   form,
   client,
   login,
+  routerLocations,
   router: routerReducer,
 });

--- a/src/reducers/routerLocations.js
+++ b/src/reducers/routerLocations.js
@@ -1,0 +1,8 @@
+export default function routerLocations(state = [], action) {
+  switch (action.type) {
+    case '@@router/LOCATION_CHANGE':
+      return [...state, action.payload];
+    default:
+      return state;
+  }
+}

--- a/src/sass/_details.scss
+++ b/src/sass/_details.scss
@@ -12,6 +12,12 @@
 
   .position-details-header-back {
     font-size: .8em;
+    min-height: 17px;
+
+    a {
+      color: $color-black;
+      text-decoration: none;
+    }
   }
 
   .position-details-header-title {

--- a/src/sass/_variables.scss
+++ b/src/sass/_variables.scss
@@ -4,6 +4,7 @@ $color-gray-lightest: #f1f1f1;
 $color-gray-lighter: #d6d7d9;
 $blue-primary: #0071bc;
 $color-white: #fff;
+$color-black: #000;
 
 //avatar dropdown
 $avatar-background: #fff;


### PR DESCRIPTION
This makes use of `@@router/LOCATION_CHANGE` and redux to store the entire history of the session in an array. This can then be accessed by the `Position` container, and with the help of some mapping, be passed to the `PositionTitle` as a dynamic element such as `<Link to="/results?q=german">Go back to search results</Link>`.

PR'ing into `sprint-6` since this is a bigger change.