### PR TITLE
Unabbreviated params

### DIFF
--- a/src/Components/AccountDropdown/AccountDropdown.jsx
+++ b/src/Components/AccountDropdown/AccountDropdown.jsx
@@ -6,6 +6,11 @@ import { EMPTY_FUNCTION, USER_PROFILE } from '../../Constants/PropTypes';
 
 export class AccountDropdown extends Component {
 
+  constructor(props) {
+    super(props);
+    this.logout = this.logout.bind(this);
+  }
+
   logout() {
     this.props.logoutRequest();
   }
@@ -30,7 +35,7 @@ export class AccountDropdown extends Component {
             <Link to="/">Profile</Link>
           </div>
           <div className="account-dropdown--identity account-dropdown--segment">
-            <Link to="login" onClick={() => this.logout()}>Logout</Link>
+            <Link to="login" onClick={this.logout}>Logout</Link>
           </div>
         </DropdownContent>
       </Dropdown>

--- a/src/Components/CompareCheck/CompareCheck.jsx
+++ b/src/Components/CompareCheck/CompareCheck.jsx
@@ -7,6 +7,7 @@ import { EMPTY_FUNCTION } from '../../Constants/PropTypes';
 class CompareCheck extends Component {
   constructor(props) {
     super(props);
+    this.toggleSaved = this.toggleSaved.bind(this);
     this.state = {
       saved: false,
       localStorageKey: null,
@@ -60,7 +61,7 @@ class CompareCheck extends Component {
       // At the time of writing, CodeClimate's version of eslint-a11y-plugin
       // did not take role="button" into account with the following error:
       // eslint-disable-next-line jsx-a11y/no-static-element-interactions
-      <div tabIndex="0" role="button" style={{ cursor: 'pointer' }} onClick={() => this.toggleSaved()} >
+      <div tabIndex="0" role="button" style={{ cursor: 'pointer' }} onClick={this.toggleSaved} >
         <FontAwesome name={iconClass} /> {text}
       </div>
     );

--- a/src/Components/Favorite/Favorite.jsx
+++ b/src/Components/Favorite/Favorite.jsx
@@ -7,6 +7,7 @@ import { EMPTY_FUNCTION } from '../../Constants/PropTypes';
 class Favorite extends Component {
   constructor(props) {
     super(props);
+    this.toggleSaved = this.toggleSaved.bind(this);
     this.state = {
       saved: false,
       localStorageKey: null,
@@ -43,7 +44,7 @@ class Favorite extends Component {
       // At the time of writing, CodeClimate's version of eslint-a11y-plugin
       // did not take role="button" into account with the following error:
       // eslint-disable-next-line jsx-a11y/no-static-element-interactions
-      <div tabIndex="0" title="Add to favorites" role="button" style={{ cursor: 'pointer' }} onClick={() => this.toggleSaved()}>
+      <div tabIndex="0" title="Add to favorites" role="button" style={{ cursor: 'pointer' }} onClick={this.toggleSaved}>
         <FontAwesome name={iconClass} /> {this.props.hideText ? null : text}
       </div>
     );

--- a/src/Components/FavoritesButton/FavoritesButton.jsx
+++ b/src/Components/FavoritesButton/FavoritesButton.jsx
@@ -6,6 +6,7 @@ import { EMPTY_FUNCTION } from '../../Constants/PropTypes';
 class FavoritesButton extends Component {
   constructor(props) {
     super(props);
+    this.toggleSaved = this.toggleSaved.bind(this);
     this.state = {
       saved: false,
       localStorageKey: null,
@@ -61,7 +62,7 @@ class FavoritesButton extends Component {
         <button
           disabled={disabled}
           className={buttonClass}
-          onClick={() => this.toggleSaved()}
+          onClick={this.toggleSaved}
         >
           {buttonText}
         </button>

--- a/src/Components/Header/Header.jsx
+++ b/src/Components/Header/Header.jsx
@@ -98,7 +98,7 @@ export class Header extends Component {
                     <Link to="/">Profile</Link>
                   </li>
                   <li>
-                    <Link to="login" id="login-mobile" onClick={() => logout()}>Logout</Link>
+                    <Link to="login" id="login-mobile" onClick={logout}>Logout</Link>
                   </li>
                 </span>
                 <span className="desktop-nav-only">

--- a/src/Components/PillList/PillList.jsx
+++ b/src/Components/PillList/PillList.jsx
@@ -14,7 +14,7 @@ const PillList = ({ items, onPillClick }) => (
             description={item.description}
             codeRef={item.codeRef}
             selectionRef={item.selectionRef}
-            onPillClick={(p, v, r) => onPillClick(p, v, r)}
+            onPillClick={(param, value, remove) => onPillClick(param, value, remove)}
           />),
         )
     }

--- a/src/Components/PillList/PillList.jsx
+++ b/src/Components/PillList/PillList.jsx
@@ -14,7 +14,7 @@ const PillList = ({ items, onPillClick }) => (
             description={item.description}
             codeRef={item.codeRef}
             selectionRef={item.selectionRef}
-            onPillClick={(param, value, remove) => onPillClick(param, value, remove)}
+            onPillClick={onPillClick}
           />),
         )
     }

--- a/src/Components/ResetComparisons/ResetComparisons.jsx
+++ b/src/Components/ResetComparisons/ResetComparisons.jsx
@@ -20,7 +20,7 @@ class ResetComparisons extends Component {
       this.props.onToggle();
     };
     const compare = exists() ?
-      <button onClick={() => remove()}>Reset comparison choices</button>
+      <button onClick={remove}>Reset comparison choices</button>
       : null;
     return (
       <div>

--- a/src/Components/ResultsFilterContainer/ResultsFilterContainer.jsx
+++ b/src/Components/ResultsFilterContainer/ResultsFilterContainer.jsx
@@ -35,8 +35,8 @@ const ResultsFilterContainer = ({ filters, onQueryParamUpdate, onChildToggle,
               onQueryParamUpdate(e);
               onChildToggle();
             }}
-            queryParamToggle={(p, v, r) => {
-              onQueryParamToggle(p, v, r);
+            queryParamToggle={(param, value, remove) => {
+              onQueryParamToggle(param, value, remove);
               onChildToggle();
             }}
             selectedAccordion={selectedAccordion}

--- a/src/Components/ResultsList/ResultsList.jsx
+++ b/src/Components/ResultsList/ResultsList.jsx
@@ -8,7 +8,7 @@ const ResultsList = ({ results, onToggle, isLoading }) => {
   return (
     <div className={isLoading ? 'results-loading' : null}>
       { mapResults.map(result => (
-        <ResultsCard key={result.id} result={result} onToggle={() => onToggle()} />
+        <ResultsCard key={result.id} result={result} onToggle={onToggle} />
           ))}
     </div>
   );

--- a/src/Components/ResultsPage/ResultsPage.jsx
+++ b/src/Components/ResultsPage/ResultsPage.jsx
@@ -12,6 +12,7 @@ import ResultsFilterContainer from '../ResultsFilterContainer/ResultsFilterConta
 class Results extends Component {
   constructor(props) {
     super(props);
+    this.onChildToggle = this.onChildToggle.bind(this);
     this.state = {
       key: 0,
       currentPage: { value: 0 },
@@ -40,17 +41,17 @@ class Results extends Component {
         />
         <div className="usa-grid-full top-nav">
           <div className="usa-width-one-third compare-link">
-            <ViewComparisonLink onToggle={() => this.onChildToggle()} />
+            <ViewComparisonLink onToggle={this.onChildToggle} />
           </div>
           <div className="usa-width-one-third reset-comparisons">
-            <ResetComparisons onToggle={() => this.onChildToggle()} />
+            <ResetComparisons onToggle={this.onChildToggle} />
           </div>
         </div>
         <div className="usa-grid-full results-section-container">
           <ResultsFilterContainer
             filters={filters}
             onQueryParamUpdate={onQueryParamUpdate}
-            onChildToggle={() => this.onChildToggle()}
+            onChildToggle={this.onChildToggle}
             onQueryParamToggle={onQueryParamToggle}
             resetFilters={resetFilters}
             setAccordion={setAccordion}
@@ -69,7 +70,7 @@ class Results extends Component {
             defaultPageNumber={defaultPageNumber}
             queryParamUpdate={onQueryParamUpdate}
             refreshKey={this.state.key}
-            onToggle={() => this.onChildToggle()}
+            onToggle={this.onChildToggle}
             pillFilters={pillFilters}
             onQueryParamToggle={onQueryParamToggle}
           />

--- a/src/Components/ResultsPillContainer/ResultsPillContainer.jsx
+++ b/src/Components/ResultsPillContainer/ResultsPillContainer.jsx
@@ -8,7 +8,7 @@ const ResultsPillContainer = ({ items, onPillClick }) => (
     Your Selections:
     <PillList
       items={items}
-      onPillClick={(p, v, r) => onPillClick(p, v, r)}
+      onPillClick={(param, value, remove) => onPillClick(param, value, remove)}
     />
   </div>
 );

--- a/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.jsx
+++ b/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.jsx
@@ -91,7 +91,7 @@ class SearchFiltersContainer extends Component {
             (<MultiSelectFilter
               key={item.item.title}
               item={item}
-              queryParamToggle={(v, p, r) => { this.props.queryParamToggle(v, p, r); }}
+              queryParamToggle={this.props.queryParamToggle}
             />),
             title: item.item.title,
             id: `accordion-${item.item.title}`,

--- a/src/Containers/Results/Results.jsx
+++ b/src/Containers/Results/Results.jsx
@@ -197,7 +197,8 @@ class Results extends Component {
           resetFilters={() => this.resetFilters()}
           pillFilters={filters.mappedParams}
           filters={filters.filters}
-          onQueryParamToggle={(p, v, r) => this.onQueryParamToggle(p, v, r)}
+          onQueryParamToggle={(param, value, remove) =>
+            this.onQueryParamToggle(param, value, remove)}
           selectedAccordion={selectedAccordion}
           setAccordion={a => setAccordion(a)}
         />


### PR DESCRIPTION
This PR updates function calls to use shorthand when possible (`someFunction` instead of `() => someFunction()` by binding the functions to `this`. Also addresses #464 by using unabbreviated parameter names when possible. 