### PR TITLE
Pagination wrapper

### DIFF
--- a/src/Components/PaginationWrapper/PaginationWrapper.jsx
+++ b/src/Components/PaginationWrapper/PaginationWrapper.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ReactPaginate from 'react-paginate';
+
+// wrapper for react-paginate module
+// reference https://github.com/AdeleD/react-paginate for prop types
+// wrapper performs reconciliation for react-paginate's zero-based pagination
+
+const PaginationWrapper = ({
+    previousLabel,
+    nextLabel,
+    pageCount,
+    marginPagesDisplayed,
+    pageRangeDisplayed,
+    onPageChange,
+    paginationStyle,
+    containerClassName,
+    subContainerClassName,
+    forcePage,
+    activeClassName,
+  }) => (
+    <nav className={paginationStyle} aria-label="Pagination">
+      <ReactPaginate
+        previousLabel={previousLabel}
+        nextLabel={nextLabel}
+        pageCount={pageCount}
+        marginPagesDisplayed={marginPagesDisplayed}
+        pageRangeDisplayed={pageRangeDisplayed}
+        onPageChange={
+          (e) => { e.selected += 1; onPageChange(e); /* reconciles zero-based pagination */ }}
+        containerClassName={containerClassName}
+        subContainerClassName={subContainerClassName}
+        forcePage={forcePage - 1 /* reconciles zero-based pagination */}
+        activeClassName={activeClassName}
+      />
+    </nav>
+  );
+
+PaginationWrapper.propTypes = {
+  previousLabel: PropTypes.string,
+  nextLabel: PropTypes.string,
+  pageCount: PropTypes.number.isRequired,
+  marginPagesDisplayed: PropTypes.number,
+  pageRangeDisplayed: PropTypes.number,
+  onPageChange: PropTypes.func.isRequired,
+  containerClassName: PropTypes.string,
+  subContainerClassName: PropTypes.string,
+  forcePage: PropTypes.number.isRequired,
+  activeClassName: PropTypes.string,
+  paginationStyle: PropTypes.string,
+};
+
+PaginationWrapper.defaultProps = {
+  previousLabel: 'previous',
+  nextLabel: 'next',
+  marginPagesDisplayed: 2,
+  pageRangeDisplayed: 1,
+  containerClassName: 'pagination',
+  subContainerClassName: 'pages pagination',
+  activeClassName: 'active',
+  paginationStyle: 'pagination',
+};
+
+export default PaginationWrapper;

--- a/src/Components/PaginationWrapper/PaginationWrapper.test.jsx
+++ b/src/Components/PaginationWrapper/PaginationWrapper.test.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import PaginationWrapper from './PaginationWrapper';
+
+// this is merely a wrapper for the react-paginate module, so we're just
+// ensuring that it accepts props
+
+describe('PaginationWrapper', () => {
+  let wrapper = null;
+
+  it('is defined', () => {
+    wrapper = shallow(<PaginationWrapper
+      pageCount={5}
+      onPageChange={() => {}}
+      forcePage={1}
+    />);
+    expect(wrapper).toBeDefined();
+  });
+
+  it('it can take different props', () => {
+    wrapper = shallow(<PaginationWrapper
+      pageCount={5}
+      onPageChange={() => {}}
+      forcePage={1}
+    />);
+    expect(wrapper.instance().props.pageCount).toBe(5);
+  });
+});

--- a/src/Components/ResultsPage/ResultsPage.jsx
+++ b/src/Components/ResultsPage/ResultsPage.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import ReactPaginate from 'react-paginate';
+import PaginationWrapper from '../PaginationWrapper/PaginationWrapper';
 import ResultsList from '../ResultsList/ResultsList';
 import { POSITION_SEARCH_RESULTS, EMPTY_FUNCTION, SORT_BY_PARENT_OBJECT } from '../../Constants/PropTypes';
 import ViewComparisonLink from '../ViewComparisonLink/ViewComparisonLink';
@@ -35,24 +35,6 @@ class Results extends Component {
       = this.props;
     const hasLoaded = !isLoading && results.results && !!results.results.length;
     const pageCount = Math.ceil(results.count / defaultPageSize);
-    const pagination = (
-      <div className="usa-grid-full react-paginate">
-        <nav className="pagination" aria-label="Pagination">
-          <ReactPaginate
-            previousLabel={'previous'}
-            nextLabel={'next'}
-            pageCount={pageCount}
-            marginPagesDisplayed={2}
-            pageRangeDisplayed={1}
-            onPageChange={e => this.queryParamUpdate({ page: e.selected + 1 })}
-            containerClassName={'pagination'}
-            subContainerClassName={'pages pagination'}
-            forcePage={this.props.defaultPageNumber}
-            activeClassName={'active'}
-          />
-        </nav>
-      </div>
-    );
     return (
       <div className="usa-grid-full results">
         <div className="usa-grid-full">
@@ -119,7 +101,13 @@ class Results extends Component {
             <Loading isLoading={isLoading} hasErrored={hasErrored} />
           }
         </div>
-        {pagination}
+        <div className="usa-grid-full react-paginate">
+          <PaginationWrapper
+            pageCount={pageCount}
+            onPageChange={e => this.queryParamUpdate({ page: e.selected })}
+            forcePage={this.props.defaultPageNumber}
+          />
+        </div>
       </div>
     );
   }

--- a/src/Containers/Results/Results.jsx
+++ b/src/Containers/Results/Results.jsx
@@ -84,7 +84,7 @@ class Results extends Component {
           defaultSort={this.state.defaultSort.value}
           pageSizes={POSITION_PAGE_SIZES}
           defaultPageSize={this.state.defaultPageSize.value}
-          defaultPageNumber={this.state.defaultPageNumber.value - 1}
+          defaultPageNumber={this.state.defaultPageNumber.value}
           onQueryParamUpdate={q => this.onQueryParamUpdate(q)}
         />
       </div>


### PR DESCRIPTION
Moves the use of the `react-paginate` module into a wrapper component which handles props, and more importantly, performs some reconciliation between zero-based and one-based arrays. Now, math does not need to be performed on page numbers before passing them as props to the component - the `PaginationWrapper` takes care of that. #385 