### PR TITLE
Fix Total Results numbering from changes made in #403

### DIFF
--- a/src/Components/TotalResults/TotalResults.jsx
+++ b/src/Components/TotalResults/TotalResults.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const TotalResults = ({ total, pageNumber, pageSize }) => {
-  const beginning = (pageNumber * pageSize) + 1;
-  const through = Math.min((pageSize * (pageNumber + 1)), total);
+  const beginning = ((pageNumber - 1) * pageSize) + 1;
+  const through = Math.min((pageSize * (pageNumber)), total);
   return (
     <span id="total-results">
     Viewing {beginning} - {through} of {total} results

--- a/src/Components/TotalResults/TotalResults.test.jsx
+++ b/src/Components/TotalResults/TotalResults.test.jsx
@@ -7,21 +7,21 @@ describe('TotalResults', () => {
   let wrapper = null;
 
   const total = 103;
-  const pageNumber = 0;
+  const pageNumber = 1;
   const pageSize = 25;
 
   const applyViewText = (beginning, through, totalNum) => `Viewing ${beginning} - ${through} of ${totalNum} results`;
 
   it('can receive props', () => {
     wrapper = shallow(
-      <TotalResults total={total} pageNumber={0} pageSize={0} />,
+      <TotalResults total={total} pageNumber={1} pageSize={0} />,
     );
     expect(wrapper.instance().props.pageSize).toBe(0);
   });
 
   it('matches snapshot', () => {
     wrapper = shallow(
-      <TotalResults total={total} pageNumber={0} pageSize={0} />,
+      <TotalResults total={total} pageNumber={1} pageSize={0} />,
     );
     expect(toJSON(wrapper)).toMatchSnapshot();
   });


### PR DESCRIPTION
PR #403 offset page numbers by one, but the `TotalResults` component was not updated to match. This PR fixes that.