### PR TITLE
Homepage Redesign - Position Sections

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "redux-saga": "^0.15.4",
     "redux-thunk": "^2.2.0",
     "shortid": "^2.2.8",
+    "typeface-roboto": "0.0.35",
     "typeface-vollkorn": "0.0.35",
     "uswds": "^1.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
   "jest": {
     "collectCoverageFrom": [
       "src/**/*.{js,jsx}",
-      "!src/registerServiceWorker.js"
+      "!src/registerServiceWorker.js",
+      "!src/Components/**/index.js"
     ],
     "coverageReporters": [
       "lcov"

--- a/src/Components/BidListButton/BidListButton.jsx
+++ b/src/Components/BidListButton/BidListButton.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const BidListButton = () => (
+  <button> add to bid list </button>
+);
+
+export default BidListButton;

--- a/src/Components/BidListButton/BidListButton.jsx
+++ b/src/Components/BidListButton/BidListButton.jsx
@@ -1,7 +1,13 @@
 import React from 'react';
+import FontAwesome from 'react-fontawesome';
 
 const BidListButton = () => (
-  <button> add to bid list </button>
+  <button className="bid-list-button">
+    <span className="bid-list-button-icon">
+      <FontAwesome name="plus-circle" />
+    </span>
+    <span>Add to bid list</span>
+  </button>
 );
 
 export default BidListButton;

--- a/src/Components/BidListButton/index.js
+++ b/src/Components/BidListButton/index.js
@@ -1,0 +1,1 @@
+export { default } from './BidListButton';

--- a/src/Components/CondensedCardData/CondensedCardData.jsx
+++ b/src/Components/CondensedCardData/CondensedCardData.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { POSITION_DETAILS } from '../../Constants/PropTypes';
+
+const CondensedCardData = ({ result }) => (
+  <div className="usa-grid-full condensed-card-data">
+    <div>
+      <strong>{result.position || 'Position Name'}</strong>
+    </div>
+    <div>
+      <strong>Location: </strong>
+      { result.post || 'Abuja, Nigeria' /* TODO only use real data */ }
+    </div>
+    <div>
+      <strong>Skill: </strong>
+      { result.skill || 'INFORMATION SECURITY' /* TODO only use real data */ }
+    </div>
+    <div>
+      <strong>Grade: </strong>
+      { result.grade || '05' /* TODO only use real data */ }
+    </div>
+  </div>
+);
+
+CondensedCardData.propTypes = {
+  result: POSITION_DETAILS,
+};
+
+CondensedCardData.defaultProps = {
+  result: {}, // TODO - remove and pass real result as prop
+};
+
+export default CondensedCardData;

--- a/src/Components/CondensedCardData/index.js
+++ b/src/Components/CondensedCardData/index.js
@@ -1,0 +1,1 @@
+export { default } from './CondensedCardData';

--- a/src/Components/Favorite/Favorite.jsx
+++ b/src/Components/Favorite/Favorite.jsx
@@ -43,7 +43,7 @@ class Favorite extends Component {
       // At the time of writing, CodeClimate's version of eslint-a11y-plugin
       // did not take role="button" into account with the following error:
       // eslint-disable-next-line jsx-a11y/no-static-element-interactions
-      <div tabIndex="0" role="button" style={{ cursor: 'pointer' }} onClick={() => this.toggleSaved()}>
+      <div tabIndex="0" title="Add to favorites" role="button" style={{ cursor: 'pointer' }} onClick={() => this.toggleSaved()}>
         <FontAwesome name={iconClass} /> {this.props.hideText ? null : text}
       </div>
     );

--- a/src/Components/Favorite/Favorite.jsx
+++ b/src/Components/Favorite/Favorite.jsx
@@ -44,7 +44,7 @@ class Favorite extends Component {
       // did not take role="button" into account with the following error:
       // eslint-disable-next-line jsx-a11y/no-static-element-interactions
       <div tabIndex="0" role="button" style={{ cursor: 'pointer' }} onClick={() => this.toggleSaved()}>
-        <FontAwesome name={iconClass} /> {text}
+        <FontAwesome name={iconClass} /> {this.props.hideText ? null : text}
       </div>
     );
   }
@@ -53,11 +53,13 @@ class Favorite extends Component {
 Favorite.propTypes = {
   refKey: PropTypes.string.isRequired,
   type: PropTypes.string,
+  hideText: PropTypes.bool,
 };
 
 Favorite.defaultProps = {
   type: 'fav',
   onToggle: EMPTY_FUNCTION,
+  hideText: false,
 };
 
 export default Favorite;

--- a/src/Components/NewPositionsCardList/NewPositionsCardList.jsx
+++ b/src/Components/NewPositionsCardList/NewPositionsCardList.jsx
@@ -3,14 +3,30 @@ import PropTypes from 'prop-types';
 import ResultsCondensedCard from '../ResultsCondensedCard';
 
 const NewPositionsCardList = ({ positions }) => { // eslint-disable-line
-  const positionList = positions.slice().map(p => (
-    <div className="usa-width-one-third">
-      <ResultsCondensedCard result={p} />
-    </div>
-  ));
+
+  const positionList = [];
+
+  positions.slice().forEach((p) => {
+    positionList.push(
+      <div className="usa-width-one-whole condensed-card">
+        <ResultsCondensedCard result={p} />
+      </div>,
+    );
+  });
+
   return (
     <div className="usa-grid-full">
-      {positionList}
+      <div className="usa-width-one-third condensed-card-first-big" style={{ float: 'left' }}>
+        {positionList[0]}
+      </div>
+      <div className="usa-width-one-third condensed-card-second" style={{ float: 'left' }}>
+        {positionList[1]}
+        {positionList[2]}
+      </div>
+      <div className="usa-width-one-third condensed-card-third" style={{ float: 'left' }}>
+        {positionList[3]}
+        {positionList[4]}
+      </div>
     </div>
   );
 };
@@ -20,7 +36,7 @@ NewPositionsCardList.propTypes = {
 };
 
 NewPositionsCardList.defaultProps = {
-  positions: ['a', 'b', 'c'],
+  positions: ['a', 'b', 'c', 'd', 'e'],
 };
 
 export default NewPositionsCardList;

--- a/src/Components/NewPositionsCardList/NewPositionsCardList.jsx
+++ b/src/Components/NewPositionsCardList/NewPositionsCardList.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import ResultsCondensedCard from '../ResultsCondensedCard';
+import { POSITION_DETAILS_ARRAY } from '../../Constants/PropTypes';
 
-const NewPositionsCardList = ({ positions }) => { // eslint-disable-line
-
+const NewPositionsCardList = ({ positions }) => {
   const positionList = [];
 
   positions.slice().forEach((p) => {
@@ -16,14 +15,14 @@ const NewPositionsCardList = ({ positions }) => { // eslint-disable-line
 
   return (
     <div className="usa-grid-full">
-      <div className="usa-width-one-third condensed-card-first-big" style={{ float: 'left' }}>
+      <div className="usa-width-one-third condensed-card-first-big">
         {positionList[0]}
       </div>
-      <div className="usa-width-one-third condensed-card-second" style={{ float: 'left' }}>
+      <div className="usa-width-one-third condensed-card-second">
         {positionList[1]}
         {positionList[2]}
       </div>
-      <div className="usa-width-one-third condensed-card-third" style={{ float: 'left' }}>
+      <div className="usa-width-one-third condensed-card-third">
         {positionList[3]}
         {positionList[4]}
       </div>
@@ -32,11 +31,11 @@ const NewPositionsCardList = ({ positions }) => { // eslint-disable-line
 };
 
 NewPositionsCardList.propTypes = {
-  positions: PropTypes.arrayOf() // eslint-disable-line
+  positions: POSITION_DETAILS_ARRAY,
 };
 
 NewPositionsCardList.defaultProps = {
-  positions: ['a', 'b', 'c', 'd', 'e'],
+  positions: [{}, {}, {}, {}, {}],
 };
 
 export default NewPositionsCardList;

--- a/src/Components/NewPositionsCardList/NewPositionsCardList.jsx
+++ b/src/Components/NewPositionsCardList/NewPositionsCardList.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ResultsCondensedCard from '../ResultsCondensedCard';
+
+const NewPositionsCardList = ({ positions }) => { // eslint-disable-line
+  const positionList = positions.slice().map(p => (
+    <div className="usa-width-one-third">
+      <ResultsCondensedCard result={p} />
+    </div>
+  ));
+  return (
+    <div className="usa-grid-full">
+      {positionList}
+    </div>
+  );
+};
+
+NewPositionsCardList.propTypes = {
+  positions: PropTypes.arrayOf() // eslint-disable-line
+};
+
+NewPositionsCardList.defaultProps = {
+  positions: ['a', 'b', 'c'],
+};
+
+export default NewPositionsCardList;

--- a/src/Components/NewPositionsCardList/index.js
+++ b/src/Components/NewPositionsCardList/index.js
@@ -1,0 +1,1 @@
+export { default } from './NewPositionsCardList';

--- a/src/Components/NewPositionsSection/NewPositionsSection.jsx
+++ b/src/Components/NewPositionsSection/NewPositionsSection.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import PositionsSectionTitle from '../PositionsSectionTitle';
+import NewPositionsCardList from '../NewPositionsCardList';
+
+const NewPositionsSection = () => (
+  <div className="usa-grid-full">
+    <PositionsSectionTitle />
+    <NewPositionsCardList />
+  </div>
+);
+
+export default NewPositionsSection;

--- a/src/Components/NewPositionsSection/NewPositionsSection.jsx
+++ b/src/Components/NewPositionsSection/NewPositionsSection.jsx
@@ -1,10 +1,16 @@
 import React from 'react';
+import FontAwesome from 'react-fontawesome';
 import PositionsSectionTitle from '../PositionsSectionTitle';
 import NewPositionsCardList from '../NewPositionsCardList';
 
 const NewPositionsSection = () => (
-  <div className="usa-grid-full">
-    <PositionsSectionTitle title="New Positions" />
+  <div className="usa-grid-full positions-section positions-section-new">
+    <PositionsSectionTitle
+      title={
+        <span className="positions-section-title"><FontAwesome name="flag" />New Positions</span>
+      }
+      viewMoreLink="/results?ordering=create_date"
+    />
     <NewPositionsCardList />
   </div>
 );

--- a/src/Components/NewPositionsSection/NewPositionsSection.jsx
+++ b/src/Components/NewPositionsSection/NewPositionsSection.jsx
@@ -4,7 +4,7 @@ import NewPositionsCardList from '../NewPositionsCardList';
 
 const NewPositionsSection = () => (
   <div className="usa-grid-full">
-    <PositionsSectionTitle />
+    <PositionsSectionTitle title="New Positions" />
     <NewPositionsCardList />
   </div>
 );

--- a/src/Components/NewPositionsSection/index.js
+++ b/src/Components/NewPositionsSection/index.js
@@ -1,0 +1,1 @@
+export { default } from './NewPositionsSection';

--- a/src/Components/PopularPositionsCardList/PopularPositionsCardList.jsx
+++ b/src/Components/PopularPositionsCardList/PopularPositionsCardList.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import ResultsCondensedCard from '../ResultsCondensedCard';
+
+const PopularPositionsCardList = ({ positions }) => { // eslint-disable-line
+  const positionList = positions.slice().map(p => (
+    <div className="usa-grid-one-third">
+      <ResultsCondensedCard result={p} />
+    </div>
+  ));
+  return (
+    <div className="usa-grid-full">
+      {positionList}
+    </div>
+  );
+};
+
+export default PopularPositionsCardList;

--- a/src/Components/PopularPositionsCardList/PopularPositionsCardList.jsx
+++ b/src/Components/PopularPositionsCardList/PopularPositionsCardList.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import ResultsCondensedCard from '../ResultsCondensedCard';
+import { POSITION_DETAILS_ARRAY } from '../../Constants/PropTypes';
 
-const PopularPositionsCardList = ({ positions }) => { // eslint-disable-line
+const shortid = require('shortid');
+
+const PopularPositionsCardList = ({ positions }) => {
   const positionList = positions.slice().map(p => (
-    <div className="usa-width-one-third condensed-card">
+    <div key={shortid.generate()} className="usa-width-one-third condensed-card">
       <ResultsCondensedCard type="popular" result={p} />
     </div>
   ));
@@ -16,11 +18,12 @@ const PopularPositionsCardList = ({ positions }) => { // eslint-disable-line
 };
 
 PopularPositionsCardList.propTypes = {
-  positions: PropTypes.arrayOf() // eslint-disable-line
+   // TODO next round - add prop types
+  positions: POSITION_DETAILS_ARRAY,
 };
 
 PopularPositionsCardList.defaultProps = {
-  positions: ['a', 'b', 'c'],
+  positions: [{}, {}, {}], // TODO remove and only use real data
 };
 
 export default PopularPositionsCardList;

--- a/src/Components/PopularPositionsCardList/PopularPositionsCardList.jsx
+++ b/src/Components/PopularPositionsCardList/PopularPositionsCardList.jsx
@@ -1,17 +1,26 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import ResultsCondensedCard from '../ResultsCondensedCard';
 
 const PopularPositionsCardList = ({ positions }) => { // eslint-disable-line
   const positionList = positions.slice().map(p => (
-    <div className="usa-grid-one-third">
-      <ResultsCondensedCard result={p} />
+    <div className="usa-width-one-third condensed-card">
+      <ResultsCondensedCard type="popular" result={p} />
     </div>
   ));
   return (
-    <div className="usa-grid-full">
+    <div className="usa-grid-full condensed-card-popular">
       {positionList}
     </div>
   );
+};
+
+PopularPositionsCardList.propTypes = {
+  positions: PropTypes.arrayOf() // eslint-disable-line
+};
+
+PopularPositionsCardList.defaultProps = {
+  positions: ['a', 'b', 'c'],
 };
 
 export default PopularPositionsCardList;

--- a/src/Components/PopularPositionsCardList/index.js
+++ b/src/Components/PopularPositionsCardList/index.js
@@ -1,0 +1,1 @@
+export { default } from './PopularPositionsCardList';

--- a/src/Components/PopularPositionsSection/PopularPositionsSection.jsx
+++ b/src/Components/PopularPositionsSection/PopularPositionsSection.jsx
@@ -1,10 +1,19 @@
 import React from 'react';
+import FontAwesome from 'react-fontawesome';
 import PositionsSectionTitle from '../PositionsSectionTitle';
 import PopularPositionsCardList from '../PopularPositionsCardList';
 
 const PopularPositionsSection = () => (
-  <div className="usa-grid-full">
-    <PositionsSectionTitle title="Popular Positions" />
+  <div className="usa-grid-full positions-section positions-section-popular">
+    <PositionsSectionTitle
+      title={
+        <span className="positions-section-title">
+          <FontAwesome name="gratipay" />
+          Popular Positions
+        </span>
+      }
+      viewMoreLink="/results"
+    />
     <PopularPositionsCardList />
   </div>
 );

--- a/src/Components/PopularPositionsSection/PopularPositionsSection.jsx
+++ b/src/Components/PopularPositionsSection/PopularPositionsSection.jsx
@@ -4,7 +4,7 @@ import PopularPositionsCardList from '../PopularPositionsCardList';
 
 const PopularPositionsSection = () => (
   <div className="usa-grid-full">
-    <PositionsSectionTitle />
+    <PositionsSectionTitle title="Popular Positions" />
     <PopularPositionsCardList />
   </div>
 );

--- a/src/Components/PopularPositionsSection/PopularPositionsSection.jsx
+++ b/src/Components/PopularPositionsSection/PopularPositionsSection.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import PositionsSectionTitle from '../PositionsSectionTitle';
+import PopularPositionsCardList from '../PopularPositionsCardList';
+
+const PopularPositionsSection = () => (
+  <div className="usa-grid-full">
+    <PositionsSectionTitle />
+    <PopularPositionsCardList />
+  </div>
+);
+
+export default PopularPositionsSection;

--- a/src/Components/PopularPositionsSection/index.js
+++ b/src/Components/PopularPositionsSection/index.js
@@ -1,0 +1,1 @@
+export { default } from './PopularPositionsSection';

--- a/src/Components/PositionsSectionContent/PositionsSectionContent.jsx
+++ b/src/Components/PositionsSectionContent/PositionsSectionContent.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import ResultsCondensedCard from '../ResultsCondensedCard';
+
+const PositionsSectionContent = () => (
+  <ResultsCondensedCard />
+);
+
+export default PositionsSectionContent;

--- a/src/Components/PositionsSectionContent/index.js
+++ b/src/Components/PositionsSectionContent/index.js
@@ -1,0 +1,1 @@
+export { default } from './PositionsSectionContent';

--- a/src/Components/PositionsSectionTitle/PositionsSectionTitle.jsx
+++ b/src/Components/PositionsSectionTitle/PositionsSectionTitle.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import PositionsSectionTitleHeader from '../PositionsSectionTitleHeader';
+import PositionsSectionTitleViewMore from '../PositionsSectionTitleViewMore';
+
+const PositionsSectionTitle = () => (
+  <div className="usa-grid-full">
+    <div className="usa-width-one-half" style={{ float: 'left' }}>
+      <PositionsSectionTitleHeader />
+    </div>
+    <div className="usa-width-one-half" style={{ float: 'left', textAlign: 'right' }}>
+      <PositionsSectionTitleViewMore />
+    </div>
+  </div>
+);
+
+export default PositionsSectionTitle;

--- a/src/Components/PositionsSectionTitle/PositionsSectionTitle.jsx
+++ b/src/Components/PositionsSectionTitle/PositionsSectionTitle.jsx
@@ -1,16 +1,25 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import PositionsSectionTitleHeader from '../PositionsSectionTitleHeader';
 import PositionsSectionTitleViewMore from '../PositionsSectionTitleViewMore';
 
-const PositionsSectionTitle = () => (
-  <div className="usa-grid-full">
+const PositionsSectionTitle = ({ title }) => (
+  <div className="usa-grid-full" style={{ borderBottom: 'solid 1px gray', marginBottom: '10px' }}>
     <div className="usa-width-one-half" style={{ float: 'left' }}>
-      <PositionsSectionTitleHeader />
+      <PositionsSectionTitleHeader title={title} />
     </div>
     <div className="usa-width-one-half" style={{ float: 'left', textAlign: 'right' }}>
       <PositionsSectionTitleViewMore />
     </div>
   </div>
 );
+
+PositionsSectionTitle.propTypes = {
+  title: PropTypes.node,
+};
+
+PositionsSectionTitle.defaultProps = {
+  title: '',
+};
 
 export default PositionsSectionTitle;

--- a/src/Components/PositionsSectionTitle/PositionsSectionTitle.jsx
+++ b/src/Components/PositionsSectionTitle/PositionsSectionTitle.jsx
@@ -3,23 +3,20 @@ import PropTypes from 'prop-types';
 import PositionsSectionTitleHeader from '../PositionsSectionTitleHeader';
 import PositionsSectionTitleViewMore from '../PositionsSectionTitleViewMore';
 
-const PositionsSectionTitle = ({ title }) => (
-  <div className="usa-grid-full" style={{ borderBottom: 'solid 1px gray', marginBottom: '10px' }}>
-    <div className="usa-width-one-half" style={{ float: 'left' }}>
+const PositionsSectionTitle = ({ title, viewMoreLink }) => (
+  <div className="usa-grid-full positions-section-container">
+    <div className="usa-width-one-half positions-section-container-left">
       <PositionsSectionTitleHeader title={title} />
     </div>
-    <div className="usa-width-one-half" style={{ float: 'left', textAlign: 'right' }}>
-      <PositionsSectionTitleViewMore />
+    <div className="usa-width-one-half positions-section-container-right">
+      <PositionsSectionTitleViewMore viewMoreLink={viewMoreLink} />
     </div>
   </div>
 );
 
 PositionsSectionTitle.propTypes = {
-  title: PropTypes.node,
-};
-
-PositionsSectionTitle.defaultProps = {
-  title: '',
+  title: PropTypes.node.isRequired,
+  viewMoreLink: PropTypes.string.isRequired,
 };
 
 export default PositionsSectionTitle;

--- a/src/Components/PositionsSectionTitle/index.js
+++ b/src/Components/PositionsSectionTitle/index.js
@@ -1,0 +1,1 @@
+export { default } from './PositionsSectionTitle';

--- a/src/Components/PositionsSectionTitleHeader/PositionsSectionTitleHeader.jsx
+++ b/src/Components/PositionsSectionTitleHeader/PositionsSectionTitleHeader.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 const PositionsSectionTitleHeader = ({ title }) => (
   <div className="condensed-card-title-header">
-    <span style={{ borderBottom: 'solid 1px black' }}>
+    <span>
       {title}
     </span>
   </div>

--- a/src/Components/PositionsSectionTitleHeader/PositionsSectionTitleHeader.jsx
+++ b/src/Components/PositionsSectionTitleHeader/PositionsSectionTitleHeader.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const PositionsSectionTitleHeader = ({ title }) => (
-  <div className="condensed-card-title-header">
+  <div className="positions-section-title-header">
     <span>
       {title}
     </span>

--- a/src/Components/PositionsSectionTitleHeader/PositionsSectionTitleHeader.jsx
+++ b/src/Components/PositionsSectionTitleHeader/PositionsSectionTitleHeader.jsx
@@ -1,9 +1,16 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-const PositionsSectionTitleHeader = () => (
-  <div>
-    Title
+const PositionsSectionTitleHeader = ({ title }) => (
+  <div className="condensed-card-title-header">
+    <span style={{ borderBottom: 'solid 1px black' }}>
+      {title}
+    </span>
   </div>
 );
+
+PositionsSectionTitleHeader.propTypes = {
+  title: PropTypes.node.isRequired,
+};
 
 export default PositionsSectionTitleHeader;

--- a/src/Components/PositionsSectionTitleHeader/PositionsSectionTitleHeader.jsx
+++ b/src/Components/PositionsSectionTitleHeader/PositionsSectionTitleHeader.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const PositionsSectionTitleHeader = () => (
+  <div>
+    Title
+  </div>
+);
+
+export default PositionsSectionTitleHeader;

--- a/src/Components/PositionsSectionTitleHeader/index.js
+++ b/src/Components/PositionsSectionTitleHeader/index.js
@@ -1,0 +1,1 @@
+export { default } from './PositionsSectionTitleHeader';

--- a/src/Components/PositionsSectionTitleViewMore/PositionsSectionTitleViewMore.jsx
+++ b/src/Components/PositionsSectionTitleViewMore/PositionsSectionTitleViewMore.jsx
@@ -1,9 +1,20 @@
 import React from 'react';
+import FontAwesome from 'react-fontawesome';
+import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
 
-const PositionsSectionTitleViewMore = () => (
-  <div>
-    View More
+const PositionsSectionTitleViewMore = ({ viewMoreLink }) => (
+  <div className="positions-section-view-more">
+    <Link to={viewMoreLink}>View More <FontAwesome name="angle-right" /></Link>
   </div>
 );
+
+PositionsSectionTitleViewMore.propTypes = {
+  viewMoreLink: PropTypes.string.isRequired,
+};
+
+PositionsSectionTitleViewMore.defaultProps = {
+  viewMoreLink: '', // we want to require a link, but still need to instantiate a value in order to render
+};
 
 export default PositionsSectionTitleViewMore;

--- a/src/Components/PositionsSectionTitleViewMore/PositionsSectionTitleViewMore.jsx
+++ b/src/Components/PositionsSectionTitleViewMore/PositionsSectionTitleViewMore.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const PositionsSectionTitleViewMore = () => (
+  <div>
+    View More
+  </div>
+);
+
+export default PositionsSectionTitleViewMore;

--- a/src/Components/PositionsSectionTitleViewMore/index.js
+++ b/src/Components/PositionsSectionTitleViewMore/index.js
@@ -1,0 +1,1 @@
+export { default } from './PositionsSectionTitleViewMore';

--- a/src/Components/ResultsCard/__snapshots__/ResultsCard.test.jsx.snap
+++ b/src/Components/ResultsCard/__snapshots__/ResultsCard.test.jsx.snap
@@ -18,6 +18,7 @@ exports[`ResultsCardComponent matches snapshot 1`] = `
       className="results-card-favorite"
     >
       <Favorite
+        hideText={false}
         onToggle={[Function]}
         refKey="00025003"
         type="fav"

--- a/src/Components/ResultsCondensedCard/ResultsCondensedCard.jsx
+++ b/src/Components/ResultsCondensedCard/ResultsCondensedCard.jsx
@@ -1,12 +1,23 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import ResultsCondensedCardTop from '../ResultsCondensedCardTop';
 import ResultsCondensedCardBottom from '../ResultsCondensedCardBottom';
 
-const ResultsCondensedCard = () => (
-  <div className="usa-grid-full" style={{ border: 'solid 1px black' }}>
-    <ResultsCondensedCardTop />
-    <ResultsCondensedCardBottom />
+const ResultsCondensedCard = ({ type }) => (
+  <div className="usa-grid-full" style={{ marginBottom: '15px' }}>
+    <ResultsCondensedCardTop type={type} />
+    <div style={{ padding: '10px' }}>
+      <ResultsCondensedCardBottom />
+    </div>
   </div>
 );
+
+ResultsCondensedCard.propTypes = {
+  type: PropTypes.string,
+};
+
+ResultsCondensedCard.defaultProps = {
+  type: 'new',
+};
 
 export default ResultsCondensedCard;

--- a/src/Components/ResultsCondensedCard/ResultsCondensedCard.jsx
+++ b/src/Components/ResultsCondensedCard/ResultsCondensedCard.jsx
@@ -4,9 +4,9 @@ import ResultsCondensedCardTop from '../ResultsCondensedCardTop';
 import ResultsCondensedCardBottom from '../ResultsCondensedCardBottom';
 
 const ResultsCondensedCard = ({ type }) => (
-  <div className="usa-grid-full" style={{ marginBottom: '15px' }}>
+  <div className="usa-grid-full condensed-card-inner">
     <ResultsCondensedCardTop type={type} />
-    <div style={{ padding: '10px' }}>
+    <div className="condensed-card-bottom-container">
       <ResultsCondensedCardBottom />
     </div>
   </div>

--- a/src/Components/ResultsCondensedCard/ResultsCondensedCard.jsx
+++ b/src/Components/ResultsCondensedCard/ResultsCondensedCard.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import ResultsCondensedCardTop from '../ResultsCondensedCardTop';
+import ResultsCondensedCardBottom from '../ResultsCondensedCardBottom';
+
+const ResultsCondensedCard = () => (
+  <div className="usa-grid-full" style={{ border: 'solid 1px black' }}>
+    <ResultsCondensedCardTop />
+    <ResultsCondensedCardBottom />
+  </div>
+);
+
+export default ResultsCondensedCard;

--- a/src/Components/ResultsCondensedCard/index.js
+++ b/src/Components/ResultsCondensedCard/index.js
@@ -1,0 +1,1 @@
+export { default } from './ResultsCondensedCard';

--- a/src/Components/ResultsCondensedCardBottom/ResultsCondensedCardBottom.jsx
+++ b/src/Components/ResultsCondensedCardBottom/ResultsCondensedCardBottom.jsx
@@ -1,11 +1,10 @@
 import React from 'react';
+import CondensedCardData from '../CondensedCardData';
 import BidListButton from '../BidListButton';
 
 const ResultsCondensedCardBottom = () => (
   <div className="usa-grid-full condensed-card-bottom">
-    <div>data 1</div>
-    <div>data 2</div>
-    <div>data 3</div>
+    <CondensedCardData />
     <BidListButton />
   </div>
 );

--- a/src/Components/ResultsCondensedCardBottom/ResultsCondensedCardBottom.jsx
+++ b/src/Components/ResultsCondensedCardBottom/ResultsCondensedCardBottom.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import BidListButton from '../BidListButton';
+
+const ResultsCondensedCardBottom = () => (
+  <div className="usa-grid-full">
+    <div>data 1</div>
+    <div>data 2</div>
+    <div>data 3</div>
+    <BidListButton />
+  </div>
+);
+
+export default ResultsCondensedCardBottom;

--- a/src/Components/ResultsCondensedCardBottom/ResultsCondensedCardBottom.jsx
+++ b/src/Components/ResultsCondensedCardBottom/ResultsCondensedCardBottom.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import BidListButton from '../BidListButton';
 
 const ResultsCondensedCardBottom = () => (
-  <div className="usa-grid-full">
+  <div className="usa-grid-full condensed-card-bottom">
     <div>data 1</div>
     <div>data 2</div>
     <div>data 3</div>

--- a/src/Components/ResultsCondensedCardBottom/index.js
+++ b/src/Components/ResultsCondensedCardBottom/index.js
@@ -1,0 +1,1 @@
+export { default } from './ResultsCondensedCardBottom';

--- a/src/Components/ResultsCondensedCardTop/ResultsCondensedCardTop.jsx
+++ b/src/Components/ResultsCondensedCardTop/ResultsCondensedCardTop.jsx
@@ -5,13 +5,14 @@ import ResultsNewFlag from '../ResultsNewFlag';
 import Favorite from '../Favorite/Favorite';
 
 const ResultsCondensedCardTop = ({ type }) => (
-  <div className="usa-grid-full condensed-card-top" style={{ borderBottom: '1px solid gray' }}>
-    <div className="usa-grid-full" style={{ marginBottom: '20px' }}>
-      <div style={{ width: '48%', margin: '3px 0 0 1%', float: 'left' }}>
+  <div className="usa-grid-full condensed-card-top">
+    <div className="usa-grid-full condensed-card-top-header-container">
+      <div className="condensed-card-top-header condensed-card-top-header-left">
         <ResultsNewFlag />
       </div>
-      <div style={{ width: '48%', margin: '3px 1% 0 0', float: 'left', textAlign: 'right' }}>
-        <Favorite hideText />
+      <div className="condensed-card-top-header condensed-card-top-header-right">
+        {/* TODO use real favorite identifier instead of random number */}
+        <Favorite type="fav" refKey={Math.random().toString()} hideText />
       </div>
     </div>
     <FontAwesome className="condensed-top-background-image" name={type === 'popular' ? 'building' : 'flag'} size="3x" />

--- a/src/Components/ResultsCondensedCardTop/ResultsCondensedCardTop.jsx
+++ b/src/Components/ResultsCondensedCardTop/ResultsCondensedCardTop.jsx
@@ -1,19 +1,32 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import FontAwesome from 'react-fontawesome';
 import ResultsNewFlag from '../ResultsNewFlag';
 import Favorite from '../Favorite/Favorite';
 
-const ResultsCondensedCardTop = () => (
-  <div className="usa-grid-full">
-    <div style={{ width: '48%', margin: '3px 0 0 1%', float: 'left' }}>
-      <ResultsNewFlag />
+const ResultsCondensedCardTop = ({ type }) => (
+  <div className="usa-grid-full condensed-card-top" style={{ borderBottom: '1px solid gray' }}>
+    <div className="usa-grid-full" style={{ marginBottom: '20px' }}>
+      <div style={{ width: '48%', margin: '3px 0 0 1%', float: 'left' }}>
+        <ResultsNewFlag />
+      </div>
+      <div style={{ width: '48%', margin: '3px 1% 0 0', float: 'left', textAlign: 'right' }}>
+        <Favorite hideText />
+      </div>
     </div>
-    <div style={{ width: '48%', margin: '3px 1% 0 0', float: 'left', textAlign: 'right' }}>
-      <Favorite />
-    </div>
-    <div className="usa-width-one-whole">
-      Last Updated:
+    <FontAwesome className="condensed-top-background-image" name={type === 'popular' ? 'building' : 'flag'} size="3x" />
+    <div className="usa-width-one-whole condensed-card-last-updated">
+      Last Updated: 2017-06-08
     </div>
   </div>
 );
+
+ResultsCondensedCardTop.propTypes = {
+  type: PropTypes.string,
+};
+
+ResultsCondensedCardTop.defaultProps = {
+  type: 'new',
+};
 
 export default ResultsCondensedCardTop;

--- a/src/Components/ResultsCondensedCardTop/ResultsCondensedCardTop.jsx
+++ b/src/Components/ResultsCondensedCardTop/ResultsCondensedCardTop.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import ResultsNewFlag from '../ResultsNewFlag';
+import Favorite from '../Favorite/Favorite';
+
+const ResultsCondensedCardTop = () => (
+  <div className="usa-grid-full">
+    <div style={{ width: '48%', margin: '3px 0 0 1%', float: 'left' }}>
+      <ResultsNewFlag />
+    </div>
+    <div style={{ width: '48%', margin: '3px 1% 0 0', float: 'left', textAlign: 'right' }}>
+      <Favorite />
+    </div>
+    <div className="usa-width-one-whole">
+      Last Updated:
+    </div>
+  </div>
+);
+
+export default ResultsCondensedCardTop;

--- a/src/Components/ResultsCondensedCardTop/index.js
+++ b/src/Components/ResultsCondensedCardTop/index.js
@@ -1,0 +1,1 @@
+export { default } from './ResultsCondensedCardTop';

--- a/src/Components/ResultsNewFlag/ResultsNewFlag.jsx
+++ b/src/Components/ResultsNewFlag/ResultsNewFlag.jsx
@@ -3,8 +3,9 @@ import React from 'react';
 const ResultsNewFlag = () => {
   const style = {
     align: 'auto',
-    border: 'solid 1px',
+    backgroundColor: 'white',
     borderRadius: '100px',
+    color: 'black',
     fontSize: '13px',
     padding: '.1em',
     textAlign: 'center',

--- a/src/Components/ResultsNewFlag/ResultsNewFlag.jsx
+++ b/src/Components/ResultsNewFlag/ResultsNewFlag.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+const ResultsNewFlag = () => {
+  const style = {
+    align: 'auto',
+    border: 'solid 1px',
+    borderRadius: '100px',
+    fontSize: '13px',
+    padding: '.1em',
+    textAlign: 'center',
+    width: '50px',
+  };
+  return (
+    <div style={style}>
+      New
+    </div>
+  );
+};
+
+export default ResultsNewFlag;

--- a/src/Components/ResultsNewFlag/index.js
+++ b/src/Components/ResultsNewFlag/index.js
@@ -1,0 +1,1 @@
+export { default } from './ResultsNewFlag';

--- a/src/Constants/PropTypes.js
+++ b/src/Constants/PropTypes.js
@@ -41,11 +41,13 @@ export const POSITION_DETAILS = PropTypes.shape({
   languages: LANGUAGES,
 });
 
+export const POSITION_DETAILS_ARRAY = PropTypes.arrayOf(POSITION_DETAILS);
+
 export const POSITION_SEARCH_RESULTS = PropTypes.shape({
   count: PropTypes.number,
   next: PropTypes.string,
   previous: PropTypes.string,
-  results: PropTypes.arrayOf(POSITION_DETAILS),
+  results: POSITION_DETAILS_ARRAY,
 });
 
 export const FILTERS = PropTypes.arrayOf(

--- a/src/Containers/HomePage/HomePage.jsx
+++ b/src/Containers/HomePage/HomePage.jsx
@@ -5,7 +5,7 @@ import ENDPOINT_PARAMS from '../../Constants/EndpointParams';
 import ResultsSearchHeader from '../../Components/ResultsSearchHeader/ResultsSearchHeader';
 import Explore from '../../Components/Explore/Explore';
 import NewPositionsSection from '../../Components/NewPositionsSection';
-// import PopularPositionsSection from '../../Components/PopularPositionsSection';
+import PopularPositionsSection from '../../Components/PopularPositionsSection';
 
 class HomePage extends Component {
   constructor(props) {
@@ -41,6 +41,7 @@ class HomePage extends Component {
         />
         <div className="usa-grid-full positions-section">
           <NewPositionsSection />
+          <PopularPositionsSection />
         </div>
       </div>
     );

--- a/src/Containers/HomePage/HomePage.jsx
+++ b/src/Containers/HomePage/HomePage.jsx
@@ -4,6 +4,8 @@ import { ITEMS } from '../../Constants/PropTypes';
 import ENDPOINT_PARAMS from '../../Constants/EndpointParams';
 import ResultsSearchHeader from '../../Components/ResultsSearchHeader/ResultsSearchHeader';
 import Explore from '../../Components/Explore/Explore';
+import NewPositionsSection from '../../Components/NewPositionsSection';
+// import PopularPositionsSection from '../../Components/PopularPositionsSection';
 
 class HomePage extends Component {
   constructor(props) {
@@ -37,6 +39,9 @@ class HomePage extends Component {
           filters={filters}
           onRegionSubmit={this.submitRegion}
         />
+        <div className="usa-grid-full positions-section">
+          <NewPositionsSection />
+        </div>
       </div>
     );
   }

--- a/src/sass/_bidListButton.scss
+++ b/src/sass/_bidListButton.scss
@@ -1,0 +1,15 @@
+.bid-list-button {
+  background-color: $color-white;
+  border: 1px solid $blue-primary;
+  color: $color-black;
+  font-weight: 400;
+
+  .bid-list-button-icon {
+    color: $blue-primary;
+    margin-right: 5px;
+  }
+}
+
+.bid-list-button:hover {
+  border-bottom: 1px solid $blue-primary;
+}

--- a/src/sass/_bidListButton.scss
+++ b/src/sass/_bidListButton.scss
@@ -2,6 +2,8 @@
   background-color: $color-white;
   border: 1px solid $blue-primary;
   color: $color-black;
+  font-family: inherit;
+  font-size: 16px;
   font-weight: 400;
 
   .bid-list-button-icon {

--- a/src/sass/_condensedCard.scss
+++ b/src/sass/_condensedCard.scss
@@ -1,6 +1,7 @@
 .condensed-card {
 
   border: 1px solid $color-gray-light;
+  margin-bottom: 15px;
 
   .condensed-card-top {
     background-color: $blue-primary;

--- a/src/sass/_condensedCard.scss
+++ b/src/sass/_condensedCard.scss
@@ -1,10 +1,25 @@
 .condensed-card {
 
   border: 1px solid $color-gray-light;
+  font-family: Roboto;
   margin-bottom: 15px;
+
+  .condensed-card-inner {
+    margin-bottom: 15px;
+  }
+
+  .bid-list-button {
+    margin-top: 15px;
+  }
+
+  .condensed-card-title-header {
+    border-bottom: 1px solid;
+    display: inline-block;
+  }
 
   .condensed-card-top {
     background-color: $blue-primary;
+    border-bottom: 1px solid $color-gray-lightest;
     color: $color-white;
     overflow: hidden;
     padding: 3px 0 0 10px;
@@ -20,19 +35,50 @@
     top: -23%;
   }
 
+  .condensed-card-top-header {
+    float: left;
+    margin: 3px 0 0 1%;
+    width: 48%;
+  }
+
+  .condensed-card-top-header-container {
+    margin-bottom: 5px;
+  }
+
+  .condensed-card-top-header-right {
+    margin: 3px 1% 0 0;
+    text-align: right;
+  }
+
   .condensed-card-last-updated {
     font-size: 14px;
     margin: 10px;
   }
 
+  .condensed-card-bottom-container {
+    padding: 18px;
+  }
+
   .condensed-card-bottom {
-    max-height: 115px;
+    font-size: 16px;
+    max-height: 135px;
+  }
+
+  .condensed-card-data {
+    margin-bottom: 10px;
   }
 }
 
 .condensed-card-first-big {
+  float: left;
+
   .condensed-card-top {
-    min-height: 200px;
+    min-height: 255px;
+  }
+
+  .condensed-card-last-updated {
+    bottom: 0;
+    position: absolute;
   }
 
   .condensed-top-background-image {
@@ -40,8 +86,16 @@
   }
 
   .condensed-card-bottom {
-    min-height: 200px;
+    min-height: 219px;
   }
+}
+
+.condensed-card-second {
+  float: left;
+}
+
+.condensed-card-third {
+  float: left;
 }
 
 .condensed-card-popular {

--- a/src/sass/_condensedCard.scss
+++ b/src/sass/_condensedCard.scss
@@ -1,0 +1,50 @@
+.condensed-card {
+
+  border: 1px solid $color-gray-light;
+
+  .condensed-card-top {
+    background-color: $blue-primary;
+    color: $color-white;
+    overflow: hidden;
+    padding: 3px 0 0 10px;
+    position: relative;
+  }
+
+  .condensed-top-background-image {
+    filter: alpha(opacity = 10);
+    font-size: 150px;
+    left: 28%;
+    opacity: .1;
+    position: absolute;
+    top: -23%;
+  }
+
+  .condensed-card-last-updated {
+    font-size: 14px;
+    margin: 10px;
+  }
+
+  .condensed-card-bottom {
+    max-height: 115px;
+  }
+}
+
+.condensed-card-first-big {
+  .condensed-card-top {
+    min-height: 200px;
+  }
+
+  .condensed-top-background-image {
+    top: 17%;
+  }
+
+  .condensed-card-bottom {
+    min-height: 200px;
+  }
+}
+
+.condensed-card-popular {
+  .condensed-card-top {
+    background-color: $tm-navy;
+  }
+}

--- a/src/sass/_condensedCard.scss
+++ b/src/sass/_condensedCard.scss
@@ -8,11 +8,6 @@
     margin-top: 15px;
   }
 
-  .condensed-card-title-header {
-    border-bottom: 1px solid;
-    display: inline-block;
-  }
-
   .condensed-card-top {
     background-color: $blue-primary;
     border-bottom: 1px solid $color-gray-lightest;

--- a/src/sass/_condensedCard.scss
+++ b/src/sass/_condensedCard.scss
@@ -4,10 +4,6 @@
   font-family: Roboto;
   margin-bottom: 15px;
 
-  .condensed-card-inner {
-    margin-bottom: 15px;
-  }
-
   .bid-list-button {
     margin-top: 15px;
   }
@@ -56,6 +52,7 @@
   }
 
   .condensed-card-bottom-container {
+    min-height: 170px;
     padding: 18px;
   }
 
@@ -73,7 +70,7 @@
   float: left;
 
   .condensed-card-top {
-    min-height: 255px;
+    min-height: 241px;
   }
 
   .condensed-card-last-updated {

--- a/src/sass/_home.scss
+++ b/src/sass/_home.scss
@@ -67,3 +67,7 @@
     }
   }
 }
+
+.positions-section {
+
+}

--- a/src/sass/_home.scss
+++ b/src/sass/_home.scss
@@ -87,6 +87,11 @@
     text-align: right;
   }
 
+  .positions-section-title-header {
+    border-bottom: 1px solid;
+    display: inline-block;
+  }
+
   .positions-section-title {
     font-family: Vollkorn;
     font-size: 19px;

--- a/src/sass/_home.scss
+++ b/src/sass/_home.scss
@@ -70,4 +70,44 @@
 
 .positions-section {
 
+  margin-top: 25px;
+
+  .positions-section-container {
+    border-bottom: solid 1px $color-gray-lightest;
+    line-height: 40px;
+    margin-bottom: 20px;
+  }
+
+  .positions-section-container-left {
+    float: left;
+  }
+
+  .positions-section-container-right {
+    float: left;
+    text-align: right;
+  }
+
+  .positions-section-title {
+    font-family: Vollkorn;
+    font-size: 19px;
+
+    .fa {
+      color: $blue-primary;
+      margin-right: 8px;
+    }
+  }
+
+  .positions-section-view-more {
+    font-family: Roboto;
+    font-size: 16px;
+
+    a {
+      text-decoration: none;
+    }
+
+    .fa {
+      margin-left: 6px;
+    }
+  }
+
 }

--- a/src/sass/_home.scss
+++ b/src/sass/_home.scss
@@ -109,5 +109,4 @@
       margin-left: 6px;
     }
   }
-
 }

--- a/src/sass/_variables.scss
+++ b/src/sass/_variables.scss
@@ -9,6 +9,7 @@ $color-black: #000;
 $color-gray: #5b616b;
 $tm-dark-blue: #00293f;
 $tm-white-smoke: #f5f5f5;
+$tm-navy: #215493;
 
 //avatar dropdown
 $avatar-background: #fff;

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -11,6 +11,8 @@
 @import 'variables';
 
 // Components
+@import 'condensedCard';
+@import 'bidListButton';
 @import 'details';
 @import 'home';
 @import 'results';

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -1,8 +1,11 @@
 // Font Awesome
 @import '../../node_modules/font-awesome/css/font-awesome.min.css';
 
-// Volkorn font
+// Fonts
+// Volkorn
 @import '../../node_modules/typeface-vollkorn/index.css';
+// Roboto
+@import '../../node_modules/typeface-roboto/index.css';
 
 // USWDS
 @import '../../node_modules/uswds/dist/css/uswds.css';

--- a/yarn.lock
+++ b/yarn.lock
@@ -374,7 +374,7 @@ babel-code-frame@^6.11.0, babel-code-frame@^6.16.0, babel-code-frame@^6.22.0, ba
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-core@6.24.1:
+babel-core@6.24.1, babel-core@^6.0.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.24.1.tgz#8c428564dce1e1f41fb337ec34f4c3b022b5ad83"
   dependencies:
@@ -398,7 +398,7 @@ babel-core@6.24.1:
     slash "^1.0.0"
     source-map "^0.5.0"
 
-babel-core@^6.0.0, babel-core@^6.26.0:
+babel-core@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.0.tgz#af32f78b31a6fcef119c87b0fd8d9753f03a0bb8"
   dependencies:
@@ -874,17 +874,11 @@ babel-plugin-transform-react-jsx@6.24.1, babel-plugin-transform-react-jsx@^6.24.
     babel-plugin-syntax-jsx "^6.8.0"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-regenerator@6.24.1:
+babel-plugin-transform-regenerator@6.24.1, babel-plugin-transform-regenerator@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz#b8da305ad43c3c99b4848e4fe4037b770d23c418"
   dependencies:
     regenerator-transform "0.9.11"
-
-babel-plugin-transform-regenerator@^6.22.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz#e0703696fbde27f0a3efcacf8b4dca2f7b3a8f2f"
-  dependencies:
-    regenerator-transform "^0.10.0"
 
 babel-plugin-transform-runtime@6.23.0:
   version "6.23.0"
@@ -994,14 +988,14 @@ babel-register@^6.24.1, babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@6.23.0:
+babel-runtime@6.23.0, babel-runtime@^6.0.0, babel-runtime@^6.22.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-runtime@^6.0.0, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
+babel-runtime@^6.18.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
@@ -2153,16 +2147,9 @@ domutils@1.1:
   dependencies:
     domelementtype "1"
 
-domutils@1.5.1:
+domutils@1.5.1, domutils@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
-  dependencies:
-    dom-serializer "0"
-    domelementtype "1"
-
-domutils@^1.5.1:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.6.2.tgz#1958cc0b4c9426e9ed367fb1c8e854891b0fa3ff"
   dependencies:
     dom-serializer "0"
     domelementtype "1"
@@ -3475,7 +3462,7 @@ inline-source-map@~0.6.0:
   dependencies:
     source-map "~0.5.3"
 
-inquirer@3.2.1:
+inquirer@3.2.1, inquirer@^3.0.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.2.1.tgz#06ceb0f540f45ca548c17d6840959878265fa175"
   dependencies:
@@ -3510,25 +3497,6 @@ inquirer@^0.12.0:
     rx-lite "^3.1.2"
     string-width "^1.0.1"
     strip-ansi "^3.0.0"
-    through "^2.3.6"
-
-inquirer@^3.0.1:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.2.2.tgz#c2aaede1507cc54d826818737742d621bef2e823"
-  dependencies:
-    ansi-escapes "^2.0.0"
-    chalk "^2.0.0"
-    cli-cursor "^2.1.0"
-    cli-width "^2.0.0"
-    external-editor "^2.0.4"
-    figures "^2.0.0"
-    lodash "^4.3.0"
-    mute-stream "0.0.7"
-    run-async "^2.2.0"
-    rx-lite "^4.0.8"
-    rx-lite-aggregates "^4.0.8"
-    string-width "^2.1.0"
-    strip-ansi "^4.0.0"
     through "^2.3.6"
 
 insert-module-globals@^7.0.0:
@@ -4675,17 +4643,13 @@ minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4, minimatc
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8:
+minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
 minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
 mixin-object@^2.0.1:
   version "2.0.1"
@@ -5686,15 +5650,9 @@ progress@^1.1.8, progress@~1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
 
-promise@7.1.1:
+promise@7.1.1, promise@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
-  dependencies:
-    asap "~2.0.3"
-
-promise@^7.1.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
   dependencies:
     asap "~2.0.3"
 
@@ -6148,14 +6106,6 @@ regenerator-runtime@^0.11.0:
 regenerator-transform@0.9.11:
   version "0.9.11"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.9.11.tgz#3a7d067520cb7b7176769eb5ff868691befe1283"
-  dependencies:
-    babel-runtime "^6.18.0"
-    babel-types "^6.19.0"
-    private "^0.1.6"
-
-regenerator-transform@^0.10.0:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.10.1.tgz#1e4996837231da8b7f3cf4114d71b5691a0680dd"
   dependencies:
     babel-runtime "^6.18.0"
     babel-types "^6.19.0"
@@ -7140,6 +7090,14 @@ typedarray@^0.0.6, typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
+typeface-roboto@0.0.35:
+  version "0.0.35"
+  resolved "https://registry.yarnpkg.com/typeface-roboto/-/typeface-roboto-0.0.35.tgz#5965d3f6d4cd72b7b2833d6b7d42c9b59b8392ba"
+
+typeface-vollkorn@0.0.35:
+  version "0.0.35"
+  resolved "https://registry.yarnpkg.com/typeface-vollkorn/-/typeface-vollkorn-0.0.35.tgz#df4142ca267ad1fe39f151868469fc02bfb752d0"
+
 typescript@^2.4.1:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.1.tgz#ce7cc93ada3de19475cc9d17e3adea7aee1832aa"
@@ -7532,17 +7490,13 @@ window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
 
-wordwrap@0.0.2:
+wordwrap@0.0.2, wordwrap@~0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"
 
 wordwrap@^1.0.0, wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
-
-wordwrap@~0.0.2:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
 
 worker-farm@^1.3.1:
   version "1.5.0"


### PR DESCRIPTION
Adds the New and Popular Positions sections to the Homepage.

What this PR covers:
- Presentation layer of new and popular positions on the home page
- Appropriate prop types
- "View More" link

What this PR does not cover:
- Tests
- Passing real data as props to the components (i.e. the actual results from the API)
- Any real action associated with the "Add to Bid List" button
- How to check if a position is considered "new"
- Actual results property names for placeholders
- A URL to use for Popular Positions "View More" link (straight `/results` for now)