### PR TITLE
Popular -> Highlighted positions

### DIFF
--- a/src/Components/HighlightedPositionsCardList/HighlightedPositionsCardList.jsx
+++ b/src/Components/HighlightedPositionsCardList/HighlightedPositionsCardList.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import ResultsCondensedCard from '../ResultsCondensedCard';
 import { POSITION_DETAILS_ARRAY, FAVORITE_POSITIONS_ARRAY } from '../../Constants/PropTypes';
 
-const PopularPositionsCardList = ({ positions, toggleFavorite, favorites, isLoading,
+const HighlightedPositionsCardList = ({ positions, toggleFavorite, favorites, isLoading,
     userProfileFavoritePositionIsLoading, userProfileFavoritePositionHasErrored }) => {
   const positionList = positions.slice().map(p => (
     <div key={p.id} className="usa-width-one-third condensed-card">
@@ -12,19 +12,19 @@ const PopularPositionsCardList = ({ positions, toggleFavorite, favorites, isLoad
         toggleFavorite={toggleFavorite}
         userProfileFavoritePositionIsLoading={userProfileFavoritePositionIsLoading}
         userProfileFavoritePositionHasErrored={userProfileFavoritePositionHasErrored}
-        type="popular"
+        type="highlighted"
         position={p}
       />
     </div>
   ));
   return (
-    <div className={`usa-grid-full condensed-card-popular ${isLoading ? 'results-loading' : ''}`}>
+    <div className={`usa-grid-full condensed-card-highlighted ${isLoading ? 'results-loading' : ''}`}>
       {positionList}
     </div>
   );
 };
 
-PopularPositionsCardList.propTypes = {
+HighlightedPositionsCardList.propTypes = {
   positions: POSITION_DETAILS_ARRAY,
   favorites: FAVORITE_POSITIONS_ARRAY,
   toggleFavorite: PropTypes.func.isRequired,
@@ -33,10 +33,10 @@ PopularPositionsCardList.propTypes = {
   isLoading: PropTypes.bool,
 };
 
-PopularPositionsCardList.defaultProps = {
+HighlightedPositionsCardList.defaultProps = {
   positions: [],
   favorites: [],
   isLoading: false,
 };
 
-export default PopularPositionsCardList;
+export default HighlightedPositionsCardList;

--- a/src/Components/HighlightedPositionsCardList/HighlightedPositionsCardList.test.jsx
+++ b/src/Components/HighlightedPositionsCardList/HighlightedPositionsCardList.test.jsx
@@ -1,13 +1,13 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 import toJSON from 'enzyme-to-json';
-import PopularPositionsCardList from './PopularPositionsCardList';
+import HighlightedPositionsCardList from './HighlightedPositionsCardList';
 import resultsObject from '../../__mocks__/resultsObject';
 
-describe('PopularPositionsCardListComponent', () => {
+describe('HighlightedPositionsCardListComponent', () => {
   it('is defined', () => {
     const wrapper = shallow(
-      <PopularPositionsCardList
+      <HighlightedPositionsCardList
         positions={resultsObject.results}
         toggleFavorite={() => {}}
         userProfileFavoritePositionIsLoading={false}
@@ -19,7 +19,7 @@ describe('PopularPositionsCardListComponent', () => {
 
   it('can receive props', () => {
     const wrapper = shallow(
-      <PopularPositionsCardList
+      <HighlightedPositionsCardList
         positions={resultsObject.results}
         toggleFavorite={() => {}}
         userProfileFavoritePositionIsLoading={false}
@@ -31,7 +31,7 @@ describe('PopularPositionsCardListComponent', () => {
 
   it('can change className based on isLoading', () => {
     const wrapper = shallow(
-      <PopularPositionsCardList
+      <HighlightedPositionsCardList
         positions={resultsObject.results}
         toggleFavorite={() => {}}
         userProfileFavoritePositionIsLoading={false}
@@ -44,7 +44,7 @@ describe('PopularPositionsCardListComponent', () => {
 
   it('matches snapshot', () => {
     const wrapper = shallow(
-      <PopularPositionsCardList
+      <HighlightedPositionsCardList
         positions={resultsObject.results}
         toggleFavorite={() => {}}
         userProfileFavoritePositionIsLoading={false}

--- a/src/Components/HighlightedPositionsCardList/__snapshots__/HighlightedPositionsCardList.test.jsx.snap
+++ b/src/Components/HighlightedPositionsCardList/__snapshots__/HighlightedPositionsCardList.test.jsx.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PopularPositionsCardListComponent matches snapshot 1`] = `
+exports[`HighlightedPositionsCardListComponent matches snapshot 1`] = `
 <div
-  className="usa-grid-full condensed-card-popular "
+  className="usa-grid-full condensed-card-highlighted "
 >
   <div
     className="usa-width-one-third condensed-card"
@@ -51,7 +51,7 @@ exports[`PopularPositionsCardListComponent matches snapshot 1`] = `
         }
       }
       toggleFavorite={[Function]}
-      type="popular"
+      type="highlighted"
       userProfileFavoritePositionHasErrored={false}
       userProfileFavoritePositionIsLoading={false}
     />
@@ -77,7 +77,7 @@ exports[`PopularPositionsCardListComponent matches snapshot 1`] = `
         }
       }
       toggleFavorite={[Function]}
-      type="popular"
+      type="highlighted"
       userProfileFavoritePositionHasErrored={false}
       userProfileFavoritePositionIsLoading={false}
     />

--- a/src/Components/HighlightedPositionsCardList/index.js
+++ b/src/Components/HighlightedPositionsCardList/index.js
@@ -1,0 +1,1 @@
+export { default } from './HighlightedPositionsCardList';

--- a/src/Components/HighlightedPositionsSection/HighlightedPositionsSection.jsx
+++ b/src/Components/HighlightedPositionsSection/HighlightedPositionsSection.jsx
@@ -2,22 +2,22 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import FontAwesome from 'react-fontawesome';
 import PositionsSectionTitle from '../PositionsSectionTitle';
-import PopularPositionsCardList from '../PopularPositionsCardList';
+import HighlightedPositionsCardList from '../HighlightedPositionsCardList';
 import { POSITION_DETAILS_ARRAY, FAVORITE_POSITIONS_ARRAY } from '../../Constants/PropTypes';
 
-const PopularPositionsSection = ({ positions, toggleFavorite, favorites, isLoading,
+const HighlightedPositionsSection = ({ positions, toggleFavorite, favorites, isLoading,
   userProfileFavoritePositionIsLoading, userProfileFavoritePositionHasErrored }) => (
-    <div className="usa-grid-full positions-section positions-section-popular">
+    <div className="usa-grid-full positions-section positions-section-highlighted">
       <PositionsSectionTitle
         title={
           <span className="positions-section-title">
             <FontAwesome name="gratipay" />
-            Popular Positions
+            Highlighted Positions
           </span>
         }
         viewMoreLink="/results"
       />
-      <PopularPositionsCardList
+      <HighlightedPositionsCardList
         favorites={favorites}
         toggleFavorite={toggleFavorite}
         userProfileFavoritePositionIsLoading={userProfileFavoritePositionIsLoading}
@@ -28,7 +28,7 @@ const PopularPositionsSection = ({ positions, toggleFavorite, favorites, isLoadi
     </div>
 );
 
-PopularPositionsSection.propTypes = {
+HighlightedPositionsSection.propTypes = {
   positions: POSITION_DETAILS_ARRAY.isRequired,
   favorites: FAVORITE_POSITIONS_ARRAY,
   toggleFavorite: PropTypes.func.isRequired,
@@ -37,9 +37,9 @@ PopularPositionsSection.propTypes = {
   isLoading: PropTypes.bool,
 };
 
-PopularPositionsSection.defaultProps = {
+HighlightedPositionsSection.defaultProps = {
   favorites: [],
   isLoading: false,
 };
 
-export default PopularPositionsSection;
+export default HighlightedPositionsSection;

--- a/src/Components/HighlightedPositionsSection/HighlightedPositionsSection.test.jsx
+++ b/src/Components/HighlightedPositionsSection/HighlightedPositionsSection.test.jsx
@@ -1,13 +1,13 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 import toJSON from 'enzyme-to-json';
-import PopularPositionsSection from './PopularPositionsSection';
+import HighlightedPositionsSection from './HighlightedPositionsSection';
 import resultsObject from '../../__mocks__/resultsObject';
 
-describe('PopularPositionsSectionComponent', () => {
+describe('HighlightedPositionsSectionComponent', () => {
   it('is defined', () => {
     const wrapper = shallow(
-      <PopularPositionsSection
+      <HighlightedPositionsSection
         positions={resultsObject.results}
         toggleFavorite={() => {}}
         userProfileFavoritePositionIsLoading={false}
@@ -19,7 +19,7 @@ describe('PopularPositionsSectionComponent', () => {
 
   it('can receive props', () => {
     const wrapper = shallow(
-      <PopularPositionsSection
+      <HighlightedPositionsSection
         positions={resultsObject.results}
         toggleFavorite={() => {}}
         userProfileFavoritePositionIsLoading={false}
@@ -31,7 +31,7 @@ describe('PopularPositionsSectionComponent', () => {
 
   it('matches snapshot', () => {
     const wrapper = shallow(
-      <PopularPositionsSection
+      <HighlightedPositionsSection
         positions={resultsObject.results}
         toggleFavorite={() => {}}
         userProfileFavoritePositionIsLoading={false}

--- a/src/Components/HighlightedPositionsSection/__snapshots__/HighlightedPositionsSection.test.jsx.snap
+++ b/src/Components/HighlightedPositionsSection/__snapshots__/HighlightedPositionsSection.test.jsx.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PopularPositionsSectionComponent matches snapshot 1`] = `
+exports[`HighlightedPositionsSectionComponent matches snapshot 1`] = `
 <div
-  className="usa-grid-full positions-section positions-section-popular"
+  className="usa-grid-full positions-section positions-section-highlighted"
 >
   <PositionsSectionTitle
     title={
@@ -12,12 +12,12 @@ exports[`PopularPositionsSectionComponent matches snapshot 1`] = `
         <FontAwesome
           name="gratipay"
         />
-        Popular Positions
+        Highlighted Positions
       </span>
     }
     viewMoreLink="/results"
   />
-  <PopularPositionsCardList
+  <HighlightedPositionsCardList
     favorites={Array []}
     isLoading={false}
     positions={

--- a/src/Components/HighlightedPositionsSection/index.js
+++ b/src/Components/HighlightedPositionsSection/index.js
@@ -1,0 +1,1 @@
+export { default } from './HighlightedPositionsSection';

--- a/src/Components/PopularPositionsCardList/index.js
+++ b/src/Components/PopularPositionsCardList/index.js
@@ -1,1 +1,0 @@
-export { default } from './PopularPositionsCardList';

--- a/src/Components/PopularPositionsSection/index.js
+++ b/src/Components/PopularPositionsSection/index.js
@@ -1,1 +1,0 @@
-export { default } from './PopularPositionsSection';

--- a/src/Components/ResultsCondensedCardTop/ResultsCondensedCardTop.jsx
+++ b/src/Components/ResultsCondensedCardTop/ResultsCondensedCardTop.jsx
@@ -27,7 +27,7 @@ const ResultsCondensedCardTop = ({ type, position, toggleFavorite, favorites,
           }
         </div>
       </div>
-      <FontAwesome className="condensed-top-background-image" name={type === 'popular' ? 'building' : 'flag'} size="3x" />
+      <FontAwesome className="condensed-top-background-image" name={type === 'highlighted' ? 'building' : 'flag'} size="3x" />
       <div className="usa-width-one-whole condensed-card-last-updated">
         <span className="last-updated-title">Last Updated: </span>
         <span className="last-updated-date">

--- a/src/Components/ResultsCondensedCardTop/ResultsCondensedCardTop.test.jsx
+++ b/src/Components/ResultsCondensedCardTop/ResultsCondensedCardTop.test.jsx
@@ -55,13 +55,13 @@ describe('ResultsCondensedCardTopComponent', () => {
     const wrapper = shallow(
       <ResultsCondensedCardTop
         position={position}
-        type={'popular'}
+        type={'highlighted'}
         toggleFavorite={() => {}}
         userProfileFavoritePositionIsLoading={false}
         userProfileFavoritePositionHasErrored={false}
         favorites={favorites}
       />,
     );
-    expect(wrapper.instance().props.type).toBe('popular');
+    expect(wrapper.instance().props.type).toBe('highlighted');
   });
 });

--- a/src/Constants/DefaultProps.js
+++ b/src/Constants/DefaultProps.js
@@ -1,7 +1,7 @@
 export const ACCORDION_SELECTION = { main: '', sub: '' };
 
 export const DEFAULT_HOME_PAGE_POSITIONS = {
-  isPopular: [],
+  isHighlighted: [],
   isNew: [],
 };
 

--- a/src/Constants/PropTypes.js
+++ b/src/Constants/PropTypes.js
@@ -52,7 +52,7 @@ export const POSITION_SEARCH_RESULTS = PropTypes.shape({
 
 export const HOME_PAGE_POSITIONS = PropTypes.shape({
   isNew: POSITION_DETAILS_ARRAY,
-  isPopular: POSITION_DETAILS_ARRAY,
+  isHighlighted: POSITION_DETAILS_ARRAY,
 });
 
 export const FILTERS = PropTypes.arrayOf(

--- a/src/Containers/HomePage/HomePage.jsx
+++ b/src/Containers/HomePage/HomePage.jsx
@@ -5,7 +5,7 @@ import ENDPOINT_PARAMS from '../../Constants/EndpointParams';
 import ResultsSearchHeader from '../../Components/ResultsSearchHeader/ResultsSearchHeader';
 import Explore from '../../Components/Explore/Explore';
 import NewPositionsSection from '../../Components/NewPositionsSection';
-import PopularPositionsSection from '../../Components/PopularPositionsSection';
+import HighlightedPositionsSection from '../../Components/HighlightedPositionsSection';
 import Spinner from '../../Components/Spinner';
 
 class HomePage extends Component {
@@ -57,12 +57,12 @@ class HomePage extends Component {
             positions={homePagePositions.isNew}
             isLoading={homePagePositionsIsLoading}
           />
-          <PopularPositionsSection
+          <HighlightedPositionsSection
             favorites={userProfile.favorite_positions}
             toggleFavorite={toggleFavorite}
             userProfileFavoritePositionIsLoading={userProfileFavoritePositionIsLoading}
             userProfileFavoritePositionHasErrored={userProfileFavoritePositionHasErrored}
-            positions={homePagePositions.isPopular}
+            positions={homePagePositions.isHighlighted}
             isLoading={homePagePositionsIsLoading}
           />
         </div>

--- a/src/actions/homePagePositions.js
+++ b/src/actions/homePagePositions.js
@@ -26,20 +26,20 @@ export function homePagePositionsFetchData() {
     dispatch(homePagePositionsIsLoading(true));
     dispatch(homePagePositionsHasErrored(false));
 
-    const resultsTypes = { isPopular: [], isNew: [] };
+    const resultsTypes = { isHighlighted: [], isNew: [] };
 
-    // Have results been pushed to isPopular and isNew? If so, return success
+    // Have results been pushed to isHighlighted and isNew? If so, return success
     function checkForCompletion() {
-      if (resultsTypes.isPopular.length && resultsTypes.isNew.length) {
+      if (resultsTypes.isHighlighted.length && resultsTypes.isNew.length) {
         dispatch(homePagePositionsFetchDataSuccess(resultsTypes));
         dispatch(homePagePositionsIsLoading(false));
         dispatch(homePagePositionsHasErrored(false));
       }
     }
 
-    const queryTypes = [{ name: 'isPopular', query: 'limit=3' }, { name: 'isNew', query: 'ordering=create_date&limit=5' }];
+    const queryTypes = [{ name: 'isHighlighted', query: 'highlighted/?limit=3' }, { name: 'isNew', query: '?ordering=create_date&limit=5' }];
     queryTypes.forEach((type) => {
-      axios.get(`${api}/position/?${type.query}`)
+      axios.get(`${api}/position/${type.query}`)
               .then((response) => {
                 dispatch(homePagePositionsIsLoading(false));
                 resultsTypes[type.name] = response.data.results;

--- a/src/actions/homePagePositions.test.js
+++ b/src/actions/homePagePositions.test.js
@@ -16,7 +16,7 @@ describe('async actions', () => {
       resultsObject,
     );
 
-    mockAdapter.onGet('http://localhost:8000/api/v1/position/?limit=3').reply(200,
+    mockAdapter.onGet('http://localhost:8000/api/v1/position/highlighted/?limit=3').reply(200,
       resultsObject,
     );
   });

--- a/src/reducers/homePagePositions.js
+++ b/src/reducers/homePagePositions.js
@@ -1,4 +1,4 @@
-export const positions = { isPopular: [], isNew: [] };
+export const positions = { isHighlighted: [], isNew: [] };
 
 export function homePagePositionsHasErrored(state = false, action) {
   switch (action.type) {

--- a/src/reducers/homePagePositions.test.js
+++ b/src/reducers/homePagePositions.test.js
@@ -11,6 +11,6 @@ describe('reducers', () => {
 
   it('can set reducer HOME_PAGE_POSITIONS_FETCH_DATA_SUCCESS', () => {
     expect(reducers.homePagePositions(
-      {}, { type: 'HOME_PAGE_POSITIONS_FETCH_DATA_SUCCESS', results: { isPopular: ['test'], isNew: ['test'] } }).isPopular.length).toBe(1);
+      {}, { type: 'HOME_PAGE_POSITIONS_FETCH_DATA_SUCCESS', results: { isHighlighted: ['test'], isNew: ['test'] } }).isHighlighted.length).toBe(1);
   });
 });

--- a/src/sass/_condensedCard.scss
+++ b/src/sass/_condensedCard.scss
@@ -112,7 +112,7 @@
   float: left;
 }
 
-.condensed-card-popular {
+.condensed-card-highlighted {
   .condensed-card-top {
     background-color: $tm-navy;
   }


### PR DESCRIPTION
Changes "Popular" to "Highlighted" positions. Uses the `/position/highlighted/` endpoint to populate the card list. Currently there is no filter for Highlighted positions on the Results page, so "View More" directs to the base `/results` route to avoid confusion.