### PR TITLE
Add opacity to home page positions when loading

### DIFF
--- a/src/Components/NewPositionsCardList/NewPositionsCardList.jsx
+++ b/src/Components/NewPositionsCardList/NewPositionsCardList.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import ResultsCondensedCard from '../ResultsCondensedCard';
 import { POSITION_DETAILS_ARRAY, FAVORITE_POSITIONS_ARRAY } from '../../Constants/PropTypes';
 
-const NewPositionsCardList = ({ positions, toggleFavorite, favorites,
+const NewPositionsCardList = ({ positions, toggleFavorite, favorites, isLoading,
   userProfileFavoritePositionIsLoading, userProfileFavoritePositionHasErrored }) => {
   const positionList = [];
 
@@ -25,7 +25,7 @@ const NewPositionsCardList = ({ positions, toggleFavorite, favorites,
   });
 
   return (
-    <div className="usa-grid-full">
+    <div className={`usa-grid-full ${isLoading ? 'results-loading' : ''}`}>
       <div className="usa-width-one-third condensed-card-first-big">
         {positionList[0]}
       </div>
@@ -47,11 +47,13 @@ NewPositionsCardList.propTypes = {
   toggleFavorite: PropTypes.func.isRequired,
   userProfileFavoritePositionIsLoading: PropTypes.bool.isRequired,
   userProfileFavoritePositionHasErrored: PropTypes.bool.isRequired,
+  isLoading: PropTypes.bool,
 };
 
 NewPositionsCardList.defaultProps = {
   positions: [],
   favorites: [],
+  isLoading: false,
 };
 
 export default NewPositionsCardList;

--- a/src/Components/NewPositionsCardList/NewPositionsCardList.test.jsx
+++ b/src/Components/NewPositionsCardList/NewPositionsCardList.test.jsx
@@ -29,6 +29,19 @@ describe('NewPositionsCardListComponent', () => {
     expect(wrapper.instance().props.positions[0].id).toBe(resultsObject.results[0].id);
   });
 
+  it('can change className based on isLoading', () => {
+    const wrapper = shallow(
+      <NewPositionsCardList
+        positions={resultsObject.results}
+        toggleFavorite={() => {}}
+        userProfileFavoritePositionIsLoading={false}
+        userProfileFavoritePositionHasErrored={false}
+        isLoading
+      />,
+    );
+    expect(wrapper.find('.results-loading')).toBeDefined();
+  });
+
   it('matches snapshot', () => {
     const wrapper = shallow(
       <NewPositionsCardList

--- a/src/Components/NewPositionsCardList/__snapshots__/NewPositionsCardList.test.jsx.snap
+++ b/src/Components/NewPositionsCardList/__snapshots__/NewPositionsCardList.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`NewPositionsCardListComponent matches snapshot 1`] = `
 <div
-  className="usa-grid-full"
+  className="usa-grid-full "
 >
   <div
     className="usa-width-one-third condensed-card-first-big"

--- a/src/Components/NewPositionsSection/NewPositionsSection.jsx
+++ b/src/Components/NewPositionsSection/NewPositionsSection.jsx
@@ -5,7 +5,7 @@ import PositionsSectionTitle from '../PositionsSectionTitle';
 import NewPositionsCardList from '../NewPositionsCardList';
 import { POSITION_DETAILS_ARRAY, FAVORITE_POSITIONS_ARRAY } from '../../Constants/PropTypes';
 
-const NewPositionsSection = ({ positions, toggleFavorite, favorites,
+const NewPositionsSection = ({ positions, toggleFavorite, favorites, isLoading,
   userProfileFavoritePositionIsLoading, userProfileFavoritePositionHasErrored }) => (
 
     <div className="usa-grid-full positions-section positions-section-new">
@@ -21,6 +21,7 @@ const NewPositionsSection = ({ positions, toggleFavorite, favorites,
         userProfileFavoritePositionIsLoading={userProfileFavoritePositionIsLoading}
         userProfileFavoritePositionHasErrored={userProfileFavoritePositionHasErrored}
         positions={positions}
+        isLoading={isLoading}
       />
     </div>
 );
@@ -31,10 +32,12 @@ NewPositionsSection.propTypes = {
   toggleFavorite: PropTypes.func.isRequired,
   userProfileFavoritePositionIsLoading: PropTypes.bool.isRequired,
   userProfileFavoritePositionHasErrored: PropTypes.bool.isRequired,
+  isLoading: PropTypes.bool,
 };
 
 NewPositionsSection.defaultProps = {
   favorites: [],
+  isLoading: false,
 };
 
 export default NewPositionsSection;

--- a/src/Components/NewPositionsSection/__snapshots__/NewPositionsSection.test.jsx.snap
+++ b/src/Components/NewPositionsSection/__snapshots__/NewPositionsSection.test.jsx.snap
@@ -19,6 +19,7 @@ exports[`NewPositionsSectionComponent matches snapshot 1`] = `
   />
   <NewPositionsCardList
     favorites={Array []}
+    isLoading={false}
     positions={
       Array [
         Object {

--- a/src/Components/PopularPositionsCardList/PopularPositionsCardList.jsx
+++ b/src/Components/PopularPositionsCardList/PopularPositionsCardList.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import ResultsCondensedCard from '../ResultsCondensedCard';
 import { POSITION_DETAILS_ARRAY, FAVORITE_POSITIONS_ARRAY } from '../../Constants/PropTypes';
 
-const PopularPositionsCardList = ({ positions, toggleFavorite, favorites,
+const PopularPositionsCardList = ({ positions, toggleFavorite, favorites, isLoading,
     userProfileFavoritePositionIsLoading, userProfileFavoritePositionHasErrored }) => {
   const positionList = positions.slice().map(p => (
     <div key={p.id} className="usa-width-one-third condensed-card">
@@ -18,7 +18,7 @@ const PopularPositionsCardList = ({ positions, toggleFavorite, favorites,
     </div>
   ));
   return (
-    <div className="usa-grid-full condensed-card-popular">
+    <div className={`usa-grid-full condensed-card-popular ${isLoading ? 'results-loading' : ''}`}>
       {positionList}
     </div>
   );
@@ -30,11 +30,13 @@ PopularPositionsCardList.propTypes = {
   toggleFavorite: PropTypes.func.isRequired,
   userProfileFavoritePositionIsLoading: PropTypes.bool.isRequired,
   userProfileFavoritePositionHasErrored: PropTypes.bool.isRequired,
+  isLoading: PropTypes.bool,
 };
 
 PopularPositionsCardList.defaultProps = {
   positions: [],
   favorites: [],
+  isLoading: false,
 };
 
 export default PopularPositionsCardList;

--- a/src/Components/PopularPositionsCardList/PopularPositionsCardList.test.jsx
+++ b/src/Components/PopularPositionsCardList/PopularPositionsCardList.test.jsx
@@ -29,6 +29,19 @@ describe('PopularPositionsCardListComponent', () => {
     expect(wrapper.instance().props.positions[0].id).toBe(resultsObject.results[0].id);
   });
 
+  it('can change className based on isLoading', () => {
+    const wrapper = shallow(
+      <PopularPositionsCardList
+        positions={resultsObject.results}
+        toggleFavorite={() => {}}
+        userProfileFavoritePositionIsLoading={false}
+        userProfileFavoritePositionHasErrored={false}
+        isLoading
+      />,
+    );
+    expect(wrapper.find('.results-loading')).toBeDefined();
+  });
+
   it('matches snapshot', () => {
     const wrapper = shallow(
       <PopularPositionsCardList

--- a/src/Components/PopularPositionsCardList/__snapshots__/PopularPositionsCardList.test.jsx.snap
+++ b/src/Components/PopularPositionsCardList/__snapshots__/PopularPositionsCardList.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`PopularPositionsCardListComponent matches snapshot 1`] = `
 <div
-  className="usa-grid-full condensed-card-popular"
+  className="usa-grid-full condensed-card-popular "
 >
   <div
     className="usa-width-one-third condensed-card"

--- a/src/Components/PopularPositionsSection/PopularPositionsSection.jsx
+++ b/src/Components/PopularPositionsSection/PopularPositionsSection.jsx
@@ -5,7 +5,7 @@ import PositionsSectionTitle from '../PositionsSectionTitle';
 import PopularPositionsCardList from '../PopularPositionsCardList';
 import { POSITION_DETAILS_ARRAY, FAVORITE_POSITIONS_ARRAY } from '../../Constants/PropTypes';
 
-const PopularPositionsSection = ({ positions, toggleFavorite, favorites,
+const PopularPositionsSection = ({ positions, toggleFavorite, favorites, isLoading,
   userProfileFavoritePositionIsLoading, userProfileFavoritePositionHasErrored }) => (
     <div className="usa-grid-full positions-section positions-section-popular">
       <PositionsSectionTitle
@@ -23,6 +23,7 @@ const PopularPositionsSection = ({ positions, toggleFavorite, favorites,
         userProfileFavoritePositionIsLoading={userProfileFavoritePositionIsLoading}
         userProfileFavoritePositionHasErrored={userProfileFavoritePositionHasErrored}
         positions={positions}
+        isLoading={isLoading}
       />
     </div>
 );
@@ -33,10 +34,12 @@ PopularPositionsSection.propTypes = {
   toggleFavorite: PropTypes.func.isRequired,
   userProfileFavoritePositionIsLoading: PropTypes.bool.isRequired,
   userProfileFavoritePositionHasErrored: PropTypes.bool.isRequired,
+  isLoading: PropTypes.bool,
 };
 
 PopularPositionsSection.defaultProps = {
   favorites: [],
+  isLoading: false,
 };
 
 export default PopularPositionsSection;

--- a/src/Components/PopularPositionsSection/__snapshots__/PopularPositionsSection.test.jsx.snap
+++ b/src/Components/PopularPositionsSection/__snapshots__/PopularPositionsSection.test.jsx.snap
@@ -19,6 +19,7 @@ exports[`PopularPositionsSectionComponent matches snapshot 1`] = `
   />
   <PopularPositionsCardList
     favorites={Array []}
+    isLoading={false}
     positions={
       Array [
         Object {

--- a/src/Containers/HomePage/HomePage.jsx
+++ b/src/Containers/HomePage/HomePage.jsx
@@ -55,6 +55,7 @@ class HomePage extends Component {
             userProfileFavoritePositionIsLoading={userProfileFavoritePositionIsLoading}
             userProfileFavoritePositionHasErrored={userProfileFavoritePositionHasErrored}
             positions={homePagePositions.isNew}
+            isLoading={homePagePositionsIsLoading}
           />
           <PopularPositionsSection
             favorites={userProfile.favorite_positions}
@@ -62,6 +63,7 @@ class HomePage extends Component {
             userProfileFavoritePositionIsLoading={userProfileFavoritePositionIsLoading}
             userProfileFavoritePositionHasErrored={userProfileFavoritePositionHasErrored}
             positions={homePagePositions.isPopular}
+            isLoading={homePagePositionsIsLoading}
           />
         </div>
       </div>

--- a/src/sass/_spinner.scss
+++ b/src/sass/_spinner.scss
@@ -5,6 +5,7 @@ $tm-spinner-filled-ratio: 1.15;
 
 .tm-spinner {
   color: $tm-navy;
+  z-index: 100; // make sure spinner is on top
 }
 
 .tm-spinner-homepage-position-results {

--- a/src/sass/_spinner.scss
+++ b/src/sass/_spinner.scss
@@ -5,7 +5,7 @@ $tm-spinner-filled-ratio: 1.15;
 
 .tm-spinner {
   color: $tm-navy;
-  z-index: 100; // make sure spinner is on top
+  z-index: $spinner-z; // make sure spinner is on top
 }
 
 .tm-spinner-homepage-position-results {

--- a/src/sass/_variables.scss
+++ b/src/sass/_variables.scss
@@ -16,3 +16,7 @@ $avatar-background: #fff;
 $avatar-dropdown-border-top-color: rgba(0, 0, 0, .05);
 $avatar-dropdown-box-shadow-color: rgba(0, 0, 0, .15);
 $avatar-dropdown-account-segment-color: #e1e1e1;
+
+// z-index values
+// we'll use this section to keep track of and order them
+$spinner-z: 100;


### PR DESCRIPTION
Addresses #580 by adding opacity to the containers for New and Popular positions on the home page when they're loading.