### PR TITLE
Accessibility fix for SearchBar component

### DIFF
--- a/src/Components/SearchBar/SearchBar.jsx
+++ b/src/Components/SearchBar/SearchBar.jsx
@@ -37,27 +37,29 @@ class SearchBar extends Component {
           name="search"
           placeholder={placeholder}
         />
-        <div id="enabled-search">
+        <div id={`enabled-search-${id}`}>
           { !noButton &&
           <button
-            id="enabled-search-button"
+            id={`enabled-search-button-${id}`}
             className={submitDisabled ? 'usa-button-disabled' : null}
             disabled={submitDisabled}
             type="submit"
+            title="submit search"
           >
             <span className="usa-search-submit-text">{showSubmitText ? submitText : null}</span>
             <span className="usa-sr-only">{showSubmitText ? submitText : 'Search'}</span>
           </button>
           }
         </div>
-        <div id="disabled-search" style={hidden}>
+        <div id={`disabled-search-${id}`} style={hidden}>
           {
             !noButton &&
             <button
               className="usa-button-disabled"
               disabled="true"
               type="submit"
-              id="disabled-search-button"
+              id={`disabled-search-button-${id}`}
+              title="search button disabled"
             >
               <span className="usa-search-submit-text usa-button-disabled">
                 {showSubmitText ? submitText : null}

--- a/src/Components/SearchBar/__snapshots__/SearchBar.test.jsx.snap
+++ b/src/Components/SearchBar/__snapshots__/SearchBar.test.jsx.snap
@@ -29,12 +29,13 @@ exports[`SearchBarComponent big matches snapshot 1`] = `
           value=""
         />
         <div
-          id="enabled-search"
+          id="enabled-search-search-2"
         >
           <button
             className={null}
             disabled={false}
-            id="enabled-search-button"
+            id="enabled-search-button-search-2"
+            title="submit search"
             type="submit"
           >
             <span
@@ -50,7 +51,7 @@ exports[`SearchBarComponent big matches snapshot 1`] = `
           </button>
         </div>
         <div
-          id="disabled-search"
+          id="disabled-search-search-2"
           style={
             Object {
               "display": "none",
@@ -60,7 +61,8 @@ exports[`SearchBarComponent big matches snapshot 1`] = `
           <button
             className="usa-button-disabled"
             disabled="true"
-            id="disabled-search-button"
+            id="disabled-search-button-search-2"
+            title="search button disabled"
             type="submit"
           >
             <span
@@ -110,12 +112,13 @@ exports[`SearchBarComponent medium matches snapshot 1`] = `
           value=""
         />
         <div
-          id="enabled-search"
+          id="enabled-search-search-2"
         >
           <button
             className={null}
             disabled={false}
-            id="enabled-search-button"
+            id="enabled-search-button-search-2"
+            title="submit search"
             type="submit"
           >
             <span
@@ -131,7 +134,7 @@ exports[`SearchBarComponent medium matches snapshot 1`] = `
           </button>
         </div>
         <div
-          id="disabled-search"
+          id="disabled-search-search-2"
           style={
             Object {
               "display": "none",
@@ -141,7 +144,8 @@ exports[`SearchBarComponent medium matches snapshot 1`] = `
           <button
             className="usa-button-disabled"
             disabled="true"
-            id="disabled-search-button"
+            id="disabled-search-button-search-2"
+            title="search button disabled"
             type="submit"
           >
             <span
@@ -191,12 +195,13 @@ exports[`SearchBarComponent small matches snapshot 1`] = `
           value=""
         />
         <div
-          id="enabled-search"
+          id="enabled-search-search-2"
         >
           <button
             className={null}
             disabled={false}
-            id="enabled-search-button"
+            id="enabled-search-button-search-2"
+            title="submit search"
             type="submit"
           >
             <span
@@ -210,7 +215,7 @@ exports[`SearchBarComponent small matches snapshot 1`] = `
           </button>
         </div>
         <div
-          id="disabled-search"
+          id="disabled-search-search-2"
           style={
             Object {
               "display": "none",
@@ -220,7 +225,8 @@ exports[`SearchBarComponent small matches snapshot 1`] = `
           <button
             className="usa-button-disabled"
             disabled="true"
-            id="disabled-search-button"
+            id="disabled-search-button-search-2"
+            title="search button disabled"
             type="submit"
           >
             <span


### PR DESCRIPTION
SearchBar component did not have necessary `name` attribute for its buttons. Additionally, multiple SearchBar components could not be used on the same page, as the `id`s were not unique enough. This PR fixes both of those issues.