### PR TITLE
View Details Button on Homepage Cards

### DIFF
--- a/src/Components/BidListButton/BidListButton.jsx
+++ b/src/Components/BidListButton/BidListButton.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import FontAwesome from 'react-fontawesome';
 
+// TODO - will this be a link or an action?
 const BidListButton = () => (
-  <button className="bid-list-button">
-    <span className="bid-list-button-icon">
+  <button className="white-button">
+    <span className="white-button-icon">
       <FontAwesome name="plus-circle" />
     </span>
     <span>Add to bid list</span>

--- a/src/Components/LinkButton/LinkButton.jsx
+++ b/src/Components/LinkButton/LinkButton.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
+
+const LinkButton = ({ children, className, toLink }) => (
+  <span className="link-button-wrapper">
+    <Link
+      className={`link-button ${className}`}
+      type="submit"
+      role="button"
+      to={toLink}
+    >
+      {children}
+    </Link>
+  </span>
+);
+
+LinkButton.propTypes = {
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+  toLink: PropTypes.string.isRequired,
+};
+
+LinkButton.defaultProps = {
+  className: '',
+};
+
+export default LinkButton;

--- a/src/Components/LinkButton/LinkButton.test.jsx
+++ b/src/Components/LinkButton/LinkButton.test.jsx
@@ -1,0 +1,36 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import toJSON from 'enzyme-to-json';
+import LinkButton from './LinkButton';
+
+describe('LinkButtonComponent', () => {
+  const child = (<span>Text</span>);
+  const toLink = '/test/100';
+  it('is defined', () => {
+    const wrapper = shallow(
+      <LinkButton toLink={toLink}>
+        {child}
+      </LinkButton>,
+    );
+    expect(wrapper).toBeDefined();
+  });
+
+  it('can take props', () => {
+    const wrapper = shallow(
+      <LinkButton className="test-class" toLink={toLink}>
+        {child}
+      </LinkButton>,
+    );
+    expect(wrapper.instance().props.toLink).toBe(toLink);
+    expect(wrapper.find('.test-class')).toBeDefined();
+  });
+
+  it('matches snapshot', () => {
+    const wrapper = shallow(
+      <LinkButton toLink={toLink}>
+        {child}
+      </LinkButton>,
+    );
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/Components/LinkButton/__snapshots__/LinkButton.test.jsx.snap
+++ b/src/Components/LinkButton/__snapshots__/LinkButton.test.jsx.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LinkButtonComponent matches snapshot 1`] = `
+<span
+  className="link-button-wrapper"
+>
+  <Link
+    className="link-button "
+    replace={false}
+    role="button"
+    to="/test/100"
+    type="submit"
+  >
+    <span>
+      Text
+    </span>
+  </Link>
+</span>
+`;

--- a/src/Components/LinkButton/index.js
+++ b/src/Components/LinkButton/index.js
@@ -1,0 +1,1 @@
+export { default } from './LinkButton';

--- a/src/Components/ResultsCondensedCardBottom/ResultsCondensedCardBottom.jsx
+++ b/src/Components/ResultsCondensedCardBottom/ResultsCondensedCardBottom.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import CondensedCardData from '../CondensedCardData';
-import BidListButton from '../BidListButton';
+import ViewDetailsButton from '../ViewDetailsButton/ViewDetailsButton';
 import { POSITION_DETAILS } from '../../Constants/PropTypes';
 
 const ResultsCondensedCardBottom = ({ position }) => (
   <div className="usa-grid-full condensed-card-bottom">
     <CondensedCardData position={position} />
-    <BidListButton />
+    <ViewDetailsButton id={position.position_number} />
   </div>
 );
 

--- a/src/Components/ResultsCondensedCardBottom/__snapshots__/ResultsCondensedCardBottom.test.jsx.snap
+++ b/src/Components/ResultsCondensedCardBottom/__snapshots__/ResultsCondensedCardBottom.test.jsx.snap
@@ -47,6 +47,8 @@ exports[`ResultsCondensedCardBottomComponent matches snapshot 1`] = `
       }
     }
   />
-  <BidListButton />
+  <ViewDetailsButton
+    id="00025003"
+  />
 </div>
 `;

--- a/src/Components/ViewDetailsButton/ViewDetailsButton.jsx
+++ b/src/Components/ViewDetailsButton/ViewDetailsButton.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import FontAwesome from 'react-fontawesome';
+import LinkButton from '../LinkButton';
+
+const ViewDetailsButton = ({ id }) => (
+  <LinkButton toLink={`/details/${id}`} className="white-button">
+    <span className="white-button-icon">
+      <FontAwesome name="plus-circle" />
+    </span>
+    View details
+  </LinkButton>
+);
+
+ViewDetailsButton.propTypes = {
+  id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+};
+
+export default ViewDetailsButton;

--- a/src/Components/ViewDetailsButton/ViewDetailsButton.test.jsx
+++ b/src/Components/ViewDetailsButton/ViewDetailsButton.test.jsx
@@ -1,0 +1,27 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import toJSON from 'enzyme-to-json';
+import ViewDetailsButton from './ViewDetailsButton';
+
+describe('ViewDetailsButtonComponent', () => {
+  it('is defined', () => {
+    const wrapper = shallow(
+      <ViewDetailsButton id="1" />,
+    );
+    expect(wrapper).toBeDefined();
+  });
+
+  it('can take props', () => {
+    const wrapper = shallow(
+      <ViewDetailsButton id="1" />,
+    );
+    expect(wrapper.instance().props.id).toBe('1');
+  });
+
+  it('matches snapshot', () => {
+    const wrapper = shallow(
+      <ViewDetailsButton id="1" />,
+    );
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/Components/ViewDetailsButton/__snapshots__/ViewDetailsButton.test.jsx.snap
+++ b/src/Components/ViewDetailsButton/__snapshots__/ViewDetailsButton.test.jsx.snap
@@ -1,8 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`BidListButtonComponent matches snapshot 1`] = `
-<button
+exports[`ViewDetailsButtonComponent matches snapshot 1`] = `
+<LinkButton
   className="white-button"
+  toLink="/details/1"
 >
   <span
     className="white-button-icon"
@@ -11,8 +12,6 @@ exports[`BidListButtonComponent matches snapshot 1`] = `
       name="plus-circle"
     />
   </span>
-  <span>
-    Add to bid list
-  </span>
-</button>
+  View details
+</LinkButton>
 `;

--- a/src/sass/_condensedCard.scss
+++ b/src/sass/_condensedCard.scss
@@ -14,10 +14,27 @@
     width: 50px;
   }
 
-  .bid-list-button {
+  .white-button {
     bottom: 17px;
     margin-top: 15px;
     position: absolute;
+  }
+
+  .link-button-wrapper {
+    a:visited {
+      color: $color-black;
+    }
+  }
+
+  .link-button-wrapper:hover,
+  .link-button-wrapper:active {
+    a:visited {
+      color: $color-white;
+    }
+
+    .fa {
+      color: $color-white;
+    }
   }
 
   .condensed-card-top {
@@ -81,7 +98,7 @@
 .condensed-card-first-big {
   float: left;
 
-  .bid-list-button {
+  .white-button {
     bottom: unset;
     position: unset;
   }

--- a/src/sass/_whiteButton.scss
+++ b/src/sass/_whiteButton.scss
@@ -1,4 +1,4 @@
-.bid-list-button {
+.white-button {
   background-color: $color-white;
   border: 1px solid $blue-primary;
   color: $color-black;
@@ -6,12 +6,13 @@
   font-size: 16px;
   font-weight: 400;
 
-  .bid-list-button-icon {
+  .white-button-icon {
     color: $blue-primary;
     margin-right: 5px;
   }
 }
 
-.bid-list-button:hover {
+.white-button:hover {
   border-bottom: 1px solid $blue-primary;
+  color: $color-white;
 }

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -18,7 +18,7 @@
 
 // Components
 @import 'condensedCard';
-@import 'bidListButton';
+@import 'whiteButton';
 @import 'details';
 @import 'home';
 @import 'results';


### PR DESCRIPTION
Replaces the dummy "Add to bid list" button on the Home Page's condensed cards with a "View details" button that navigates to the Position Details page. Also abstracts the button to a `LinkButton` component for when we want to use a `Link` with button styles and attributes.