### PR TITLE
Add cancel token to Results request

### DIFF
--- a/src/actions/results.js
+++ b/src/actions/results.js
@@ -1,6 +1,9 @@
 import axios from 'axios';
 import api from '../api';
 
+const CancelToken = axios.CancelToken;
+let cancel;
+
 export function resultsHasErrored(bool) {
   return {
     type: 'RESULTS_HAS_ERRORED',
@@ -22,13 +25,19 @@ export function resultsFetchDataSuccess(results) {
 
 export function resultsFetchData(query) {
   return (dispatch) => {
+    if (cancel) { cancel(); }
     dispatch(resultsIsLoading(true));
-    axios.get(`${api}/position/?${query}`)
-            .then((response) => {
-              dispatch(resultsIsLoading(false));
-              return response.data;
-            })
-            .then(results => dispatch(resultsFetchDataSuccess(results)))
-            .catch(() => dispatch(resultsHasErrored(true)));
+    axios.get(`${api}/position/?${query}`, {
+      cancelToken: new CancelToken((c) => {
+        cancel = c;
+      }),
+    },
+    )
+      .then((response) => {
+        dispatch(resultsIsLoading(false));
+        return response.data;
+      })
+      .then(results => dispatch(resultsFetchDataSuccess(results)))
+      .catch(() => dispatch(resultsHasErrored(true)));
   };
 }


### PR DESCRIPTION
Adds a cancel token that gets called before requests to cancel old Results requests.