### PR TITLE
Scroll to top on pagination change

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-router": "^4.1.1",
     "react-router-dom": "^4.1.1",
     "react-router-redux": "^5.0.0-alpha.6",
+    "react-scroll": "^1.5.4",
     "react-simple-dropdown": "^3.0.0",
     "redux": "^3.7.1",
     "redux-form": "^7.0.1",

--- a/src/Components/ResultsContainer/ResultsContainer.jsx
+++ b/src/Components/ResultsContainer/ResultsContainer.jsx
@@ -10,7 +10,7 @@ import ResultsPillContainer from '../ResultsPillContainer/ResultsPillContainer';
 
 const ResultsContainer = ({ results, isLoading, hasErrored, sortBy, pageCount, hasLoaded,
         defaultSort, pageSizes, defaultPageSize, refreshKey, pillFilters,
-        defaultPageNumber, queryParamUpdate, onToggle, onQueryParamToggle,
+        defaultPageNumber, queryParamUpdate, onToggle, onQueryParamToggle, scrollToTop,
   }) => (
     <div className="results-container">
       <ResultsPillContainer
@@ -57,7 +57,11 @@ const ResultsContainer = ({ results, isLoading, hasErrored, sortBy, pageCount, h
        <div className="usa-grid-full react-paginate">
          <PaginationWrapper
            pageCount={pageCount}
-           onPageChange={queryParamUpdate}
+           onPageChange={(q) => {
+             queryParamUpdate(q);
+             scrollToTop();
+           }
+           }
            forcePage={defaultPageNumber}
          />
        </div>
@@ -81,6 +85,7 @@ ResultsContainer.propTypes = {
   onToggle: PropTypes.func.isRequired,
   refreshKey: PropTypes.number, // refresh components that rely on local storage
   pillFilters: PILL_ITEM_ARRAY,
+  scrollToTop: PropTypes.func,
 };
 
 ResultsContainer.defaultProps = {
@@ -93,6 +98,7 @@ ResultsContainer.defaultProps = {
   defaultPageNumber: 0,
   refreshKey: 0,
   pillFilters: [],
+  scrollToTop: EMPTY_FUNCTION,
 };
 
 export default ResultsContainer;

--- a/src/Components/ResultsPage/ResultsPage.jsx
+++ b/src/Components/ResultsPage/ResultsPage.jsx
@@ -27,7 +27,7 @@ class Results extends Component {
     const { results, isLoading, hasErrored, sortBy, defaultKeyword, defaultLocation, resetFilters,
             pillFilters, defaultSort, pageSizes, defaultPageSize, onQueryParamToggle,
             defaultPageNumber, onQueryParamUpdate, filters,
-            selectedAccordion, setAccordion }
+            selectedAccordion, setAccordion, scrollToTop }
       = this.props;
     const hasLoaded = !isLoading && results.results && !!results.results.length;
     const pageCount = Math.ceil(results.count / defaultPageSize);
@@ -72,6 +72,7 @@ class Results extends Component {
             onToggle={() => this.onChildToggle()}
             pillFilters={pillFilters}
             onQueryParamToggle={onQueryParamToggle}
+            scrollToTop={scrollToTop}
           />
         </div>
       </div>
@@ -97,6 +98,7 @@ Results.propTypes = {
   selectedAccordion: ACCORDION_SELECTION_OBJECT,
   setAccordion: PropTypes.func.isRequired,
   filters: ITEMS,
+  scrollToTop: PropTypes.func,
 };
 
 Results.defaultProps = {
@@ -112,6 +114,7 @@ Results.defaultProps = {
   pillFilters: [],
   selectedAccordion: ACCORDION_SELECTION,
   filters: [],
+  scrollToTop: EMPTY_FUNCTION,
 };
 
 Results.contextTypes = {

--- a/src/Components/SearchFilters/BooleanFilter/BooleanFilter.jsx
+++ b/src/Components/SearchFilters/BooleanFilter/BooleanFilter.jsx
@@ -5,23 +5,23 @@ import FieldSet from '../../FieldSet/FieldSet';
 import { FILTER_ITEM } from '../../../Constants/PropTypes';
 
 const BooleanFilter = ({ item, onBooleanFilterClick }) => (
-    <FieldSet key={item.item.title} legend={item.item.title}>
-      <CheckBox
-        id={`checkbox-${item.item.title}`}
-        label="Yes"
-        title={item.item.title}
-        name={item.item.title}
-        value={item.data[0].isSelected || false}
-        selectionRef={item.item.selectionRef}
-        onCheckBoxClick={
+  <FieldSet key={item.item.title} legend={item.item.title}>
+    <CheckBox
+      id={`checkbox-${item.item.title}`}
+      label="Yes"
+      title={item.item.title}
+      name={item.item.title}
+      value={item.data[0].isSelected || false}
+      selectionRef={item.item.selectionRef}
+      onCheckBoxClick={
           (e) => {
             onBooleanFilterClick(
               e, item.data[0].code, item.item.selectionRef, item.data[0].isSelected,
             );
           }
         }
-      />
-    </FieldSet>
+    />
+  </FieldSet>
 );
 
 BooleanFilter.propTypes = {

--- a/src/Containers/Results/Results.jsx
+++ b/src/Containers/Results/Results.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { push } from 'react-router-redux';
 import queryString from 'query-string';
+import { scrollToTop } from '../../utilities';
 import { resultsFetchData } from '../../actions/results';
 import { filtersFetchData } from '../../actions/filters';
 import { setSelectedAccordion } from '../../actions/selectedAccordion';
@@ -15,6 +16,9 @@ import { POSITION_SEARCH_SORTS, POSITION_PAGE_SIZES } from '../../Constants/Sort
 class Results extends Component {
   constructor(props) {
     super(props);
+    this.onQueryParamUpdate = this.onQueryParamUpdate.bind(this);
+    this.onQueryParamToggle = this.onQueryParamToggle.bind(this);
+    this.resetFilters = this.resetFilters.bind(this);
     this.state = {
       key: 0,
       query: { value: window.location.search.replace('?', '') || '' },
@@ -191,15 +195,16 @@ class Results extends Component {
           pageSizes={POSITION_PAGE_SIZES}
           defaultPageSize={this.state.defaultPageSize.value}
           defaultPageNumber={this.state.defaultPageNumber.value}
-          onQueryParamUpdate={q => this.onQueryParamUpdate(q)}
+          onQueryParamUpdate={this.onQueryParamUpdate}
           defaultKeyword={this.state.defaultKeyword.value}
           defaultLocation={this.state.defaultLocation.value}
-          resetFilters={() => this.resetFilters()}
+          resetFilters={this.resetFilters}
           pillFilters={filters.mappedParams}
           filters={filters.filters}
-          onQueryParamToggle={(p, v, r) => this.onQueryParamToggle(p, v, r)}
+          onQueryParamToggle={this.onQueryParamToggle}
           selectedAccordion={selectedAccordion}
-          setAccordion={a => setAccordion(a)}
+          setAccordion={setAccordion}
+          scrollToTop={scrollToTop}
         />
       </div>
     );

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -1,3 +1,7 @@
+import Scroll from 'react-scroll';
+
+const scroll = Scroll.animateScroll;
+
 export function localStorageFetchValue(key, value) {
   const saved = { exists: true, count: 0 };
   const retrievedKey = localStorage.getItem(key);
@@ -100,4 +104,12 @@ export const formExploreRegionDropdown = (filters) => {
     );
   }
   return regions;
+};
+
+export const scrollToTop = () => {
+  scroll.scrollToTop({
+    duration: 700,
+    delay: 270,
+    smooth: 'easeOutQuad',
+  });
 };

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -106,10 +106,13 @@ export const formExploreRegionDropdown = (filters) => {
   return regions;
 };
 
-export const scrollToTop = () => {
-  scroll.scrollToTop({
-    duration: 700,
-    delay: 270,
-    smooth: 'easeOutQuad',
-  });
+// see all props at https://github.com/fisshy/react-scroll#propsoptions
+const defaultScrollConfig = {
+  duration: 700,
+  delay: 270,
+  smooth: 'easeOutQuad',
+};
+
+export const scrollToTop = (config = defaultScrollConfig) => {
+  scroll.scrollToTop(config);
 };

--- a/src/utilities.test.js
+++ b/src/utilities.test.js
@@ -6,6 +6,7 @@ import { validStateEmail,
          titleSort,
          pillSort,
          formExploreRegionDropdown,
+         scrollToTop,
        } from './utilities';
 
 describe('local storage', () => {
@@ -108,5 +109,11 @@ describe('formExploreRegionDropdown function', () => {
 
   it('can the placeholder object to the beginning of the array', () => {
     expect(regions[0].disabled).toBe(true);
+  });
+});
+
+describe('scrollToTop function', () => {
+  it('can call the scrollToTop function', () => {
+    scrollToTop();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5911,6 +5911,13 @@ react-router@^4.1.1:
     prop-types "^15.5.4"
     warning "^3.0.0"
 
+react-scroll@^1.5.4:
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/react-scroll/-/react-scroll-1.5.4.tgz#8c5c4ced659553be1fa39959776c85055fceb137"
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.5.8"
+
 react-simple-dropdown@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/react-simple-dropdown/-/react-simple-dropdown-3.0.0.tgz#5a2cac441748a090a3b7009b4807ea206002b7c3"


### PR DESCRIPTION
Introduces the `react-scroll` library to scroll to the top of the window when the page number is changed on the Results page. Also adds some `this` bindings to functions on the Results component.

Tried to mimic [USAJobs](https://www.usajobs.gov/Search/?k=technology) while keeping in mind that our site is a little different.