### PR TITLE
Results search bar container

### DIFF
--- a/src/Components/ResultsPage/ResultsPage.jsx
+++ b/src/Components/ResultsPage/ResultsPage.jsx
@@ -5,6 +5,7 @@ import ViewComparisonLink from '../ViewComparisonLink/ViewComparisonLink';
 import ResetComparisons from '../ResetComparisons/ResetComparisons';
 import ResetFiltersConnect from '../ResetFilters/ResetFiltersConnect';
 import ResultsContainer from '../ResultsContainer/ResultsContainer';
+import SearchBar from '../SearchBar/SearchBar';
 
 class Results extends Component {
   constructor(props) {
@@ -28,6 +29,28 @@ class Results extends Component {
     const pageCount = Math.ceil(results.count / defaultPageSize);
     return (
       <div className="results">
+        <div style={{ backgroundColor: 'rgb(242, 242, 242)', height: 'auto' }}>
+          <div className="usa-grid-full results-search-bar-container">
+            <div className="usa-width-one-half search-keyword" style={{ float: 'left', padding: '15px' }}>
+              <SearchBar
+                id="search-field"
+                label="Keywords"
+                type="medium"
+                submitText="Search"
+                labelSrOnly={false}
+              />
+            </div>
+            <div className="usa-width-one-half search-location" style={{ float: 'left', padding: '15px' }}>
+              <SearchBar
+                id="search-field"
+                label="Location"
+                type="medium"
+                submitText="Search"
+                labelSrOnly={false}
+              />
+            </div>
+          </div>
+        </div>
         <div className="usa-grid-full top-nav">
           <div className="usa-width-one-third compare-link">
             <ViewComparisonLink onToggle={() => this.onChildToggle()} />

--- a/src/Components/ResultsPage/ResultsPage.jsx
+++ b/src/Components/ResultsPage/ResultsPage.jsx
@@ -5,7 +5,7 @@ import ViewComparisonLink from '../ViewComparisonLink/ViewComparisonLink';
 import ResetComparisons from '../ResetComparisons/ResetComparisons';
 import ResetFiltersConnect from '../ResetFilters/ResetFiltersConnect';
 import ResultsContainer from '../ResultsContainer/ResultsContainer';
-import SearchBar from '../SearchBar/SearchBar';
+import ResultsSearchHeader from '../ResultsSearchHeader/ResultsSearchHeader';
 
 class Results extends Component {
   constructor(props) {
@@ -22,35 +22,18 @@ class Results extends Component {
   }
 
   render() {
-    const { results, isLoading, hasErrored, sortBy,
+    const { results, isLoading, hasErrored, sortBy, defaultKeyword, defaultLocation,
             defaultSort, pageSizes, defaultPageSize, defaultPageNumber, onQueryParamUpdate }
       = this.props;
     const hasLoaded = !isLoading && results.results && !!results.results.length;
     const pageCount = Math.ceil(results.count / defaultPageSize);
     return (
       <div className="results">
-        <div style={{ backgroundColor: 'rgb(242, 242, 242)', height: 'auto' }}>
-          <div className="usa-grid-full results-search-bar-container">
-            <div className="usa-width-one-half search-keyword" style={{ float: 'left', padding: '15px' }}>
-              <SearchBar
-                id="search-field"
-                label="Keywords"
-                type="medium"
-                submitText="Search"
-                labelSrOnly={false}
-              />
-            </div>
-            <div className="usa-width-one-half search-location" style={{ float: 'left', padding: '15px' }}>
-              <SearchBar
-                id="search-field"
-                label="Location"
-                type="medium"
-                submitText="Search"
-                labelSrOnly={false}
-              />
-            </div>
-          </div>
-        </div>
+        <ResultsSearchHeader
+          queryParamUpdate={e => onQueryParamUpdate(e)}
+          defaultKeyword={defaultKeyword}
+          defaultLocation={defaultLocation}
+        />
         <div className="usa-grid-full top-nav">
           <div className="usa-width-one-third compare-link">
             <ViewComparisonLink onToggle={() => this.onChildToggle()} />
@@ -95,6 +78,8 @@ Results.propTypes = {
   pageSizes: SORT_BY_PARENT_OBJECT.isRequired,
   defaultPageSize: PropTypes.node,
   defaultPageNumber: PropTypes.number,
+  defaultKeyword: PropTypes.string,
+  defaultLocation: PropTypes.string,
 };
 
 Results.defaultProps = {
@@ -105,6 +90,8 @@ Results.defaultProps = {
   defaultSort: '',
   defaultPageSize: 10,
   defaultPageNumber: 0,
+  defaultKeyword: '',
+  defaultLocation: '',
 };
 
 Results.contextTypes = {

--- a/src/Components/ResultsSearchHeader/ResultsSearchHeader.jsx
+++ b/src/Components/ResultsSearchHeader/ResultsSearchHeader.jsx
@@ -1,0 +1,81 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import FontAwesome from 'react-fontawesome';
+import SearchBar from '../SearchBar/SearchBar';
+
+class ResultsSearchHeader extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      q: { value: this.props.defaultKeyword || '' },
+      location: { value: this.props.defaultLocation || '' },
+    };
+  }
+  changeText(type, e) {
+    this.setState({ [type]: { value: e.target.value } });
+  }
+  submitSearch(e) {
+    // resolves “Form submission canceled because the form is not connected” warning
+    e.preventDefault();
+    const { q, location } = this.state;
+    // send any updates to q and location back to the Results container, and reset our page number
+    this.props.queryParamUpdate({ q: q.value, location: location.value, page: 1 });
+  }
+  render() {
+    return (
+      <div className="results-search-bar">
+        <div className="usa-grid-full results-search-bar-container">
+          <form onSubmit={e => this.submitSearch(e)} >
+            <fieldset className="usa-width-five-sixths">
+              <legend className="usa-sr-only">Search keyword and location</legend>
+              <div className="usa-width-one-half search-results-inputs search-keyword" style={{ float: 'left', padding: '15px' }}>
+                <SearchBar
+                  id="search-keyword-field"
+                  label={<div><FontAwesome name="search" style={{ marginRight: '10px' }} />Keywords</div>}
+                  type="medium"
+                  submitText="Search"
+                  labelSrOnly={false}
+                  noForm
+                  noButton
+                  placeholder="Skill code, Grade Code, Language, Post Name"
+                  onChangeText={(e) => { this.changeText('q', e); }}
+                  defaultValue={this.props.defaultKeyword}
+                />
+              </div>
+              <div className="usa-width-one-half search-results-inputs search-location" style={{ float: 'left', padding: '15px' }}>
+                <SearchBar
+                  id="search-location-field"
+                  label={<div><FontAwesome name="map-marker" style={{ marginRight: '10px' }} />Location</div>}
+                  type="medium"
+                  submitText="Search"
+                  labelSrOnly={false}
+                  noForm
+                  noButton
+                  placeholder="City, State, or Country"
+                  onChangeText={(e) => { this.changeText('location', e); }}
+                  defaultValue={this.props.defaultLocation}
+                />
+              </div>
+            </fieldset>
+            <div className="usa-width-one-sixth search-submit-button">
+              <button className="usa-button" type="submit">Search</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    );
+  }
+}
+
+ResultsSearchHeader.propTypes = {
+  queryParamUpdate: PropTypes.func.isRequired,
+  defaultKeyword: PropTypes.string,
+  defaultLocation: PropTypes.string,
+};
+
+ResultsSearchHeader.defaultProps = {
+  defaultKeyword: '',
+  defaultLocation: '',
+};
+
+export default ResultsSearchHeader;

--- a/src/Components/ResultsSearchHeader/ResultsSearchHeader.test.jsx
+++ b/src/Components/ResultsSearchHeader/ResultsSearchHeader.test.jsx
@@ -1,0 +1,80 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import sinon from 'sinon';
+import toJSON from 'enzyme-to-json';
+import ResultsSearchHeader from './ResultsSearchHeader';
+
+describe('ResultsSearchHeaderComponent', () => {
+  let wrapper = null;
+
+  const defaultKeyword = 'keyword';
+  const defaultLocation = 'a location';
+
+  it('is defined', () => {
+    wrapper = shallow(<ResultsSearchHeader
+      queryParamUpdate={() => {}}
+    />);
+    expect(wrapper).toBeDefined();
+  });
+
+  it('can receive props', () => {
+    wrapper = shallow(<ResultsSearchHeader
+      queryParamUpdate={() => {}}
+      defaultKeyword={defaultKeyword}
+      defaultLocation={defaultLocation}
+    />);
+    expect(wrapper.instance().props.defaultKeyword).toBe(defaultKeyword);
+  });
+
+  it('can call the queryParamUpdate function', () => {
+    const spy = sinon.spy();
+    wrapper = shallow(<ResultsSearchHeader
+      queryParamUpdate={spy}
+      defaultKeyword={defaultKeyword}
+      defaultLocation={defaultLocation}
+    />);
+    wrapper.instance().props.queryParamUpdate();
+    expect(spy.calledOnce).toBe(true);
+  });
+
+  it('can call the changeText function', () => {
+    wrapper = shallow(<ResultsSearchHeader
+      queryParamUpdate={() => {}}
+      defaultKeyword={defaultKeyword}
+      defaultLocation={defaultLocation}
+    />);
+    wrapper.instance().changeText('q', { target: { value: defaultKeyword } });
+    expect(wrapper.instance().state.q.value).toBe(defaultKeyword);
+  });
+
+  it('can submit a search', () => {
+    const spy = sinon.spy();
+    wrapper = shallow(<ResultsSearchHeader
+      queryParamUpdate={spy}
+      defaultKeyword={defaultKeyword}
+      defaultLocation={defaultLocation}
+    />);
+    wrapper.find('form').simulate('submit', { preventDefault: () => {} });
+    expect(spy.calledOnce).toBe(true);
+  });
+
+  it('can call the submitSearch function', () => {
+    const spy = sinon.spy();
+    wrapper = shallow(<ResultsSearchHeader
+      queryParamUpdate={spy}
+      defaultKeyword={defaultKeyword}
+      defaultLocation={defaultLocation}
+    />);
+    wrapper.instance().submitSearch({ preventDefault: () => {} });
+    expect(spy.calledOnce).toBe(true);
+  });
+
+  it('matches snapshot', () => {
+    wrapper = shallow(<ResultsSearchHeader
+      queryParamUpdate={() => {}}
+      defaultKeyword={defaultKeyword}
+      defaultLocation={defaultLocation}
+    />);
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/Components/ResultsSearchHeader/__snapshots__/ResultsSearchHeader.test.jsx.snap
+++ b/src/Components/ResultsSearchHeader/__snapshots__/ResultsSearchHeader.test.jsx.snap
@@ -1,0 +1,109 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ResultsSearchHeaderComponent matches snapshot 1`] = `
+<div
+  className="results-search-bar"
+>
+  <div
+    className="usa-grid-full results-search-bar-container"
+  >
+    <form
+      onSubmit={[Function]}
+    >
+      <fieldset
+        className="usa-width-five-sixths"
+      >
+        <legend
+          className="usa-sr-only"
+        >
+          Search keyword and location
+        </legend>
+        <div
+          className="usa-width-one-half search-results-inputs search-keyword"
+          style={
+            Object {
+              "float": "left",
+              "padding": "15px",
+            }
+          }
+        >
+          <SearchBar
+            alertText="Disabled"
+            defaultValue="keyword"
+            id="search-keyword-field"
+            label={
+              <div>
+                <FontAwesome
+                  name="search"
+                  style={
+                    Object {
+                      "marginRight": "10px",
+                    }
+                  }
+                />
+                Keywords
+              </div>
+            }
+            labelSrOnly={false}
+            noButton={true}
+            noForm={true}
+            onChangeText={[Function]}
+            onSubmitSearch={[Function]}
+            placeholder="Skill code, Grade Code, Language, Post Name"
+            submitDisabled={false}
+            submitText="Search"
+            type="medium"
+          />
+        </div>
+        <div
+          className="usa-width-one-half search-results-inputs search-location"
+          style={
+            Object {
+              "float": "left",
+              "padding": "15px",
+            }
+          }
+        >
+          <SearchBar
+            alertText="Disabled"
+            defaultValue="a location"
+            id="search-location-field"
+            label={
+              <div>
+                <FontAwesome
+                  name="map-marker"
+                  style={
+                    Object {
+                      "marginRight": "10px",
+                    }
+                  }
+                />
+                Location
+              </div>
+            }
+            labelSrOnly={false}
+            noButton={true}
+            noForm={true}
+            onChangeText={[Function]}
+            onSubmitSearch={[Function]}
+            placeholder="City, State, or Country"
+            submitDisabled={false}
+            submitText="Search"
+            type="medium"
+          />
+        </div>
+      </fieldset>
+      <div
+        className="usa-width-one-sixth search-submit-button"
+      >
+        <button
+          className="usa-button"
+          type="submit"
+        >
+          Search
+        </button>
+      </div>
+    </form>
+  </div>
+</div>
+`;

--- a/src/Components/SearchBar/SearchBar.jsx
+++ b/src/Components/SearchBar/SearchBar.jsx
@@ -1,11 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { EMPTY_FUNCTION } from '../../Constants/PropTypes';
 
 class SearchBar extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      searchText: { value: '' },
+      searchText: { value: this.props.defaultValue || '' },
     };
   }
   changeText(e) {
@@ -17,49 +18,67 @@ class SearchBar extends Component {
     const hidden = {
       display: 'none',
     };
-    const { id, type, submitDisabled, submitText, alertText, onSubmitSearch, label, labelSrOnly }
+    const { id, type, submitDisabled, submitText, placeholder,
+      alertText, onSubmitSearch, label, labelSrOnly, noForm, noButton }
       = this.props;
     const { searchText } = this.state;
     let showSubmitText = true; // do not hide submit text initially
     if (type === 'small') { showSubmitText = false; } // small search class should not have text
+    const child = (
+      <div className="label-input-wrapper">
+        <label className={labelSrOnly ? 'usa-sr-only' : null} htmlFor={id}>
+          {label}
+        </label>
+        <input
+          id={id}
+          value={searchText.value}
+          onChange={e => this.changeText(e)}
+          type="search"
+          name="search"
+          placeholder={placeholder}
+        />
+        <div id="enabled-search">
+          { !noButton &&
+          <button
+            id="enabled-search-button"
+            className={submitDisabled ? 'usa-button-disabled' : null}
+            disabled={submitDisabled}
+            type="submit"
+          >
+            <span className="usa-search-submit-text">{showSubmitText ? submitText : null}</span>
+          </button>
+          }
+        </div>
+        <div id="disabled-search" style={hidden}>
+          {
+            !noButton &&
+            <button
+              className="usa-button-disabled"
+              disabled="true"
+              type="submit"
+              id="disabled-search-button"
+            >
+              <span className="usa-search-submit-text usa-button-disabled">
+                {showSubmitText ? submitText : null}
+              </span>
+            </button>
+          }
+          <span className="alert-text">{alertText}</span>
+        </div>
+      </div>
+    );
     return (
       <div className={`usa-search usa-search-${type}`}>
         <div role="search">
-          <form onSubmit={e => onSubmitSearch(e)}>
-            <label className={labelSrOnly ? 'usa-sr-only' : null} htmlFor={id}>
-              {label}
-            </label>
-            <input
-              id={id}
-              value={searchText.value}
-              onChange={e => this.changeText(e)}
-              type="search"
-              name="search"
-            />
-            <div id="enabled-search">
-              <button
-                id="enabled-search-button"
-                className={submitDisabled ? 'usa-button-disabled' : null}
-                disabled={submitDisabled}
-                type="submit"
-              >
-                <span className="usa-search-submit-text">{showSubmitText ? submitText : null}</span>
-              </button>
-            </div>
-            <div id="disabled-search" style={hidden}>
-              <button
-                className="usa-button-disabled"
-                disabled="true"
-                type="submit"
-                id="disabled-search-button"
-              >
-                <span className="usa-search-submit-text usa-button-disabled">
-                  {showSubmitText ? submitText : null}
-                </span>
-              </button>
-              <span className="alert-text">{alertText}</span>
-            </div>
-          </form>
+          { !noForm &&
+            <form onSubmit={e => onSubmitSearch(e)}>
+              {child}
+            </form>
+          }
+          {
+            noForm &&
+            child
+          }
         </div>
       </div>
     );
@@ -68,14 +87,18 @@ class SearchBar extends Component {
 
 SearchBar.propTypes = {
   id: PropTypes.string.isRequired,
-  label: PropTypes.string,
+  label: PropTypes.node,
   type: PropTypes.oneOf(['small', 'medium', 'big']),
   submitDisabled: PropTypes.bool,
   submitText: PropTypes.string.isRequired,
   alertText: PropTypes.string,
   onChangeText: PropTypes.func.isRequired,
-  onSubmitSearch: PropTypes.func.isRequired,
+  onSubmitSearch: PropTypes.func,
   labelSrOnly: PropTypes.bool,
+  noForm: PropTypes.bool,
+  noButton: PropTypes.bool,
+  placeholder: PropTypes.string,
+  defaultValue: PropTypes.string,
 };
 
 SearchBar.defaultProps = {
@@ -84,6 +107,11 @@ SearchBar.defaultProps = {
   alertText: 'Disabled',
   label: 'Search', // sr only if flagged
   labelSrOnly: true,
+  noForm: false,
+  noButton: false,
+  placeholder: null,
+  defaultValue: null,
+  onSubmitSearch: EMPTY_FUNCTION,
 };
 
 export default SearchBar;

--- a/src/Components/SearchBar/SearchBar.jsx
+++ b/src/Components/SearchBar/SearchBar.jsx
@@ -14,7 +14,11 @@ class SearchBar extends Component {
     this.setState({ searchText }, this.props.onChangeText(e));
   }
   render() {
-    const { id, type, submitDisabled, submitText, alertText, onSubmitSearch, label } = this.props;
+    const hidden = {
+      display: 'none',
+    };
+    const { id, type, submitDisabled, submitText, alertText, onSubmitSearch, label, labelSrOnly }
+      = this.props;
     const { searchText } = this.state;
     let showSubmitText = true; // do not hide submit text initially
     if (type === 'small') { showSubmitText = false; } // small search class should not have text
@@ -22,7 +26,7 @@ class SearchBar extends Component {
       <div className={`usa-search usa-search-${type}`}>
         <div role="search">
           <form onSubmit={e => onSubmitSearch(e)}>
-            <label className="usa-sr-only" htmlFor={id}>
+            <label className={labelSrOnly ? 'usa-sr-only' : null} htmlFor={id}>
               {label}
             </label>
             <input
@@ -42,7 +46,7 @@ class SearchBar extends Component {
                 <span className="usa-search-submit-text">{showSubmitText ? submitText : null}</span>
               </button>
             </div>
-            <div id="disabled-search" className="hidden">
+            <div id="disabled-search" style={hidden}>
               <button
                 className="usa-button-disabled"
                 disabled="true"
@@ -71,13 +75,15 @@ SearchBar.propTypes = {
   alertText: PropTypes.string,
   onChangeText: PropTypes.func.isRequired,
   onSubmitSearch: PropTypes.func.isRequired,
+  labelSrOnly: PropTypes.bool,
 };
 
 SearchBar.defaultProps = {
   type: 'big', // should be one of the USWDS search types - https://standards.usa.gov/components/search-bar/
   submitDisabled: false,
   alertText: 'Disabled',
-  label: 'Search', // sr only
+  label: 'Search', // sr only if flagged
+  labelSrOnly: true,
 };
 
 export default SearchBar;

--- a/src/Components/SearchBar/__snapshots__/SearchBar.test.jsx.snap
+++ b/src/Components/SearchBar/__snapshots__/SearchBar.test.jsx.snap
@@ -10,56 +10,65 @@ exports[`SearchBarComponent big matches snapshot 1`] = `
     <form
       onSubmit={[Function]}
     >
-      <label
-        className="usa-sr-only"
-        htmlFor="search-2"
-      >
-        Label
-      </label>
-      <input
-        id="search-2"
-        name="search"
-        onChange={[Function]}
-        type="search"
-        value=""
-      />
       <div
-        id="enabled-search"
+        className="label-input-wrapper"
       >
-        <button
-          className={null}
-          disabled={false}
-          id="enabled-search-button"
-          type="submit"
+        <label
+          className="usa-sr-only"
+          htmlFor="search-2"
         >
-          <span
-            className="usa-search-submit-text"
+          Label
+        </label>
+        <input
+          id="search-2"
+          name="search"
+          onChange={[Function]}
+          placeholder={null}
+          type="search"
+          value=""
+        />
+        <div
+          id="enabled-search"
+        >
+          <button
+            className={null}
+            disabled={false}
+            id="enabled-search-button"
+            type="submit"
           >
-            Submit 2
-          </span>
-        </button>
-      </div>
-      <div
-        className="hidden"
-        id="disabled-search"
-      >
-        <button
-          className="usa-button-disabled"
-          disabled="true"
-          id="disabled-search-button"
-          type="submit"
+            <span
+              className="usa-search-submit-text"
+            >
+              Submit 2
+            </span>
+          </button>
+        </div>
+        <div
+          id="disabled-search"
+          style={
+            Object {
+              "display": "none",
+            }
+          }
         >
-          <span
-            className="usa-search-submit-text usa-button-disabled"
+          <button
+            className="usa-button-disabled"
+            disabled="true"
+            id="disabled-search-button"
+            type="submit"
           >
-            Submit 2
+            <span
+              className="usa-search-submit-text usa-button-disabled"
+            >
+              Submit 2
+            </span>
+          </button>
+          <span
+            className="alert-text"
+          >
+            Search is disabled
           </span>
-        </button>
-        <span
-          className="alert-text"
-        >
-          Search is disabled
-        </span>
+        </div>
       </div>
     </form>
   </div>
@@ -76,56 +85,65 @@ exports[`SearchBarComponent medium matches snapshot 1`] = `
     <form
       onSubmit={[Function]}
     >
-      <label
-        className="usa-sr-only"
-        htmlFor="search-2"
-      >
-        Label
-      </label>
-      <input
-        id="search-2"
-        name="search"
-        onChange={[Function]}
-        type="search"
-        value=""
-      />
       <div
-        id="enabled-search"
+        className="label-input-wrapper"
       >
-        <button
-          className={null}
-          disabled={false}
-          id="enabled-search-button"
-          type="submit"
+        <label
+          className="usa-sr-only"
+          htmlFor="search-2"
         >
-          <span
-            className="usa-search-submit-text"
+          Label
+        </label>
+        <input
+          id="search-2"
+          name="search"
+          onChange={[Function]}
+          placeholder={null}
+          type="search"
+          value=""
+        />
+        <div
+          id="enabled-search"
+        >
+          <button
+            className={null}
+            disabled={false}
+            id="enabled-search-button"
+            type="submit"
           >
-            Submit 2
-          </span>
-        </button>
-      </div>
-      <div
-        className="hidden"
-        id="disabled-search"
-      >
-        <button
-          className="usa-button-disabled"
-          disabled="true"
-          id="disabled-search-button"
-          type="submit"
+            <span
+              className="usa-search-submit-text"
+            >
+              Submit 2
+            </span>
+          </button>
+        </div>
+        <div
+          id="disabled-search"
+          style={
+            Object {
+              "display": "none",
+            }
+          }
         >
-          <span
-            className="usa-search-submit-text usa-button-disabled"
+          <button
+            className="usa-button-disabled"
+            disabled="true"
+            id="disabled-search-button"
+            type="submit"
           >
-            Submit 2
+            <span
+              className="usa-search-submit-text usa-button-disabled"
+            >
+              Submit 2
+            </span>
+          </button>
+          <span
+            className="alert-text"
+          >
+            Search is disabled
           </span>
-        </button>
-        <span
-          className="alert-text"
-        >
-          Search is disabled
-        </span>
+        </div>
       </div>
     </form>
   </div>
@@ -142,52 +160,61 @@ exports[`SearchBarComponent small matches snapshot 1`] = `
     <form
       onSubmit={[Function]}
     >
-      <label
-        className="usa-sr-only"
-        htmlFor="search-2"
-      >
-        Label
-      </label>
-      <input
-        id="search-2"
-        name="search"
-        onChange={[Function]}
-        type="search"
-        value=""
-      />
       <div
-        id="enabled-search"
+        className="label-input-wrapper"
       >
-        <button
-          className={null}
-          disabled={false}
-          id="enabled-search-button"
-          type="submit"
+        <label
+          className="usa-sr-only"
+          htmlFor="search-2"
         >
+          Label
+        </label>
+        <input
+          id="search-2"
+          name="search"
+          onChange={[Function]}
+          placeholder={null}
+          type="search"
+          value=""
+        />
+        <div
+          id="enabled-search"
+        >
+          <button
+            className={null}
+            disabled={false}
+            id="enabled-search-button"
+            type="submit"
+          >
+            <span
+              className="usa-search-submit-text"
+            />
+          </button>
+        </div>
+        <div
+          id="disabled-search"
+          style={
+            Object {
+              "display": "none",
+            }
+          }
+        >
+          <button
+            className="usa-button-disabled"
+            disabled="true"
+            id="disabled-search-button"
+            type="submit"
+          >
+            <span
+              className="usa-search-submit-text usa-button-disabled"
+            />
+          </button>
           <span
-            className="usa-search-submit-text"
-          />
-        </button>
-      </div>
-      <div
-        className="hidden"
-        id="disabled-search"
-      >
-        <button
-          className="usa-button-disabled"
-          disabled="true"
-          id="disabled-search-button"
-          type="submit"
-        >
-          <span
-            className="usa-search-submit-text usa-button-disabled"
-          />
-        </button>
-        <span
-          className="alert-text"
-        >
-          Search is disabled
-        </span>
+            className="alert-text"
+          >
+            Search is disabled
+          </span>
+        </div>
       </div>
     </form>
   </div>

--- a/src/Containers/Results/Results.jsx
+++ b/src/Containers/Results/Results.jsx
@@ -18,11 +18,14 @@ class Results extends Component {
       defaultSort: { value: '' },
       defaultPageSize: { value: '' },
       defaultPageNumber: { value: 1 },
+      defaultKeyword: { value: '' },
+      defaultLocation: { value: '' },
     };
   }
 
   componentWillMount() {
-    const { query, defaultSort, defaultPageSize, defaultPageNumber } = this.state;
+    const { query, defaultSort, defaultPageSize, defaultPageNumber, defaultKeyword,
+            defaultLocation } = this.state;
     if (!this.props.isAuthorized()) {
       this.props.onNavigateTo(PUBLIC_ROOT);
     } else {
@@ -37,6 +40,12 @@ class Results extends Component {
       // set our default page number
       defaultPageNumber.value =
         parseInt(parsedQuery.page, 10) || defaultPageNumber.value;
+      // set our default keyword (?q=...)
+      defaultKeyword.value =
+        parsedQuery.q || defaultKeyword.value;
+      // set our default location keyword
+      defaultLocation.value =
+        parsedQuery.location || defaultLocation.value;
       // add our defaultSort and defaultPageSize to the query,
       // but don't add them to history on initial render if
       // they weren't included in the initial query params
@@ -86,6 +95,8 @@ class Results extends Component {
           defaultPageSize={this.state.defaultPageSize.value}
           defaultPageNumber={this.state.defaultPageNumber.value}
           onQueryParamUpdate={q => this.onQueryParamUpdate(q)}
+          defaultKeyword={this.state.defaultKeyword.value}
+          defaultLocation={this.state.defaultLocation.value}
         />
       </div>
     );

--- a/src/sass/_results.scss
+++ b/src/sass/_results.scss
@@ -172,7 +172,7 @@
   float: left;
   height: 600px;
   margin-right: 0;
-  width: 25%;
+  width: 20%;
 
   @media screen and (max-width: 951px) {
     height: 100px;
@@ -184,7 +184,7 @@
 .results-container {
   float: left;
   padding-left: 30px;
-  width: 75%;
+  width: 80%;
 
   @media screen and (max-width: 951px) {
     padding-left: 0;
@@ -214,33 +214,4 @@
 
 .results-section-container {
   max-width: 1140px;
-}
-
-.results-search-bar-container {
-
-  max-width: 1140px;
-
-  padding: 20px 30px;
-
-  .search-keyword {
-    padding: 0 30px;
-
-    button {
-      display: none;
-    }
-
-    input {
-      border-right: solid 1px;
-      width: 400px;
-    }
-  }
-
-  .search-location {
-    padding: 0 30px;
-
-    input {
-      border-right: solid 1px;
-      width: 300px;
-    }
-  }
 }

--- a/src/sass/_results.scss
+++ b/src/sass/_results.scss
@@ -215,3 +215,32 @@
 .results-section-container {
   max-width: 1140px;
 }
+
+.results-search-bar-container {
+
+  max-width: 1140px;
+
+  padding: 20px 30px;
+
+  .search-keyword {
+    padding: 0 30px;
+
+    button {
+      display: none;
+    }
+
+    input {
+      border-right: solid 1px;
+      width: 400px;
+    }
+  }
+
+  .search-location {
+    padding: 0 30px;
+
+    input {
+      border-right: solid 1px;
+      width: 300px;
+    }
+  }
+}

--- a/src/sass/_resultsSearchBarContainer.scss
+++ b/src/sass/_resultsSearchBarContainer.scss
@@ -1,0 +1,69 @@
+.results-search-bar {
+  background-color: $color-gray-lightest;
+  height: auto;
+}
+
+.results-search-bar-container {
+
+  height: auto;
+
+  max-width: 1140px;
+
+  padding: 0 30px 25px;
+
+  .label-input-wrapper {
+    width: 100%;
+  }
+
+  .search-results-inputs {
+    input {
+      border-right: solid 1px;
+      display: inline-block;
+    }
+
+    label {
+      margin: 0 0 5px 5px;
+    }
+  }
+
+  .search-submit-button {
+    margin-top: 37px;
+
+    button {
+      font-size: .9em;
+      padding: 10px 25px;
+    }
+  }
+
+  .search-keyword {
+    padding: 0 30px;
+
+    input {
+      width: 100%;
+    }
+
+    label {
+      display: block;
+      text-align: left;
+    }
+  }
+
+  .search-location {
+    padding: 0 30px;
+
+    form {
+      border-radius: 3px;
+      display: inline-grid;
+      font-size: .9em;
+      margin-left: 30px;
+    }
+
+    input {
+      width: 100%;
+    }
+
+    label {
+      display: inline-block;
+    }
+  }
+}

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -11,6 +11,7 @@
 @import 'details';
 @import 'home';
 @import 'results';
+@import 'resultsSearchBarContainer';
 @import 'footer';
 @import 'header';
 @import 'accountdropdown';


### PR DESCRIPTION
This PR adds a search bar container and search bars to the results page based on wireframes. Accepts default values, passed down from the query params and the `Results` container so that default values can be initialized. Upon changing the text of either search bar and submitting the form, `?q` and `?location` are updated or pushed to history and results are refreshed. Also adds a reusable `SearchBar` component.

Review #439 first.