### PR TITLE
Store API endpoint refs in actions instead of components

### DIFF
--- a/src/Components/App/App.test.jsx
+++ b/src/Components/App/App.test.jsx
@@ -5,6 +5,6 @@ import App from './App';
 
 it('renders without crashing', () => {
   const div = document.createElement('div');
-  ReactDOM.render(<MemoryRouter><App api={'http://localhost:8000/api/v1'} /></MemoryRouter>, div);
+  ReactDOM.render(<MemoryRouter><App /></MemoryRouter>, div);
   global.document.getElementById = id => id === 'root' && div;
 });

--- a/src/Components/Filters/Filters.test.jsx
+++ b/src/Components/Filters/Filters.test.jsx
@@ -26,8 +26,6 @@ const store = configureStore();
 
 const context = createRouterContext();
 
-const api = 'http://localhost:8000/api/v1';
-
 let wrapper = null;
 
 describe('FiltersComponent', () => {
@@ -156,12 +154,12 @@ describe('FiltersComponent', () => {
   it('renders without crashing', () => {
     const div = document.createElement('div');
     ReactDOM.render(<MemoryRouter>
-      <Filters api={api} items={items} store={store} /></MemoryRouter>, div);
+      <Filters items={items} store={store} /></MemoryRouter>, div);
   });
 
   it('is defined', (done) => {
     const home = TestUtils.renderIntoDocument(<MemoryRouter>
-      <Filters api={api} store={store} items={items} location={{}} />
+      <Filters store={store} items={items} location={{}} />
     </MemoryRouter>, { context });
     const f = () => {
       setTimeout(() => {
@@ -173,7 +171,7 @@ describe('FiltersComponent', () => {
   });
 
   it('can change text', (done) => {
-    wrapper = shallow(<Filters store={store} items={items} api={api} />, { context });
+    wrapper = shallow(<Filters store={store} items={items} />, { context });
     wrapper.find('#search-field').simulate('change', { target: { value: 'info Tech' } });
     expect(wrapper.find('#search-field').props().value).toBe('info Tech');
     wrapper.unmount();
@@ -181,7 +179,7 @@ describe('FiltersComponent', () => {
   });
 
   it('can create a query string', (done) => {
-    wrapper = shallow(<Filters api={api} items={items} />, { context });
+    wrapper = shallow(<Filters items={items} />, { context });
     const f = () => {
       setTimeout(() => {
         wrapper.instance().changeText({ target: { value: 'info Tech' } });
@@ -193,7 +191,7 @@ describe('FiltersComponent', () => {
   });
 
   it('can call the createQueryString function to create multi-parameter query strings', (done) => {
-    wrapper = shallow(<Filters api={api} items={items} />, { context });
+    wrapper = shallow(<Filters items={items} />, { context });
     const f = () => {
       setTimeout(() => {
         wrapper.instance().changeText({ target: { value: 'info Tech' } });
@@ -209,7 +207,7 @@ describe('FiltersComponent', () => {
   });
 
   it('can check a checkbox', (done) => {
-    wrapper = shallow(<Filters api={api} items={items} />, { context });
+    wrapper = shallow(<Filters items={items} />, { context });
     const f = () => {
       setTimeout(() => {
         wrapper.find('#S0010').simulate('change', (0, { target: { checked: true, value: '0010' } }));
@@ -224,7 +222,7 @@ describe('FiltersComponent', () => {
   });
 
   it('can check and then uncheck a checkbox', (done) => {
-    wrapper = shallow(<Filters api={api} items={items} />, { context });
+    wrapper = shallow(<Filters items={items} />, { context });
     const f = () => {
       setTimeout(() => {
         wrapper.find('#S0010').simulate('change', (0, { target: { checked: true, value: '0010' } }));
@@ -246,7 +244,7 @@ describe('FiltersComponent', () => {
   });
 
   it('should disable search if less than two filters are selected', (done) => {
-    wrapper = shallow(<Filters api={api} items={items} />, { context });
+    wrapper = shallow(<Filters items={items} />, { context });
     const f = () => {
       setTimeout(() => {
         // no filters are initially set, so should return true
@@ -267,7 +265,7 @@ describe('FiltersComponent', () => {
   });
 
   it('should enable search if two filters are selected, excluding search text', (done) => {
-    wrapper = shallow(<Filters api={api} items={items} />, { context });
+    wrapper = shallow(<Filters items={items} />, { context });
     const f = () => {
       setTimeout(() => {
         // no filters are initially set, so should return true
@@ -284,7 +282,7 @@ describe('FiltersComponent', () => {
   });
 
   it('should be able to enable language proficiency filters', (done) => {
-    wrapper = shallow(<Filters api={api} items={items} />, { context });
+    wrapper = shallow(<Filters items={items} />, { context });
     const f = () => {
       setTimeout(() => {
         // change English written to 1
@@ -302,7 +300,7 @@ describe('FiltersComponent', () => {
   });
 
   it('should be able to submit a search', (done) => {
-    wrapper = shallow(<Filters api={api} items={items} />, { context });
+    wrapper = shallow(<Filters items={items} />, { context });
     const f = () => {
       setTimeout(() => {
         wrapper.find('#search-field').simulate('change', { target: { value: 'test' } });

--- a/src/Components/PositionDetails/PositionDetails.jsx
+++ b/src/Components/PositionDetails/PositionDetails.jsx
@@ -8,7 +8,7 @@ import PositionTitle from '../PositionTitle/PositionTitle';
 import PositionDetailsItem from '../PositionDetailsItem/PositionDetailsItem';
 import PositionAdditionalDetails from '../PositionAdditionalDetails/PositionAdditionalDetails';
 
-const PositionDetails = ({ details, api, isLoading, hasErrored, goBackLink }) => {
+const PositionDetails = ({ details, isLoading, hasErrored, goBackLink }) => {
   const isReady = details && !isLoading && !hasErrored;
   return (
     <div>
@@ -19,7 +19,7 @@ const PositionDetails = ({ details, api, isLoading, hasErrored, goBackLink }) =>
         <PositionAdditionalDetails />
         <div className="usa-grid">
           <FavoritesButton refKey={details.position_number} type="fav" />
-          <Share api={api} identifier={details.id} />
+          <Share identifier={details.id} />
         </div>
       </div>}
       {isLoading && <Loading isLoading={isLoading} hasErrored={hasErrored} />}
@@ -29,7 +29,6 @@ const PositionDetails = ({ details, api, isLoading, hasErrored, goBackLink }) =>
 
 PositionDetails.propTypes = {
   details: POSITION_DETAILS,
-  api: PropTypes.string.isRequired,
   isLoading: PropTypes.bool,
   hasErrored: PropTypes.bool,
   goBackLink: PropTypes.node.isRequired,

--- a/src/Components/PositionDetails/PositionDetails.test.jsx
+++ b/src/Components/PositionDetails/PositionDetails.test.jsx
@@ -7,12 +7,9 @@ import goBackLink from '../../__mocks__/goBackLink';
 describe('PositionDetailsComponent', () => {
   let wrapper = null;
 
-  const api = 'localhost:8000/api/v1/';
-
   it('can receive props', () => {
     wrapper = shallow(
       <PositionDetails
-        api={api}
         details={detailsObject}
         isLoading={false}
         hasErrored={false}
@@ -27,7 +24,6 @@ describe('PositionDetailsComponent', () => {
 
     wrapper = shallow(
       <PositionDetails
-        api={api}
         details={detailsObject}
         isLoading={false}
         hasErrored={false}
@@ -42,7 +38,6 @@ describe('PositionDetailsComponent', () => {
 
     wrapper = shallow(
       <PositionDetails
-        api={api}
         details={detailsObject}
         isLoading
         hasErrored={false}

--- a/src/Components/Share/Share.jsx
+++ b/src/Components/Share/Share.jsx
@@ -8,7 +8,7 @@ import { EMPTY_FUNCTION } from '../../Constants/PropTypes';
 class Share extends Component {
 
   onChildSend(e) {
-    this.props.sendData(`${this.props.api}/share/`, e);
+    this.props.sendData(e);
   }
 
   render() {
@@ -30,7 +30,6 @@ Share.contextTypes = {
 };
 
 Share.propTypes = {
-  api: PropTypes.string.isRequired,
   response: PropTypes.bool,
   sendData: PropTypes.func,
   hasErrored: PropTypes.oneOfType([

--- a/src/Components/Share/Share.test.jsx
+++ b/src/Components/Share/Share.test.jsx
@@ -11,18 +11,16 @@ const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
 
 describe('Main', () => {
-  const api = 'http://localhost:8000/api/v1';
-
   it('is defined', () => {
     const share = TestUtils.renderIntoDocument(<Provider store={mockStore({})}><MemoryRouter>
-      <Share api={api} identifier={5} />
+      <Share identifier={5} />
     </MemoryRouter></Provider>);
     expect(share).toBeDefined();
   });
 
   it('can call the onChildSend function', () => {
     const wrapper = shallow(
-      <Share.WrappedComponent api="test" identifier={1} onNavigateTo={() => {}} />,
+      <Share.WrappedComponent identifier={1} onNavigateTo={() => {}} />,
     );
     wrapper.instance().onChildSend();
   });

--- a/src/Containers/Compare/Compare.jsx
+++ b/src/Containers/Compare/Compare.jsx
@@ -25,9 +25,7 @@ class Results extends Component {
   }
 
   getComparisons(ids) {
-    const query = ids;
-    const api = this.props.api;
-    this.props.fetchData(`${api}/position/?position_number__in=${query}`);
+    this.props.fetchData(ids);
   }
 
   render() {
@@ -41,7 +39,6 @@ class Results extends Component {
 }
 
 Results.propTypes = {
-  api: PropTypes.string.isRequired,
   onNavigateTo: PropTypes.func.isRequired,
   match: PropTypes.shape({
     params: PropTypes.shape({

--- a/src/Containers/Compare/Compare.test.jsx
+++ b/src/Containers/Compare/Compare.test.jsx
@@ -10,18 +10,16 @@ const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
 
 describe('Main', () => {
-  const api = 'http://localhost:8000/api/v1';
-
   it('is defined', () => {
     const compare = TestUtils.renderIntoDocument(<Provider store={mockStore({})}><MemoryRouter>
-      <Compare isAuthorized={() => true} api={api} onNavigateTo={() => {}} />
+      <Compare isAuthorized={() => true} onNavigateTo={() => {}} />
     </MemoryRouter></Provider>);
     expect(compare).toBeDefined();
   });
 
   it('can handle authentication redirects', () => {
     const compare = TestUtils.renderIntoDocument(<Provider store={mockStore({})}><MemoryRouter>
-      <Compare isAuthorized={() => false} api={api} onNavigateTo={() => {}} />
+      <Compare isAuthorized={() => false} onNavigateTo={() => {}} />
     </MemoryRouter></Provider>);
     expect(compare).toBeDefined();
   });

--- a/src/Containers/Home/Home.jsx
+++ b/src/Containers/Home/Home.jsx
@@ -30,8 +30,8 @@ class Home extends Component {
   }
 
   getFilters() {
-    const { api, items } = this.props;
-    this.props.fetchData(api, items);
+    const { items } = this.props;
+    this.props.fetchData(items);
   }
 
   render() {
@@ -48,7 +48,6 @@ class Home extends Component {
 }
 
 Home.propTypes = {
-  api: PropTypes.string.isRequired,
   onNavigateTo: PropTypes.func.isRequired,
   fetchData: PropTypes.func,
   isLoading: PropTypes.bool,

--- a/src/Containers/Home/Home.test.jsx
+++ b/src/Containers/Home/Home.test.jsx
@@ -11,18 +11,16 @@ const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
 
 describe('Home', () => {
-  const api = 'http://localhost:8000/api/v1';
-
   it('is defined', () => {
     const home = TestUtils.renderIntoDocument(<Provider store={mockStore({})}><MemoryRouter>
-      <Home isAuthorized={() => true} api={api} onNavigateTo={() => {}} />
+      <Home isAuthorized={() => true} onNavigateTo={() => {}} />
     </MemoryRouter></Provider>);
     expect(home).toBeDefined();
   });
 
   it('can handle authentication redirects', () => {
     const home = TestUtils.renderIntoDocument(<Provider store={mockStore({})}><MemoryRouter>
-      <Home isAuthorized={() => false} api={api} onNavigateTo={() => {}} />
+      <Home isAuthorized={() => false} onNavigateTo={() => {}} />
     </MemoryRouter></Provider>);
     expect(home).toBeDefined();
   });
@@ -30,7 +28,6 @@ describe('Home', () => {
   it('can call the onChildSubmit function', () => {
     const wrapper = shallow(<Home.WrappedComponent
       isAuthorized={() => true}
-      api={api}
       onNavigateTo={() => {}}
     />);
     wrapper.instance().onChildSubmit();

--- a/src/Containers/Main/Main.test.jsx
+++ b/src/Containers/Main/Main.test.jsx
@@ -5,11 +5,9 @@ import { MemoryRouter } from 'react-router-dom';
 import Main from './Main';
 
 describe('Main', () => {
-  const api = 'http://localhost:8000/api/v1';
-
   it('is defined', () => {
     const main = TestUtils.renderIntoDocument(<MemoryRouter>
-      <Main api={api} />
+      <Main />
     </MemoryRouter>);
     expect(main).toBeDefined();
   });
@@ -44,19 +42,19 @@ describe('Main', () => {
       },
     ];
     const main = TestUtils.renderIntoDocument(<MemoryRouter initialEntries={['/results']}>
-      <Main api={api} results={resultsArray} />
+      <Main results={resultsArray} />
     </MemoryRouter>);
     expect(main).toBeDefined();
   });
   it('handles a position details route', () => {
     const main = TestUtils.renderIntoDocument(<MemoryRouter initialEntries={['/details/00011111']}>
-      <Main api={api} />
+      <Main />
     </MemoryRouter>);
     expect(main).toBeDefined();
   });
   it('handles a post details route', () => {
     const main = TestUtils.renderIntoDocument(<MemoryRouter initialEntries={['/post/00011111']}>
-      <Main api={api} />
+      <Main />
     </MemoryRouter>);
     expect(main).toBeDefined();
   });

--- a/src/Containers/Position/Position.jsx
+++ b/src/Containers/Position/Position.jsx
@@ -20,9 +20,7 @@ class Position extends Component {
   }
 
   getDetails(id) {
-    const query = id;
-    const api = this.props.api;
-    this.props.fetchData(`${api}/position/?position_number=${query}`);
+    this.props.fetchData(id);
   }
 
   render() {
@@ -30,7 +28,6 @@ class Position extends Component {
     return (
       <div>
         <PositionDetails
-          api={this.props.api}
           details={positionDetails[0]}
           isLoading={isLoading}
           hasErrored={hasErrored}
@@ -46,7 +43,6 @@ Position.contextTypes = {
 };
 
 Position.propTypes = {
-  api: PropTypes.string.isRequired,
   onNavigateTo: PropTypes.func.isRequired,
   match: PropTypes.shape({
     params: PropTypes.shape({

--- a/src/Containers/Position/Position.test.jsx
+++ b/src/Containers/Position/Position.test.jsx
@@ -11,13 +11,10 @@ const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
 
 describe('Main', () => {
-  const api = 'http://localhost:8000/api/v1';
-
   it('is defined', () => {
     const position = TestUtils.renderIntoDocument(<Provider store={mockStore({})}><MemoryRouter>
       <Position
         isAuthorized={() => true}
-        api={api}
         onNavigateTo={() => {}}
         routerLocations={routerLocations}
       />
@@ -29,7 +26,6 @@ describe('Main', () => {
     const position = TestUtils.renderIntoDocument(<Provider store={mockStore({})}><MemoryRouter>
       <Position
         isAuthorized={() => false}
-        api={api}
         onNavigateTo={() => {}}
         routerLocations={routerLocations}
       />

--- a/src/Containers/Post/Post.jsx
+++ b/src/Containers/Post/Post.jsx
@@ -19,9 +19,7 @@ class Post extends Component {
   }
 
   getPost(id) {
-    const query = id;
-    const api = this.props.api;
-    this.props.fetchData(`${api}/orgpost/${query}/`);
+    this.props.fetchData(id);
   }
 
   render() {
@@ -35,7 +33,6 @@ class Post extends Component {
 }
 
 Post.propTypes = {
-  api: PropTypes.string.isRequired,
   onNavigateTo: PropTypes.func.isRequired,
   match: PropTypes.shape({
     params: PropTypes.shape({

--- a/src/Containers/Post/Post.test.jsx
+++ b/src/Containers/Post/Post.test.jsx
@@ -10,18 +10,16 @@ const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
 
 describe('Main', () => {
-  const api = 'http://localhost:8000/api/v1';
-
   it('is defined', () => {
     const post = TestUtils.renderIntoDocument(<Provider store={mockStore({})}><MemoryRouter>
-      <Post isAuthorized={() => true} api={api} onNavigateTo={() => {}} />
+      <Post isAuthorized={() => true} onNavigateTo={() => {}} />
     </MemoryRouter></Provider>);
     expect(post).toBeDefined();
   });
 
   it('can handle authentication redirects', () => {
     const post = TestUtils.renderIntoDocument(<Provider store={mockStore({})}><MemoryRouter>
-      <Post isAuthorized={() => false} api={api} onNavigateTo={() => {}} />
+      <Post isAuthorized={() => false} onNavigateTo={() => {}} />
     </MemoryRouter></Provider>);
     expect(post).toBeDefined();
   });

--- a/src/Containers/Results/Results.jsx
+++ b/src/Containers/Results/Results.jsx
@@ -48,7 +48,7 @@ class Results extends Component {
         parsedQuery, // this order dictates that query params take precedence over default values
       );
       const newQueryString = queryString.stringify(newQuery);
-      this.callFetchData(`position/?${newQueryString}`);
+      this.callFetchData(newQueryString);
     }
   }
 
@@ -68,8 +68,7 @@ class Results extends Component {
   }
 
   callFetchData(q) {
-    const api = this.props.api;
-    this.props.fetchData(`${api}/${q}`);
+    this.props.fetchData(q);
   }
 
   render() {
@@ -93,7 +92,6 @@ class Results extends Component {
 }
 
 Results.propTypes = {
-  api: PropTypes.string.isRequired,
   onNavigateTo: PropTypes.func.isRequired,
   fetchData: PropTypes.func.isRequired,
   hasErrored: PropTypes.bool.isRequired,

--- a/src/Containers/Results/Results.test.jsx
+++ b/src/Containers/Results/Results.test.jsx
@@ -12,18 +12,16 @@ const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
 
 describe('Main', () => {
-  const api = 'http://localhost:8000/api/v1';
-
   it('is defined', () => {
     const results = TestUtils.renderIntoDocument(<Provider store={mockStore({})}><MemoryRouter>
-      <Results isAuthorized={() => true} api={api} onNavigateTo={() => {}} />
+      <Results isAuthorized={() => true} onNavigateTo={() => {}} />
     </MemoryRouter></Provider>);
     expect(results).toBeDefined();
   });
 
   it('can handle authentication redirects', () => {
     const results = TestUtils.renderIntoDocument(<Provider store={mockStore({})}><MemoryRouter>
-      <Results isAuthorized={() => false} api={api} onNavigateTo={() => {}} />
+      <Results isAuthorized={() => false} onNavigateTo={() => {}} />
     </MemoryRouter></Provider>);
     expect(results).toBeDefined();
   });
@@ -33,7 +31,6 @@ describe('Main', () => {
       <Results.WrappedComponent
         isAuthorized={() => true}
         fetchData={() => {}}
-        api={api}
         onNavigateTo={() => {}}
       />,
     );
@@ -48,7 +45,6 @@ describe('Main', () => {
       <Results.WrappedComponent
         isAuthorized={() => true}
         fetchData={() => {}}
-        api={api}
         onNavigateTo={() => {}}
       />,
     );

--- a/src/Containers/Routes/Routes.test.jsx
+++ b/src/Containers/Routes/Routes.test.jsx
@@ -10,44 +10,43 @@ const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
 
 describe('Routes', () => {
-  const api = 'http://localhost:8000/api/v1';
   it('handles a home route', () => {
     const routes = TestUtils.renderIntoDocument(<Provider store={mockStore({})}><MemoryRouter>
-      <Routes api={api} isAuthorized={() => true} />
+      <Routes isAuthorized={() => true} />
     </MemoryRouter></Provider>);
     expect(routes).toBeDefined();
   });
   it('handles a login route', () => {
     const routes = TestUtils.renderIntoDocument(<Provider store={mockStore({})}><MemoryRouter>
-      <Routes api={api} isAuthorized={() => false} />
+      <Routes isAuthorized={() => false} />
     </MemoryRouter></Provider>);
     expect(routes).toBeDefined();
   });
   it('handles a search results route', () => {
     const routes = TestUtils.renderIntoDocument(<Provider store={mockStore({})}>
       <MemoryRouter initialEntries={['/results']}>
-        <Routes api={api} isAuthorized={() => true} />
+        <Routes isAuthorized={() => true} />
       </MemoryRouter></Provider>);
     expect(routes).toBeDefined();
   });
   it('handles a position details route', () => {
     const routes = TestUtils.renderIntoDocument(<Provider store={mockStore({})}>
       <MemoryRouter initialEntries={['/details/00011111']}>
-        <Routes api={api} isAuthorized={() => true} />
+        <Routes isAuthorized={() => true} />
       </MemoryRouter></Provider>);
     expect(routes).toBeDefined();
   });
   it('handles a post details route', () => {
     const routes = TestUtils.renderIntoDocument(<Provider store={mockStore({})}>
       <MemoryRouter initialEntries={['/post/00011111']}>
-        <Routes api={api} isAuthorized={() => true} />
+        <Routes isAuthorized={() => true} />
       </MemoryRouter></Provider>);
     expect(routes).toBeDefined();
   });
   it('handles a compare route', () => {
     const routes = TestUtils.renderIntoDocument(<Provider store={mockStore({})}>
       <MemoryRouter initialEntries={['/compare/00011111,00011112']}>
-        <Routes api={api} isAuthorized={() => true} />
+        <Routes isAuthorized={() => true} />
       </MemoryRouter></Provider>);
     expect(routes).toBeDefined();
   });

--- a/src/actions/comparisons.js
+++ b/src/actions/comparisons.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import api from '../api';
 
 export function comparisonsHasErrored(bool) {
   return {
@@ -19,10 +20,10 @@ export function comparisonsFetchDataSuccess(comparisons) {
   };
 }
 
-export function comparisonsFetchData(url) {
+export function comparisonsFetchData(query) {
   return (dispatch) => {
     dispatch(comparisonsIsLoading(true));
-    axios.get(url)
+    axios.get(`${api}/position/?position_number__in=${query}`)
             .then((response) => {
               dispatch(comparisonsIsLoading(false));
               return response.data.results;

--- a/src/actions/comparisons.test.js
+++ b/src/actions/comparisons.test.js
@@ -43,7 +43,7 @@ describe('async actions', () => {
       ],
     };
 
-    mockAdapter.onGet('http://localhost:8000/api/v1/comparisons/').reply(200,
+    mockAdapter.onGet('http://localhost:8000/api/v1/position/?position_number__in=6,60').reply(200,
       comparisons,
     );
   });
@@ -53,7 +53,7 @@ describe('async actions', () => {
 
     const f = () => {
       setTimeout(() => {
-        store.dispatch(actions.comparisonsFetchData('http://localhost:8000/api/v1/comparisons/'));
+        store.dispatch(actions.comparisonsFetchData('6,60'));
         store.dispatch(actions.comparisonsIsLoading());
         done();
       }, 0);

--- a/src/actions/filters.js
+++ b/src/actions/filters.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import api from '../api';
 
 export function filtersHasErrored(bool) {
   return {
@@ -19,7 +20,7 @@ export function filtersFetchDataSuccess(filters) {
   };
 }
 
-export function filtersFetchData(api, items) {
+export function filtersFetchData(items) {
   return (dispatch) => {
     dispatch(filtersIsLoading(true));
 

--- a/src/actions/filters.test.js
+++ b/src/actions/filters.test.js
@@ -49,8 +49,6 @@ const items = [
   },
 ];
 
-const api = 'http://localhost:8000/api/v1';
-
 describe('async actions', () => {
   beforeEach(() => {
     const mockAdapter = new MockAdapter(axios);
@@ -75,7 +73,7 @@ describe('async actions', () => {
 
     const f = () => {
       setTimeout(() => {
-        store.dispatch(actions.filtersFetchData(api, items));
+        store.dispatch(actions.filtersFetchData(items));
         store.dispatch(actions.filtersIsLoading());
         done();
       }, 0);
@@ -90,7 +88,7 @@ describe('async actions', () => {
 
     const f = () => {
       setTimeout(() => {
-        store.dispatch(actions.filtersFetchData(api, invalidItems));
+        store.dispatch(actions.filtersFetchData(invalidItems));
         store.dispatch(actions.filtersIsLoading());
         done();
       }, 0);

--- a/src/actions/positionDetails.js
+++ b/src/actions/positionDetails.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import api from '../api';
 
 export function positionDetailsHasErrored(bool) {
   return {
@@ -19,10 +20,10 @@ export function positionDetailsFetchDataSuccess(positionDetails) {
   };
 }
 
-export function positionDetailsFetchData(url) {
+export function positionDetailsFetchData(query) {
   return (dispatch) => {
     dispatch(positionDetailsIsLoading(true));
-    axios.get(url)
+    axios.get(`${api}/position/?position_number=${query}`)
             .then((response) => {
               dispatch(positionDetailsIsLoading(false));
               return response.data.results;

--- a/src/actions/positionDetails.test.js
+++ b/src/actions/positionDetails.test.js
@@ -35,7 +35,7 @@ describe('async actions', () => {
 
     const f = () => {
       setTimeout(() => {
-        store.dispatch(actions.positionDetailsFetchData('http://localhost:8000/api/v1/position/?position_number=00011111'));
+        store.dispatch(actions.positionDetailsFetchData('00011111'));
         store.dispatch(actions.positionDetailsIsLoading());
         done();
       }, 0);

--- a/src/actions/post.js
+++ b/src/actions/post.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import api from '../api';
 
 export function postHasErrored(bool) {
   return {
@@ -19,10 +20,10 @@ export function postFetchDataSuccess(post) {
   };
 }
 
-export function postFetchData(url) {
+export function postFetchData(query) {
   return (dispatch) => {
     dispatch(postIsLoading(true));
-    axios.get(url)
+    axios.get(`${api}/orgpost/${query}/`)
             .then((response) => {
               dispatch(postIsLoading(false));
               return response.data;

--- a/src/actions/post.test.js
+++ b/src/actions/post.test.js
@@ -25,7 +25,7 @@ describe('async actions', () => {
       languages: [{ id: 1, language: 'French (FR)', written_proficiency: '2', spoken_proficiency: '2', representation: 'French (FR) 2/2' }],
     };
 
-    mockAdapter.onGet('http://localhost:8000/api/v1/orgpost/100').reply(200,
+    mockAdapter.onGet('http://localhost:8000/api/v1/orgpost/100/').reply(200,
       post,
     );
   });
@@ -35,7 +35,7 @@ describe('async actions', () => {
 
     const f = () => {
       setTimeout(() => {
-        store.dispatch(actions.postFetchData('http://localhost:8000/api/v1/orgpost/100'));
+        store.dispatch(actions.postFetchData('100'));
         store.dispatch(actions.postIsLoading());
         done();
       }, 0);

--- a/src/actions/results.js
+++ b/src/actions/results.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import api from '../api';
 
 export function resultsHasErrored(bool) {
   return {
@@ -19,10 +20,10 @@ export function resultsFetchDataSuccess(results) {
   };
 }
 
-export function resultsFetchData(url) {
+export function resultsFetchData(query) {
   return (dispatch) => {
     dispatch(resultsIsLoading(true));
-    axios.get(url)
+    axios.get(`${api}/position/?${query}`)
             .then((response) => {
               dispatch(resultsIsLoading(false));
               return response.data;

--- a/src/actions/results.test.js
+++ b/src/actions/results.test.js
@@ -40,7 +40,7 @@ describe('async actions', () => {
       },
     ];
 
-    mockAdapter.onGet('http://localhost:8000/api/v1/results/').reply(200,
+    mockAdapter.onGet('http://localhost:8000/api/v1/position/?').reply(200,
       results,
     );
   });
@@ -50,7 +50,7 @@ describe('async actions', () => {
 
     const f = () => {
       setTimeout(() => {
-        store.dispatch(actions.resultsFetchData('http://localhost:8000/api/v1/results/'));
+        store.dispatch(actions.resultsFetchData(''));
         store.dispatch(actions.resultsIsLoading());
         done();
       }, 0);

--- a/src/actions/share.js
+++ b/src/actions/share.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { fetchUserToken } from '../utilities';
+import api from '../api';
 
 export function shareHasErrored(bool) {
   return {
@@ -20,12 +21,12 @@ export function shareSuccess(share) {
   };
 }
 
-export function shareSendData(url, data) {
+export function shareSendData(data) {
   return (dispatch) => {
     dispatch(shareIsSending(true));
     dispatch(shareSuccess(false));
     dispatch(shareHasErrored(false));
-    axios.post(url, data, { headers: { Authorization: fetchUserToken() } })
+    axios.post(`${api}/share/`, data, { headers: { Authorization: fetchUserToken() } })
             .then((response) => {
               dispatch(shareIsSending(false));
               dispatch(shareHasErrored(false));

--- a/src/actions/share.test.js
+++ b/src/actions/share.test.js
@@ -10,7 +10,9 @@ const mockStore = configureMockStore(middlewares);
 const testEmail = 'test@email.com';
 
 describe('async actions', () => {
-  beforeEach(() => {
+  it('can submit request to send email', (done) => {
+    const store = mockStore({ share: false });
+
     const mockAdapter = new MockAdapter(axios);
 
     const response = { email: { to: testEmail, subject: '[TalentMAP] Shared position', body: 'Shared' } };
@@ -19,16 +21,8 @@ describe('async actions', () => {
       response,
     );
 
-    mockAdapter.onPost('http://localhost:8000/api/v1/share/failure').reply(404,
-      response,
-    );
-  });
-
-  it('can submit request to send email', (done) => {
-    const store = mockStore({ share: false });
-
     const message = {
-      type: 'position', // TODO - pass in as a prop if we allow sharing of other pages
+      type: 'position',
       mode: 'email',
       id: 1,
       email: testEmail,
@@ -36,7 +30,7 @@ describe('async actions', () => {
 
     const f = () => {
       setTimeout(() => {
-        store.dispatch(actions.shareSendData('http://localhost:8000/api/v1/share/', message));
+        store.dispatch(actions.shareSendData(message));
         store.dispatch(actions.shareIsSending());
         done();
       }, 0);
@@ -47,8 +41,14 @@ describe('async actions', () => {
   it('can handle a failed submission', (done) => {
     const store = mockStore({ share: false });
 
+    const mockAdapter = new MockAdapter(axios);
+
+    mockAdapter.onPost('http://localhost:8000/api/v1/share/').reply(404,
+      {},
+    );
+
     const message = {
-      type: 'position', // TODO - pass in as a prop if we allow sharing of other pages
+      type: 'position',
       mode: 'email',
       id: 1,
       email: testEmail,
@@ -56,7 +56,7 @@ describe('async actions', () => {
 
     const f = () => {
       setTimeout(() => {
-        store.dispatch(actions.shareSendData('http://localhost:8000/api/v1/share/failure', message));
+        store.dispatch(actions.shareSendData(message));
         store.dispatch(actions.shareIsSending());
         done();
       }, 0);

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -2,10 +2,9 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import './sass/styles.scss';
 import App from './Components/App/App';
-import api from './api';
 
 require('../node_modules/uswds/dist/js/uswds.min.js');
 
 ReactDOM.render((
-  <App api={api} />
+  <App />
 ), document.getElementById('root') || document.createElement('div'));


### PR DESCRIPTION
Instead of passing `api` as a prop `App`, and storing endpoints at the component level, actions reference `api` from `api.js` and store endpoints within their functions.