### PR TITLE
Responsive account links

### DIFF
--- a/src/Components/AccountDropdown/AccountDropdown.jsx
+++ b/src/Components/AccountDropdown/AccountDropdown.jsx
@@ -1,10 +1,8 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
-import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import Dropdown, { DropdownTrigger, DropdownContent } from 'react-simple-dropdown';
 import { EMPTY_FUNCTION, USER_PROFILE } from '../../Constants/PropTypes';
-import { logoutRequest } from '../../login/actions';
 
 export class AccountDropdown extends Component {
 
@@ -47,14 +45,7 @@ AccountDropdown.propTypes = {
 
 AccountDropdown.defaultProps = {
   logoutRequest: EMPTY_FUNCTION,
-  userProfile: {
-  },
+  userProfile: {},
 };
 
-const mapStateToProps = state => ({
-  login: state.login,
-});
-
-const connected = connect(mapStateToProps, { logoutRequest })(AccountDropdown);
-
-export default connected;
+export default AccountDropdown;

--- a/src/Components/Header/Header.jsx
+++ b/src/Components/Header/Header.jsx
@@ -31,7 +31,7 @@ export class Header extends Component {
       },
     } = this.props;
 
-    let showLogin = (<Link to="login">Login</Link>);
+    let showLogin = (<Link to="login" id="login-desktop">Login</Link>);
     let signedInAs = null;
     if (this.props.client.token && !requesting) {
       const { userProfile } = this.props;
@@ -94,7 +94,7 @@ export class Header extends Component {
                     <Link to="/">Profile</Link>
                   </li>
                   <li>
-                    <Link to="login" onClick={() => this.logout()}>Logout</Link>
+                    <Link to="login" id="login-mobile" onClick={() => this.logout()}>Logout</Link>
                   </li>
                 </span>
                 <span className="desktop-nav-only">

--- a/src/Components/Header/Header.jsx
+++ b/src/Components/Header/Header.jsx
@@ -69,13 +69,11 @@ export class Header extends Component {
                   </button>
                 </div>
               </form>
-              <ul className="usa-unstyled-list usa-nav-secondary-links">
-                <span className="usa-unstyled-list mobile-nav-only">
-                  <li>
-                    {signedInAs}
-                  </li>
-                  <hr />
-                </span>
+              <ul className="usa-unstyled-list usa-nav-secondary-links mobile-nav">
+                <li className="mobile-nav-only">
+                  {signedInAs}
+                </li>
+                <hr className="mobile-nav-only" />
                 <li className="js-search-button-container">
                   <button className="usa-header-search-button js-search-button">Search</button>
                 </li>

--- a/src/Components/Header/Header.jsx
+++ b/src/Components/Header/Header.jsx
@@ -32,8 +32,13 @@ export class Header extends Component {
     } = this.props;
 
     let showLogin = (<Link to="login">Login</Link>);
+    let signedInAs = null;
     if (this.props.client.token && !requesting) {
+      const { userProfile } = this.props;
       showLogin = (<AccountDropdown userProfile={this.props.userProfile} />);
+      if (userProfile.user && userProfile.user.username) {
+        signedInAs = `Signed in as ${userProfile.user.username}`;
+      }
     }
 
     return (
@@ -65,6 +70,12 @@ export class Header extends Component {
                 </div>
               </form>
               <ul className="usa-unstyled-list usa-nav-secondary-links">
+                <span className="usa-unstyled-list mobile-nav-only">
+                  <li>
+                    {signedInAs}
+                  </li>
+                  <hr />
+                </span>
                 <li className="js-search-button-container">
                   <button className="usa-header-search-button js-search-button">Search</button>
                 </li>
@@ -77,9 +88,20 @@ export class Header extends Component {
                 <li>
                   <a href="https://github.com/18F/State-TalentMAP/issues">Feedback</a>
                 </li>
-                <li>
-                  {showLogin}
-                </li>
+                <span className="usa-unstyled-list mobile-nav-only">
+                  <hr />
+                  <li>
+                    <Link to="/">Profile</Link>
+                  </li>
+                  <li>
+                    <Link to="login" onClick={() => this.logout()}>Logout</Link>
+                  </li>
+                </span>
+                <span className="desktop-nav-only">
+                  <li>
+                    {showLogin}
+                  </li>
+                </span>
               </ul>
             </div>
           </div>

--- a/src/Components/Header/Header.test.jsx
+++ b/src/Components/Header/Header.test.jsx
@@ -29,7 +29,7 @@ describe('Header', () => {
 
   it('matches snapshot when logged in', () => {
     const header = shallow(
-      <Header client={client} login={loginObject} fetchData={() => {}} isAuthorized={() => true} />,
+      <Header client={client} login={loginObject} userProfile={{ user: { username: 'test' } }} fetchData={() => {}} isAuthorized={() => true} />,
     );
     expect(toJSON(header)).toMatchSnapshot();
   });
@@ -57,6 +57,6 @@ describe('Header', () => {
         />
       </MemoryRouter></Provider>,
     );
-    expect(header.find('[href="login"]').text()).toBe('Login');
+    expect(header.find('#login-desktop').text()).toBe('Login');
   });
 });

--- a/src/Components/Header/__snapshots__/Header.test.jsx.snap
+++ b/src/Components/Header/__snapshots__/Header.test.jsx.snap
@@ -78,6 +78,14 @@ exports[`Header matches snapshot when logged in 1`] = `
         <ul
           className="usa-unstyled-list usa-nav-secondary-links"
         >
+          <span
+            className="usa-unstyled-list mobile-nav-only"
+          >
+            <li>
+              Signed in as test
+            </li>
+            <hr />
+          </span>
           <li
             className="js-search-button-container"
           >
@@ -109,11 +117,45 @@ exports[`Header matches snapshot when logged in 1`] = `
               Feedback
             </a>
           </li>
-          <li>
-            <Connect(AccountDropdown)
-              userProfile={Object {}}
-            />
-          </li>
+          <span
+            className="usa-unstyled-list mobile-nav-only"
+          >
+            <hr />
+            <li>
+              <Link
+                replace={false}
+                to="/"
+              >
+                Profile
+              </Link>
+            </li>
+            <li>
+              <Link
+                id="login-mobile"
+                onClick={[Function]}
+                replace={false}
+                to="login"
+              >
+                Logout
+              </Link>
+            </li>
+          </span>
+          <span
+            className="desktop-nav-only"
+          >
+            <li>
+              <AccountDropdown
+                logoutRequest={[Function]}
+                userProfile={
+                  Object {
+                    "user": Object {
+                      "username": "test",
+                    },
+                  }
+                }
+              />
+            </li>
+          </span>
         </ul>
       </div>
     </div>
@@ -202,6 +244,12 @@ exports[`Header matches snapshot when logged out 1`] = `
         <ul
           className="usa-unstyled-list usa-nav-secondary-links"
         >
+          <span
+            className="usa-unstyled-list mobile-nav-only"
+          >
+            <li />
+            <hr />
+          </span>
           <li
             className="js-search-button-container"
           >
@@ -233,14 +281,42 @@ exports[`Header matches snapshot when logged out 1`] = `
               Feedback
             </a>
           </li>
-          <li>
-            <Link
-              replace={false}
-              to="login"
-            >
-              Login
-            </Link>
-          </li>
+          <span
+            className="usa-unstyled-list mobile-nav-only"
+          >
+            <hr />
+            <li>
+              <Link
+                replace={false}
+                to="/"
+              >
+                Profile
+              </Link>
+            </li>
+            <li>
+              <Link
+                id="login-mobile"
+                onClick={[Function]}
+                replace={false}
+                to="login"
+              >
+                Logout
+              </Link>
+            </li>
+          </span>
+          <span
+            className="desktop-nav-only"
+          >
+            <li>
+              <Link
+                id="login-desktop"
+                replace={false}
+                to="login"
+              >
+                Login
+              </Link>
+            </li>
+          </span>
         </ul>
       </div>
     </div>

--- a/src/Components/Header/__snapshots__/Header.test.jsx.snap
+++ b/src/Components/Header/__snapshots__/Header.test.jsx.snap
@@ -76,16 +76,16 @@ exports[`Header matches snapshot when logged in 1`] = `
           </div>
         </form>
         <ul
-          className="usa-unstyled-list usa-nav-secondary-links"
+          className="usa-unstyled-list usa-nav-secondary-links mobile-nav"
         >
-          <span
-            className="usa-unstyled-list mobile-nav-only"
+          <li
+            className="mobile-nav-only"
           >
-            <li>
-              Signed in as test
-            </li>
-            <hr />
-          </span>
+            Signed in as test
+          </li>
+          <hr
+            className="mobile-nav-only"
+          />
           <li
             className="js-search-button-container"
           >
@@ -242,14 +242,14 @@ exports[`Header matches snapshot when logged out 1`] = `
           </div>
         </form>
         <ul
-          className="usa-unstyled-list usa-nav-secondary-links"
+          className="usa-unstyled-list usa-nav-secondary-links mobile-nav"
         >
-          <span
-            className="usa-unstyled-list mobile-nav-only"
-          >
-            <li />
-            <hr />
-          </span>
+          <li
+            className="mobile-nav-only"
+          />
+          <hr
+            className="mobile-nav-only"
+          />
           <li
             className="js-search-button-container"
           >

--- a/src/sass/_responsive.scss
+++ b/src/sass/_responsive.scss
@@ -1,0 +1,11 @@
+.mobile-nav-only {
+  @media screen and (min-width: 951px) {
+    display: none;
+  }
+}
+
+.desktop-nav-only {
+  @media screen and (max-width: 950px) {
+    display: none;
+  }
+}

--- a/src/sass/_responsive.scss
+++ b/src/sass/_responsive.scss
@@ -1,6 +1,8 @@
-.mobile-nav-only {
-  @media screen and (min-width: 951px) {
-    display: none;
+.mobile-nav {
+  .mobile-nav-only {
+    @media screen and (min-width: 951px) {
+      display: none;
+    }
   }
 }
 

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -15,3 +15,4 @@
 @import 'header';
 @import 'accountdropdown';
 @import 'pagination';
+@import 'responsive';


### PR DESCRIPTION
Makes the `AccountDropdown` only visible if the mobile nav is not enabled. Once the width is small enough for the mobile nav to appear, the `AccountDropdown` is not visible, and its links are included in the mobile nav menu.