### PR TITLE
Regional Organizations

### DIFF
--- a/src/Components/Filters/Filters.jsx
+++ b/src/Components/Filters/Filters.jsx
@@ -14,7 +14,7 @@ class Filters extends Component {
         languages__language__code__in: [],
         grade__code__in: [],
         post__tour_of_duty__code__in: [],
-        organization__code__in: [],
+        bureau__code__in: [],
         post__cost_of_living_adjustment__gt: [],
         post__differential_rate__gt: [],
         post__danger_pay__gt: [],

--- a/src/Components/Filters/Filters.test.jsx
+++ b/src/Components/Filters/Filters.test.jsx
@@ -94,7 +94,7 @@ describe('FiltersComponent', () => {
         sort: 500,
         description: 'region',
         endpoint: 'organization',
-        selectionRef: 'organization__code__in',
+        selectionRef: 'bureau__code__in',
         text: 'Choose region',
         choices: [
         ],
@@ -191,7 +191,7 @@ describe('FiltersComponent', () => {
         wrapper.find('#S0020').simulate('change', (0, { target: { checked: true, value: '0020' } }));
         wrapper.find('#TOD00').simulate('change', (0, { target: { checked: true, value: '2' } }));
         wrapper.find('#R00').simulate('change', (0, { target: { checked: true, value: '2' } }));
-        expect(wrapper.instance().state.qString).toBe('organization__code__in=2&post__tour_of_duty__code__in=2&q=info%20Tech&skill__code__in=0010%2C0020');
+        expect(wrapper.instance().state.qString).toBe('bureau__code__in=2&post__tour_of_duty__code__in=2&q=info%20Tech&skill__code__in=0010%2C0020');
         done();
       }, 0);
     };

--- a/src/Constants/EndpointParams.js
+++ b/src/Constants/EndpointParams.js
@@ -3,7 +3,7 @@ const ENDPOINT_PARAMS = {
   language: 'languages__language__code__in',
   grade: 'grade__code__in',
   tod: 'post__tour_of_duty__code__in',
-  org: 'organization__code__in',
+  org: 'bureau__code__in',
   cola: 'post__cost_of_living_adjustment__gt',
   postDiff: 'post__differential_rate__gt',
   danger: 'post__danger_pay__gt',

--- a/src/api.js
+++ b/src/api.js
@@ -1,2 +1,2 @@
-const api = 'https://api.dev.talentmap.us/api/v1';
+const api = 'http://localhost:8000/api/v1';
 export default api;

--- a/src/api.js
+++ b/src/api.js
@@ -1,2 +1,2 @@
-const api = 'http://localhost:8000/api/v1';
+const api = 'https://api.dev.talentmap.us/api/v1';
 export default api;

--- a/src/reducers/filters.js
+++ b/src/reducers/filters.js
@@ -58,7 +58,7 @@ const items =
           title: 'Region',
           sort: 500,
           description: 'region',
-          endpoint: 'organization/?is_available=true',
+          endpoint: 'organization/?is_available=true&is_regional=true',
           selectionRef: ENDPOINT_PARAMS.org,
           text: 'Choose region',
           choices: [


### PR DESCRIPTION
Uses the `is_regional=true` flag for organizations to correctly display the list of Region filters. These regions plug into the `bureau__code__in=xxx` when searching for positions within that Region.