### PR TITLE
Use new API routes for Favoriting

### DIFF
--- a/src/Containers/Profile/Profile.jsx
+++ b/src/Containers/Profile/Profile.jsx
@@ -158,7 +158,7 @@ const mapDispatchToProps = dispatch => ({
   fetchData: () => dispatch(favoritePositionsFetchData()),
   onNavigateTo: dest => dispatch(push(dest)),
   toggleFavorite: (id, remove) =>
-    // Since this page reference the full Favorites route, pass true to explicitly refresh them
+    // Since this page references the full Favorites route, pass true to explicitly refresh them
     dispatch(userProfileToggleFavoritePosition(id, remove, true)),
   savedSearchesFetchData: () => dispatch(savedSearchActions.savedSearchesFetchData()),
   setCurrentSavedSearch: e => dispatch(savedSearchActions.setCurrentSavedSearch(e)),

--- a/src/Containers/Profile/Profile.jsx
+++ b/src/Containers/Profile/Profile.jsx
@@ -157,7 +157,9 @@ const mapStateToProps = (state, ownProps) => ({
 const mapDispatchToProps = dispatch => ({
   fetchData: () => dispatch(favoritePositionsFetchData()),
   onNavigateTo: dest => dispatch(push(dest)),
-  toggleFavorite: (id, remove) => dispatch(userProfileToggleFavoritePosition(id, remove)),
+  toggleFavorite: (id, remove) =>
+    // Since this page reference the full Favorites route, pass true to explicitly refresh them
+    dispatch(userProfileToggleFavoritePosition(id, remove, true)),
   savedSearchesFetchData: () => dispatch(savedSearchActions.savedSearchesFetchData()),
   setCurrentSavedSearch: e => dispatch(savedSearchActions.setCurrentSavedSearch(e)),
   deleteSearch: id => dispatch(savedSearchActions.deleteSavedSearch(id)),

--- a/src/Containers/Results/Results.jsx
+++ b/src/Containers/Results/Results.jsx
@@ -319,7 +319,11 @@ const mapDispatchToProps = dispatch => ({
     dispatch(filtersFetchData(items, queryParams, savedFilters)),
   setAccordion: accordion => dispatch(setSelectedAccordion(accordion)),
   onNavigateTo: dest => dispatch(push(dest)),
-  toggleFavorite: (id, remove) => dispatch(userProfileToggleFavoritePosition(id, remove)),
+  toggleFavorite: (id, remove) =>
+    // We don't need to pull the full Favorite Positions route, since
+    // all we want to do is check that they exist in the profile, so
+    // we pass false
+    dispatch(userProfileToggleFavoritePosition(id, remove, false)),
   saveSearch: (object, id) => dispatch(saveSearch(object, id)),
   routeChangeResetState: () => dispatch(routeChangeResetState()),
 });

--- a/src/Containers/Results/Results.jsx
+++ b/src/Containers/Results/Results.jsx
@@ -322,8 +322,8 @@ const mapDispatchToProps = dispatch => ({
   toggleFavorite: (id, remove) =>
     // We don't need to pull the full Favorite Positions route, since
     // all we want to do is check that they exist in the profile, so
-    // we pass false
-    dispatch(userProfileToggleFavoritePosition(id, remove, false)),
+    // we don't pass the refreshFavorites arg
+    dispatch(userProfileToggleFavoritePosition(id, remove)),
   saveSearch: (object, id) => dispatch(saveSearch(object, id)),
   routeChangeResetState: () => dispatch(routeChangeResetState()),
 });

--- a/src/actions/userProfile.js
+++ b/src/actions/userProfile.js
@@ -62,37 +62,30 @@ export function userProfileFetchData(bypass) {
 // what we're actually doing.
 // We also want to refresh their favorites, in case they made changes on another page.
 // Since we have to pass the entire array to the API, we want to make sure it's accurate.
-export function userProfileToggleFavoritePosition(id, remove) {
+// If we need a full refresh of Favorite Positions, such as for the profile's favorite sub-section,
+// we can pass a third arg, refreshFavorites.
+export function userProfileToggleFavoritePosition(id, remove, refreshFavorites) {
   const idString = id.toString();
   return (dispatch) => {
     dispatch(userProfileFavoritePositionIsLoading(true));
     dispatch(userProfileFavoritePositionHasErrored(false));
-    axios.get(`${api}/profile/`, { headers: { Authorization: fetchUserToken() } })
-            .then(response => response.data)
-            .then((userProfile) => {
-              // the user's refreshed favorites, mapped down to an array of IDs
-              const favorites = userProfile.favorite_positions.map(f => f.id.toString());
-              // convert the array to a Set
-              const favoritesSet = new Set(favorites);
-              // did we explicitly call to remove this position?
-              if (remove) {
-                // if so, remove it
-                favoritesSet.delete(idString);
-              } else if (!remove) { // did we call to add the position?
-                favoritesSet.add(idString);
+    let action = 'put';
+    if (remove) {
+      action = 'delete';
+    }
+    const auth = { headers: { Authorization: fetchUserToken() } };
+    // now we can patch our profile with the new favorites
+    // axios is a little weird here in that for PUTs, it expect a body as the second argument,
+    // whereas for DELETEs, it expects the headers object...
+    // so we have to conditionally decide what position to put the headers object in
+    axios[action](`${api}/position/${idString}/favorite/`, action === 'delete' ? auth : {}, action === 'put' ? auth : null)
+            .then(() => {
+              dispatch(userProfileFetchData(true));
+              dispatch(userProfileFavoritePositionIsLoading(false));
+              dispatch(userProfileFavoritePositionHasErrored(false));
+              if (refreshFavorites) {
+                dispatch(favoritePositionsFetchData());
               }
-              // make sure we have a clean object with no other params
-              const favoritesObject = Object.assign({}, { favorite_positions: favoritesSet });
-              // now we can patch our profile with the new favorites
-              axios.patch(`${api}/profile/`, favoritesObject, { headers: { Authorization: fetchUserToken() } })
-                      .then(() => {
-                        dispatch(userProfileFetchData(true));
-                        dispatch(favoritePositionsFetchData());
-                      })
-                      .catch(() => {
-                        dispatch(userProfileFavoritePositionHasErrored(true));
-                        dispatch(userProfileFavoritePositionIsLoading(false));
-                      });
             })
             .catch(() => {
               dispatch(userProfileFavoritePositionHasErrored(true));

--- a/src/actions/userProfile.js
+++ b/src/actions/userProfile.js
@@ -64,7 +64,7 @@ export function userProfileFetchData(bypass) {
 // Since we have to pass the entire array to the API, we want to make sure it's accurate.
 // If we need a full refresh of Favorite Positions, such as for the profile's favorite sub-section,
 // we can pass a third arg, refreshFavorites.
-export function userProfileToggleFavoritePosition(id, remove, refreshFavorites) {
+export function userProfileToggleFavoritePosition(id, remove, refreshFavorites = false) {
   const idString = id.toString();
   return (dispatch) => {
     dispatch(userProfileFavoritePositionIsLoading(true));
@@ -74,11 +74,13 @@ export function userProfileToggleFavoritePosition(id, remove, refreshFavorites) 
       action = 'delete';
     }
     const auth = { headers: { Authorization: fetchUserToken() } };
-    // now we can patch our profile with the new favorites
-    // axios is a little weird here in that for PUTs, it expect a body as the second argument,
+    // Now we can patch our profile with the new favorites.
+    // Axios is a little weird here in that for PUTs, it expects a body as the second argument,
     // whereas for DELETEs, it expects the headers object...
-    // so we have to conditionally decide what position to put the headers object in
-    axios[action](`${api}/position/${idString}/favorite/`, action === 'delete' ? auth : {}, action === 'put' ? auth : null)
+    // so we have to conditionally decide what position to put the headers object in.
+    const firstArg = action === 'delete' ? auth : {};
+    const secondArg = action === 'put' ? auth : null;
+    axios[action](`${api}/position/${idString}/favorite/`, firstArg, secondArg)
             .then(() => {
               dispatch(userProfileFetchData(true));
               dispatch(userProfileFavoritePositionIsLoading(false));

--- a/src/actions/userProfile.test.js
+++ b/src/actions/userProfile.test.js
@@ -44,17 +44,13 @@ describe('async actions', () => {
 
     const mockAdapter = new MockAdapter(axios);
 
-    mockAdapter.onGet('http://localhost:8000/api/v1/profile/').reply(200,
-      profile,
-    );
-
-    mockAdapter.onPatch('http://localhost:8000/api/v1/profile/').reply(200,
-      Object.assign({}, { favorite_positions: [] }),
+    mockAdapter.onDelete('http://localhost:8000/api/v1/position/1/favorite/').reply(204,
+      null,
     );
 
     const f = () => {
       setTimeout(() => {
-        store.dispatch(actions.userProfileToggleFavoritePosition('1', true));
+        store.dispatch(actions.userProfileToggleFavoritePosition('1', true, true));
         done();
       }, 0);
     };
@@ -66,39 +62,13 @@ describe('async actions', () => {
 
     const mockAdapter = new MockAdapter(axios);
 
-    mockAdapter.onGet('http://localhost:8000/api/v1/profile/').reply(200,
-      profile,
-    );
-
-    mockAdapter.onPatch('http://localhost:8000/api/v1/profile/').reply(200,
-      Object.assign({}, { favorite_positions: profile.favorite_positions }),
+    mockAdapter.onPut('http://localhost:8000/api/v1/position/1/favorite/').reply(204,
+      null,
     );
 
     const f = () => {
       setTimeout(() => {
-        store.dispatch(actions.userProfileToggleFavoritePosition('2'));
-        done();
-      }, 0);
-    };
-    f();
-  });
-
-  it('can handle favoriting errors when the profile fails', (done) => {
-    const store = mockStore({ profile: {} });
-
-    const mockAdapter = new MockAdapter(axios);
-
-    mockAdapter.onGet('http://localhost:8000/api/v1/profile/').reply(404,
-      {},
-    );
-
-    mockAdapter.onPatch('http://localhost:8000/api/v1/profile/').reply(404,
-      {},
-    );
-
-    const f = () => {
-      setTimeout(() => {
-        store.dispatch(actions.userProfileToggleFavoritePosition('2'));
+        store.dispatch(actions.userProfileToggleFavoritePosition('1', false, true));
         done();
       }, 0);
     };
@@ -110,17 +80,13 @@ describe('async actions', () => {
 
     const mockAdapter = new MockAdapter(axios);
 
-    mockAdapter.onGet('http://localhost:8000/api/v1/profile/').reply(200,
-      profile,
-    );
-
-    mockAdapter.onPatch('http://localhost:8000/api/v1/profile/').reply(404,
-      {},
+    mockAdapter.onPut('http://localhost:8000/api/v1/position/1/favorite/').reply(404,
+      null,
     );
 
     const f = () => {
       setTimeout(() => {
-        store.dispatch(actions.userProfileToggleFavoritePosition('2'));
+        store.dispatch(actions.userProfileToggleFavoritePosition('1', false, true));
         done();
       }, 0);
     };


### PR DESCRIPTION
Addresses #705 (and implicitly #704) by updating actions to use new ID-based API calls, `PUT/DELETE /api/v1/position/{id}/favorite/`.