### PR TITLE
Saved searches tweaks

### DIFF
--- a/src/Components/Favorite/Favorite.jsx
+++ b/src/Components/Favorite/Favorite.jsx
@@ -37,7 +37,7 @@ class Favorite extends Component {
       // eslint-disable-next-line jsx-a11y/no-static-element-interactions
       <div
         tabIndex="0"
-        title={`${text} favorites`}
+        title={`${text} from favorites`}
         role="button"
         style={style}
         onClick={this.toggleSaved}

--- a/src/Components/Favorite/__snapshots__/Favorite.test.jsx.snap
+++ b/src/Components/Favorite/__snapshots__/Favorite.test.jsx.snap
@@ -12,7 +12,7 @@ exports[`Favorite matches snapshot 1`] = `
     }
   }
   tabIndex="0"
-  title="Favorite favorites"
+  title="Favorite from favorites"
 >
   <FontAwesome
     name="heart-o"

--- a/src/Components/ResultsContainer/ResultsContainer.jsx
+++ b/src/Components/ResultsContainer/ResultsContainer.jsx
@@ -16,7 +16,7 @@ const ResultsContainer = ({ results, isLoading, hasErrored, sortBy, pageCount, h
         defaultPageNumber, queryParamUpdate, onToggle, onQueryParamToggle, scrollToTop,
         toggleFavorite, userProfileFavoritePositionIsLoading, newSavedSearchHasErrored,
         userProfileFavoritePositionHasErrored, saveSearch, newSavedSearchSuccess,
-        currentSavedSearch,
+        currentSavedSearch, newSavedSearchIsSaving,
   }) => (
     <div className="results-container">
       {
@@ -32,6 +32,7 @@ const ResultsContainer = ({ results, isLoading, hasErrored, sortBy, pageCount, h
         newSavedSearchSuccess={newSavedSearchSuccess}
         newSavedSearchHasErrored={newSavedSearchHasErrored}
         currentSavedSearch={currentSavedSearch}
+        newSavedSearchIsSaving={newSavedSearchIsSaving}
       />
       <ResultsControls
         results={results}
@@ -113,6 +114,7 @@ ResultsContainer.propTypes = {
   saveSearch: PropTypes.func.isRequired,
   newSavedSearchSuccess: SAVED_SEARCH_MESSAGE.isRequired,
   newSavedSearchHasErrored: SAVED_SEARCH_MESSAGE.isRequired,
+  newSavedSearchIsSaving: PropTypes.bool.isRequired,
   currentSavedSearch: SAVED_SEARCH_OBJECT,
 };
 

--- a/src/Components/ResultsContainer/ResultsContainer.test.jsx
+++ b/src/Components/ResultsContainer/ResultsContainer.test.jsx
@@ -40,6 +40,7 @@ describe('ResultsContainerComponent', () => {
         saveSearch={() => {}}
         newSavedSearchSuccess={false}
         newSavedSearchHasErrored={false}
+        newSavedSearchIsSaving={false}
       />
     </MemoryRouter>);
     expect(wrapper).toBeDefined();
@@ -62,6 +63,7 @@ describe('ResultsContainerComponent', () => {
       saveSearch={() => {}}
       newSavedSearchSuccess={false}
       newSavedSearchHasErrored={false}
+      newSavedSearchIsSaving={false}
     />);
     expect(wrapper.instance().props.pageSizes).toBe(pageSizes);
   });
@@ -83,6 +85,7 @@ describe('ResultsContainerComponent', () => {
       saveSearch={() => {}}
       newSavedSearchSuccess={false}
       newSavedSearchHasErrored={false}
+      newSavedSearchIsSaving={false}
     />);
     expect(wrapper.instance().props.pageCount).toBe(20);
   });
@@ -104,6 +107,7 @@ describe('ResultsContainerComponent', () => {
       saveSearch={() => {}}
       newSavedSearchSuccess={false}
       newSavedSearchHasErrored={false}
+      newSavedSearchIsSaving={false}
     />);
     expect(toJSON(wrapper)).toMatchSnapshot();
   });

--- a/src/Components/ResultsContainer/__snapshots__/ResultsContainer.test.jsx.snap
+++ b/src/Components/ResultsContainer/__snapshots__/ResultsContainer.test.jsx.snap
@@ -11,6 +11,7 @@ exports[`ResultsContainerComponent matches snapshot 1`] = `
   <SaveNewSearchContainer
     currentSavedSearch={Object {}}
     newSavedSearchHasErrored={false}
+    newSavedSearchIsSaving={false}
     newSavedSearchSuccess={false}
     saveSearch={[Function]}
   />

--- a/src/Components/ResultsPage/ResultsPage.jsx
+++ b/src/Components/ResultsPage/ResultsPage.jsx
@@ -31,7 +31,7 @@ class Results extends Component {
             defaultPageNumber, onQueryParamUpdate, filters, userProfile, toggleFavorite,
             selectedAccordion, setAccordion, scrollToTop, userProfileFavoritePositionIsLoading,
             userProfileFavoritePositionHasErrored, saveSearch, newSavedSearchSuccess,
-            newSavedSearchHasErrored, currentSavedSearch }
+            newSavedSearchHasErrored, currentSavedSearch, newSavedSearchIsSaving }
       = this.props;
     const hasLoaded = !isLoading && results.results && !!results.results.length;
     const pageCount = Math.ceil(results.count / defaultPageSize);
@@ -84,6 +84,7 @@ class Results extends Component {
             saveSearch={saveSearch}
             newSavedSearchSuccess={newSavedSearchSuccess}
             newSavedSearchHasErrored={newSavedSearchHasErrored}
+            newSavedSearchIsSaving={newSavedSearchIsSaving}
             currentSavedSearch={currentSavedSearch}
           />
         </div>
@@ -118,6 +119,7 @@ Results.propTypes = {
   saveSearch: PropTypes.func.isRequired,
   newSavedSearchSuccess: SAVED_SEARCH_MESSAGE.isRequired,
   newSavedSearchHasErrored: SAVED_SEARCH_MESSAGE.isRequired,
+  newSavedSearchIsSaving: PropTypes.bool.isRequired,
   currentSavedSearch: SAVED_SEARCH_OBJECT,
 };
 

--- a/src/Components/ResultsPage/ResultsPage.test.jsx
+++ b/src/Components/ResultsPage/ResultsPage.test.jsx
@@ -41,6 +41,7 @@ describe('ResultsPageComponent', () => {
       saveSearch={() => {}}
       newSavedSearchSuccess={false}
       newSavedSearchHasErrored={false}
+      newSavedSearchIsSaving={false}
     />);
     expect(wrapper).toBeDefined();
   });
@@ -66,6 +67,7 @@ describe('ResultsPageComponent', () => {
       saveSearch={() => {}}
       newSavedSearchSuccess={false}
       newSavedSearchHasErrored={false}
+      newSavedSearchIsSaving={false}
     />);
     expect(wrapper.instance().props.results.results[0].id).toBe(6);
   });
@@ -90,6 +92,7 @@ describe('ResultsPageComponent', () => {
       saveSearch={() => {}}
       newSavedSearchSuccess={false}
       newSavedSearchHasErrored={false}
+      newSavedSearchIsSaving={false}
     />);
     expect(wrapper).toBeDefined();
   });
@@ -113,6 +116,7 @@ describe('ResultsPageComponent', () => {
       saveSearch={() => {}}
       newSavedSearchSuccess={false}
       newSavedSearchHasErrored={false}
+      newSavedSearchIsSaving={false}
     />);
     wrapper.instance().onChildToggle();
     expect(wrapper).toBeDefined();

--- a/src/Components/SaveNewSearchContainer/SaveNewSearchContainer.jsx
+++ b/src/Components/SaveNewSearchContainer/SaveNewSearchContainer.jsx
@@ -38,9 +38,9 @@ class SaveNewSearchContainer extends Component {
 
   render() {
     const { showInput } = this.state;
-    const { newSavedSearchHasErrored, currentSavedSearch } = this.props;
+    const { newSavedSearchHasErrored, currentSavedSearch, newSavedSearchIsSaving } = this.props;
     return (
-      <div className="usa-grid-full save-new-search-container">
+      <div className={`usa-grid-full save-new-search-container ${newSavedSearchIsSaving ? 'results-loading' : ''}`}>
         {
           showInput.value ?
           (
@@ -67,6 +67,7 @@ class SaveNewSearchContainer extends Component {
 SaveNewSearchContainer.propTypes = {
   saveSearch: PropTypes.func.isRequired,
   newSavedSearchHasErrored: SAVED_SEARCH_MESSAGE.isRequired,
+  newSavedSearchIsSaving: PropTypes.bool.isRequired,
   currentSavedSearch: SAVED_SEARCH_OBJECT,
 };
 

--- a/src/Components/SaveNewSearchContainer/SaveNewSearchContainer.test.jsx
+++ b/src/Components/SaveNewSearchContainer/SaveNewSearchContainer.test.jsx
@@ -13,6 +13,7 @@ describe('SaveNewSearchContainerComponent', () => {
         saveSearch={() => {}}
         newSavedSearchHasErrored="message"
         newSavedSearchSuccess={false}
+        newSavedSearchIsSaving={false}
       />,
     );
     expect(wrapper).toBeDefined();
@@ -25,6 +26,7 @@ describe('SaveNewSearchContainerComponent', () => {
         saveSearch={() => {}}
         newSavedSearchHasErrored={false}
         newSavedSearchSuccess="success"
+        newSavedSearchIsSaving={false}
       />,
     );
     expect(wrapper.instance().props.newSavedSearchSuccess).toBe(success);
@@ -37,6 +39,7 @@ describe('SaveNewSearchContainerComponent', () => {
         saveSearch={spy}
         newSavedSearchHasErrored={false}
         newSavedSearchSuccess="success"
+        newSavedSearchIsSaving={false}
       />,
     );
     wrapper.instance().props.saveSearch();
@@ -49,6 +52,7 @@ describe('SaveNewSearchContainerComponent', () => {
         saveSearch={() => {}}
         newSavedSearchHasErrored={false}
         newSavedSearchSuccess={false}
+        newSavedSearchIsSaving={false}
       />,
     );
     expect(wrapper.instance().state.showInput.value).toBe(false);
@@ -63,6 +67,7 @@ describe('SaveNewSearchContainerComponent', () => {
         saveSearch={() => {}}
         newSavedSearchHasErrored={false}
         newSavedSearchSuccess="success"
+        newSavedSearchIsSaving={false}
       />,
     );
     wrapper.instance().changeNewSearchName(text);
@@ -77,6 +82,7 @@ describe('SaveNewSearchContainerComponent', () => {
         saveSearch={(e) => { textToChange.value = e; }}
         newSavedSearchHasErrored={false}
         newSavedSearchSuccess="success"
+        newSavedSearchIsSaving={false}
       />,
     );
     wrapper.instance().changeNewSearchName(text);
@@ -90,6 +96,7 @@ describe('SaveNewSearchContainerComponent', () => {
         saveSearch={() => {}}
         newSavedSearchHasErrored="message"
         newSavedSearchSuccess={false}
+        newSavedSearchIsSaving={false}
       />,
     );
     expect(toJSON(wrapper)).toMatchSnapshot();

--- a/src/Components/SaveNewSearchContainer/__snapshots__/SaveNewSearchContainer.test.jsx.snap
+++ b/src/Components/SaveNewSearchContainer/__snapshots__/SaveNewSearchContainer.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`SaveNewSearchContainerComponent matches snapshot 1`] = `
 <div
-  className="usa-grid-full save-new-search-container"
+  className="usa-grid-full save-new-search-container "
 >
   <SaveNewSearchPrompt
     currentSavedSearch={Object {}}

--- a/src/Components/SavedSearches/SavedSearches.jsx
+++ b/src/Components/SavedSearches/SavedSearches.jsx
@@ -11,7 +11,10 @@ const SavedSearches = ({ savedSearches, savedSearchesIsLoading,
   deleteSavedSearchIsLoading, deleteSavedSearchHasErrored, deleteSavedSearchSuccess,
   cloneSavedSearch, cloneSavedSearchIsLoading, cloneSavedSearchHasErrored,
   cloneSavedSearchSuccess }) => (
-    <div className={`usa-grid-full saved-searches-container ${savedSearchesIsLoading ? 'results-loading' : ''}`}>
+    <div
+      className={`usa-grid-full saved-searches-container
+      ${(savedSearchesIsLoading || cloneSavedSearchIsLoading) ? 'results-loading' : ''}`}
+    >
       <ProfileSectionTitle title="Your Saved Searches:" />
       {
         // Deleting a saved search has errored

--- a/src/Components/SavedSearches/__snapshots__/SavedSearches.test.jsx.snap
+++ b/src/Components/SavedSearches/__snapshots__/SavedSearches.test.jsx.snap
@@ -2,7 +2,8 @@
 
 exports[`SavedSearchesComponent matches snapshot 1`] = `
 <div
-  className="usa-grid-full saved-searches-container "
+  className="usa-grid-full saved-searches-container
+      "
 >
   <ProfileSectionTitle
     title="Your Saved Searches:"

--- a/src/Constants/DefaultProps.js
+++ b/src/Constants/DefaultProps.js
@@ -7,7 +7,7 @@ export const DEFAULT_HOME_PAGE_POSITIONS = {
 
 export const DEFAULT_USER_PROFILE = {
   user: {
-    username: '',
+    username: '...', // show '...' when loading
   },
   favorite_positions: [],
 };


### PR DESCRIPTION
Makes some tweaks to Saved Searches - mainly just disabling the input with CSS when things are loading, to prevent an accidental double click. Also fixes the `title` tag for Favorites.