### PR TITLE
Offset the positions section titles and containers

### DIFF
--- a/src/sass/_home.scss
+++ b/src/sass/_home.scss
@@ -74,8 +74,10 @@
 
   .positions-section-container {
     border-bottom: solid 1px $color-gray-lightest;
+    bottom: -1px;
     line-height: 40px;
     margin-bottom: 20px;
+    position: relative;
   }
 
   .positions-section-container-left {
@@ -89,7 +91,9 @@
 
   .positions-section-title-header {
     border-bottom: 1px solid;
+    bottom: -1px;
     display: inline-block;
+    position: relative;
   }
 
   .positions-section-title {


### PR DESCRIPTION
Addresses #578 by using `position: relative` and `bottom: -1px` to have borders overlap properly.