### PR TITLE
Sorting function consolidation

### DIFF
--- a/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.jsx
+++ b/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.jsx
@@ -5,7 +5,7 @@ import MultiSelectFilter from '../MultiSelectFilter/MultiSelectFilter';
 import BooleanFilterContainer from '../BooleanFilterContainer/BooleanFilterContainer';
 import LanguageFilter from '../LanguageFilter/LanguageFilter';
 import { FILTER_ITEMS_ARRAY, ACCORDION_SELECTION_OBJECT } from '../../../Constants/PropTypes';
-import { descriptionSort } from '../../../utilities';
+import { propSort } from '../../../utilities';
 
 class SearchFiltersContainer extends Component {
 
@@ -56,7 +56,7 @@ class SearchFiltersContainer extends Component {
       if (multiSelectFilterNames.indexOf(f.item.description) > -1) {
         // extra handling for skill
         if (f.item.description === 'skill') {
-          f.data.sort(descriptionSort);
+          f.data.sort(propSort('description'));
         }
         // add to Map
         multiSelectFilterMap.set(f.item.description, f);

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -47,30 +47,19 @@ export function fetchUserToken() {
   return token;
 }
 
-// keep sort functions separate in case we want to adjust the logic for some but not others
-export const titleSort = (a, b) => {
-  const A = a.title.toLowerCase();
-  const B = b.title.toLowerCase();
-  if (A < B) { // sort string ascending
-    return -1;
-  }
-  if (A > B) { return 1; }
-  return 0; // default return value (no sorting)
-};
-
-export const descriptionSort = (a, b) => {
-  const A = a.description.toLowerCase();
-  const B = b.description.toLowerCase();
-  if (A < B) { // sort string ascending
-    return -1;
-  }
-  if (A > B) { return 1; }
-  return 0; // default return value (no sorting)
-};
-
 export const pillSort = (a, b) => {
   const A = (a.description || a.code).toLowerCase();
   const B = (b.description || b.code).toLowerCase();
+  if (A < B) { // sort string ascending
+    return -1;
+  }
+  if (A > B) { return 1; }
+  return 0; // default return value (no sorting)
+};
+
+export const propSort = propName => (a, b) => {
+  const A = a[propName].toLowerCase();
+  const B = b[propName].toLowerCase();
   if (A < B) { // sort string ascending
     return -1;
   }

--- a/src/utilities.test.js
+++ b/src/utilities.test.js
@@ -2,8 +2,6 @@ import { validStateEmail,
          localStorageFetchValue,
          localStorageToggleValue,
          fetchUserToken,
-         descriptionSort,
-         titleSort,
          pillSort,
          formExploreRegionDropdown,
          scrollToTop,
@@ -12,6 +10,7 @@ import { validStateEmail,
          cleanQueryParams,
          ifEnter,
          formQueryString,
+         propSort,
        } from './utilities';
 
 describe('local storage', () => {
@@ -82,15 +81,15 @@ describe('sort functions', () => {
   const pills = [{ description: 'a' }, { code: 'b' }];
 
   it('can sort by description', () => {
-    expect(descriptionSort(items[0], items[1])).toBe(-1);
-    expect(descriptionSort(items[1], items[0])).toBe(1);
-    expect(descriptionSort(items[0], items[0])).toBe(0);
+    expect(propSort('description')(items[0], items[1])).toBe(-1);
+    expect(propSort('description')(items[1], items[0])).toBe(1);
+    expect(propSort('description')(items[0], items[0])).toBe(0);
   });
 
   it('can sort by title', () => {
-    expect(titleSort(items[0], items[1])).toBe(-1);
-    expect(titleSort(items[1], items[0])).toBe(1);
-    expect(titleSort(items[0], items[0])).toBe(0);
+    expect(propSort('title')(items[0], items[1])).toBe(-1);
+    expect(propSort('title')(items[1], items[0])).toBe(1);
+    expect(propSort('title')(items[0], items[0])).toBe(0);
   });
 
   it('can sort by description or code', () => {


### PR DESCRIPTION
Closes #463. I kept the `pillSort` function separate since it contains the additional logic `a.description || a.code`.