### PR TITLE
Add Dismiss component

### DIFF
--- a/src/Components/Dismiss/Dismiss.jsx
+++ b/src/Components/Dismiss/Dismiss.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import FontAwesome from 'react-fontawesome';
+
+const Dismiss = ({ children, onDismiss, className, buttonClassName, buttonTitle }) => (
+  <div className={`usa-grid-full ${className}`}>
+    {children}
+    <button className={buttonClassName} title={buttonTitle} onClick={onDismiss}>
+      <FontAwesome name="close" />
+    </button>
+  </div>
+  );
+
+Dismiss.propTypes = {
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string, // optional class to apply to the container
+  buttonClassName: PropTypes.string, // optional class to apply to the dismiss button
+  onDismiss: PropTypes.func.isRequired,
+  buttonTitle: PropTypes.string,
+};
+
+Dismiss.defaultProps = {
+  className: 'dismiss-container',
+  buttonClassName: 'dismiss-button',
+  buttonTitle: 'Dismiss this alert',
+};
+
+export default Dismiss;

--- a/src/Components/Dismiss/Dismiss.jsx
+++ b/src/Components/Dismiss/Dismiss.jsx
@@ -7,6 +7,7 @@ const Dismiss = ({ children, onDismiss, className, buttonClassName, buttonTitle 
     {children}
     <button className={buttonClassName} title={buttonTitle} onClick={onDismiss}>
       <FontAwesome name="close" />
+      <span className="usa-sr-only">{buttonTitle}</span>
     </button>
   </div>
   );

--- a/src/Components/Dismiss/Dismiss.test.jsx
+++ b/src/Components/Dismiss/Dismiss.test.jsx
@@ -1,0 +1,56 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import sinon from 'sinon';
+import toJSON from 'enzyme-to-json';
+import Dismiss from './Dismiss';
+
+describe('DismissComponent', () => {
+  const child = (
+    <div>
+      <span>My content</span>
+    </div>
+  );
+
+  it('can receive props', () => {
+    const title = 'click';
+    const wrapper = shallow(
+      <Dismiss onDismiss={() => {}} buttonTitle={title}>
+        {child}
+      </Dismiss>,
+    );
+    expect(wrapper.instance().props.children).toBe(child);
+    expect(wrapper.instance().props.buttonTitle).toBe(title);
+  });
+
+  it('can render classes', () => {
+    const className = 'class1';
+    const buttonClassName = 'class2';
+    const wrapper = shallow(
+      <Dismiss onDismiss={() => {}} className={className} buttonClassName={buttonClassName}>
+        {child}
+      </Dismiss>,
+    );
+    expect(wrapper.find(`.${className}`).exists()).toBe(true);
+    expect(wrapper.find(`.${buttonClassName}`).exists()).toBe(true);
+  });
+
+  it('can click the button', () => {
+    const spy = sinon.spy();
+    const wrapper = shallow(
+      <Dismiss onDismiss={spy}>
+        {child}
+      </Dismiss>,
+    );
+    wrapper.find('button').simulate('click');
+    sinon.assert.calledOnce(spy);
+  });
+
+  it('matches snapshot', () => {
+    const wrapper = shallow(
+      <Dismiss onDismiss={() => {}}>
+        {child}
+      </Dismiss>,
+    );
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/Components/Dismiss/__snapshots__/Dismiss.test.jsx.snap
+++ b/src/Components/Dismiss/__snapshots__/Dismiss.test.jsx.snap
@@ -17,6 +17,11 @@ exports[`DismissComponent matches snapshot 1`] = `
     <FontAwesome
       name="close"
     />
+    <span
+      className="usa-sr-only"
+    >
+      Dismiss this alert
+    </span>
   </button>
 </div>
 `;

--- a/src/Components/Dismiss/__snapshots__/Dismiss.test.jsx.snap
+++ b/src/Components/Dismiss/__snapshots__/Dismiss.test.jsx.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DismissComponent matches snapshot 1`] = `
+<div
+  className="usa-grid-full dismiss-container"
+>
+  <div>
+    <span>
+      My content
+    </span>
+  </div>
+  <button
+    className="dismiss-button"
+    onClick={[Function]}
+    title="Dismiss this alert"
+  >
+    <FontAwesome
+      name="close"
+    />
+  </button>
+</div>
+`;

--- a/src/Components/Dismiss/index.js
+++ b/src/Components/Dismiss/index.js
@@ -1,0 +1,1 @@
+export { default } from './Dismiss';

--- a/src/Components/ResultsContainer/ResultsContainer.jsx
+++ b/src/Components/ResultsContainer/ResultsContainer.jsx
@@ -10,6 +10,7 @@ import ResultsControls from '../ResultsControls/ResultsControls';
 import ResultsPillContainer from '../ResultsPillContainer/ResultsPillContainer';
 import SaveNewSearchContainer from '../SaveNewSearchContainer';
 import SaveNewSearchAlert from '../SaveNewSearchAlert';
+import Dismiss from '../Dismiss';
 
 class ResultsContainer extends Component {
   constructor(props) {
@@ -28,13 +29,15 @@ class ResultsContainer extends Component {
             defaultPageNumber, queryParamUpdate, onToggle, onQueryParamToggle,
             toggleFavorite, userProfileFavoritePositionIsLoading, newSavedSearchHasErrored,
             userProfileFavoritePositionHasErrored, saveSearch, newSavedSearchSuccess,
-            currentSavedSearch, newSavedSearchIsSaving,
+            currentSavedSearch, newSavedSearchIsSaving, resetSavedSearchAlerts,
       } = this.props;
     return (
       <div className="results-container">
         {
           newSavedSearchSuccess &&
-          <SaveNewSearchAlert newSavedSearchSuccess={newSavedSearchSuccess} />
+          <Dismiss onDismiss={resetSavedSearchAlerts}>
+            <SaveNewSearchAlert newSavedSearchSuccess={newSavedSearchSuccess} />
+          </Dismiss>
         }
         <ResultsPillContainer
           items={pillFilters}
@@ -127,6 +130,7 @@ ResultsContainer.propTypes = {
   newSavedSearchHasErrored: SAVED_SEARCH_MESSAGE.isRequired,
   newSavedSearchIsSaving: PropTypes.bool.isRequired,
   currentSavedSearch: SAVED_SEARCH_OBJECT,
+  resetSavedSearchAlerts: PropTypes.func.isRequired,
 };
 
 ResultsContainer.defaultProps = {

--- a/src/Components/ResultsContainer/ResultsContainer.test.jsx
+++ b/src/Components/ResultsContainer/ResultsContainer.test.jsx
@@ -42,6 +42,7 @@ describe('ResultsContainerComponent', () => {
         newSavedSearchSuccess={false}
         newSavedSearchHasErrored={false}
         newSavedSearchIsSaving={false}
+        resetSavedSearchAlerts={() => {}}
       />
     </MemoryRouter>);
     expect(wrapper).toBeDefined();
@@ -65,6 +66,7 @@ describe('ResultsContainerComponent', () => {
       newSavedSearchSuccess={false}
       newSavedSearchHasErrored={false}
       newSavedSearchIsSaving={false}
+      resetSavedSearchAlerts={() => {}}
     />);
     expect(wrapper.instance().props.pageSizes).toBe(pageSizes);
   });
@@ -87,6 +89,7 @@ describe('ResultsContainerComponent', () => {
       newSavedSearchSuccess={false}
       newSavedSearchHasErrored={false}
       newSavedSearchIsSaving={false}
+      resetSavedSearchAlerts={() => {}}
     />);
     expect(wrapper.instance().props.pageCount).toBe(20);
   });
@@ -112,6 +115,7 @@ describe('ResultsContainerComponent', () => {
       newSavedSearchHasErrored={false}
       newSavedSearchIsSaving={false}
       scrollToTop={scrollSpy}
+      resetSavedSearchAlerts={() => {}}
     />);
     wrapper.instance().onPageChange(1);
     sinon.assert.calledOnce(spy);
@@ -136,6 +140,7 @@ describe('ResultsContainerComponent', () => {
       newSavedSearchSuccess={false}
       newSavedSearchHasErrored={false}
       newSavedSearchIsSaving={false}
+      resetSavedSearchAlerts={() => {}}
     />);
     expect(toJSON(wrapper)).toMatchSnapshot();
   });

--- a/src/Components/ResultsPage/ResultsPage.jsx
+++ b/src/Components/ResultsPage/ResultsPage.jsx
@@ -31,7 +31,8 @@ class Results extends Component {
             defaultPageNumber, onQueryParamUpdate, filters, userProfile, toggleFavorite,
             selectedAccordion, setAccordion, scrollToTop, userProfileFavoritePositionIsLoading,
             userProfileFavoritePositionHasErrored, saveSearch, newSavedSearchSuccess,
-            newSavedSearchHasErrored, currentSavedSearch, newSavedSearchIsSaving }
+            newSavedSearchHasErrored, currentSavedSearch, newSavedSearchIsSaving,
+            resetSavedSearchAlerts }
       = this.props;
     const hasLoaded = !isLoading && results.results && !!results.results.length;
     const pageCount = Math.ceil(results.count / defaultPageSize);
@@ -86,6 +87,7 @@ class Results extends Component {
             newSavedSearchHasErrored={newSavedSearchHasErrored}
             newSavedSearchIsSaving={newSavedSearchIsSaving}
             currentSavedSearch={currentSavedSearch}
+            resetSavedSearchAlerts={resetSavedSearchAlerts}
           />
         </div>
       </div>
@@ -121,6 +123,7 @@ Results.propTypes = {
   newSavedSearchHasErrored: SAVED_SEARCH_MESSAGE.isRequired,
   newSavedSearchIsSaving: PropTypes.bool.isRequired,
   currentSavedSearch: SAVED_SEARCH_OBJECT,
+  resetSavedSearchAlerts: PropTypes.func.isRequired,
 };
 
 Results.defaultProps = {

--- a/src/Components/ResultsPage/ResultsPage.test.jsx
+++ b/src/Components/ResultsPage/ResultsPage.test.jsx
@@ -42,6 +42,7 @@ describe('ResultsPageComponent', () => {
       newSavedSearchSuccess={false}
       newSavedSearchHasErrored={false}
       newSavedSearchIsSaving={false}
+      resetSavedSearchAlerts={() => {}}
     />);
     expect(wrapper).toBeDefined();
   });
@@ -68,6 +69,7 @@ describe('ResultsPageComponent', () => {
       newSavedSearchSuccess={false}
       newSavedSearchHasErrored={false}
       newSavedSearchIsSaving={false}
+      resetSavedSearchAlerts={() => {}}
     />);
     expect(wrapper.instance().props.results.results[0].id).toBe(6);
   });
@@ -93,6 +95,7 @@ describe('ResultsPageComponent', () => {
       newSavedSearchSuccess={false}
       newSavedSearchHasErrored={false}
       newSavedSearchIsSaving={false}
+      resetSavedSearchAlerts={() => {}}
     />);
     expect(wrapper).toBeDefined();
   });
@@ -117,6 +120,7 @@ describe('ResultsPageComponent', () => {
       newSavedSearchSuccess={false}
       newSavedSearchHasErrored={false}
       newSavedSearchIsSaving={false}
+      resetSavedSearchAlerts={() => {}}
     />);
     wrapper.instance().onChildToggle();
     expect(wrapper).toBeDefined();

--- a/src/Containers/Results/Results.jsx
+++ b/src/Containers/Results/Results.jsx
@@ -37,7 +37,7 @@ class Results extends Component {
     const { query, defaultSort, defaultPageSize, defaultPageNumber, defaultKeyword,
             defaultLocation } = this.state;
     // clear out old alert messages
-    this.props.routeChangeResetState();
+    this.props.resetSavedSearchAlerts();
     // check auth
     if (!this.props.isAuthorized()) {
       this.props.onNavigateTo(PUBLIC_ROOT);
@@ -209,7 +209,7 @@ class Results extends Component {
   render() {
     const { results, hasErrored, isLoading, filters, toggleFavorite,
             selectedAccordion, setAccordion, userProfile,
-            userProfileFavoritePositionIsLoading,
+            userProfileFavoritePositionIsLoading, resetSavedSearchAlerts,
             userProfileFavoritePositionHasErrored, currentSavedSearch,
             newSavedSearchSuccess, newSavedSearchIsSaving, newSavedSearchHasErrored } = this.props;
     return (
@@ -242,6 +242,7 @@ class Results extends Component {
           newSavedSearchHasErrored={newSavedSearchHasErrored}
           saveSearch={this.saveSearch}
           currentSavedSearch={currentSavedSearch}
+          resetSavedSearchAlerts={resetSavedSearchAlerts}
         />
       </div>
     );
@@ -269,7 +270,7 @@ Results.propTypes = {
   newSavedSearchHasErrored: PROP_TYPES.SAVED_SEARCH_MESSAGE,
   saveSearch: PropTypes.func.isRequired,
   currentSavedSearch: PROP_TYPES.SAVED_SEARCH_OBJECT,
-  routeChangeResetState: PropTypes.func.isRequired,
+  resetSavedSearchAlerts: PropTypes.func.isRequired,
 };
 
 Results.defaultProps = {
@@ -288,7 +289,7 @@ Results.defaultProps = {
   newSavedSearchHasErrored: false,
   newSavedSearchIsSaving: false,
   currentSavedSearch: {},
-  routeChangeResetState: PROP_TYPES.EMPTY_FUNCTION,
+  resetSavedSearchAlerts: PROP_TYPES.EMPTY_FUNCTION,
 };
 
 Results.contextTypes = {
@@ -325,7 +326,7 @@ const mapDispatchToProps = dispatch => ({
     // we don't pass the refreshFavorites arg
     dispatch(userProfileToggleFavoritePosition(id, remove)),
   saveSearch: (object, id) => dispatch(saveSearch(object, id)),
-  routeChangeResetState: () => dispatch(routeChangeResetState()),
+  resetSavedSearchAlerts: () => dispatch(routeChangeResetState()),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Results);

--- a/src/actions/savedSearch.js
+++ b/src/actions/savedSearch.js
@@ -82,7 +82,8 @@ export function savedSearchesHasErrored(bool) {
   };
 }
 
-// when we want to reset alert messages after the user navigates away and comes back later
+// When we want to reset alert messages after the user navigates away and comes back later,
+// or when we want the user to be able to clear the current alert message.
 export function routeChangeResetState() {
   return (dispatch) => {
     dispatch(deleteSavedSearchSuccess(false));

--- a/src/sass/_dismiss.scss
+++ b/src/sass/_dismiss.scss
@@ -1,0 +1,19 @@
+.dismiss-container {
+  position: relative;
+}
+
+.dismiss-button {
+  background-color: $color-gray-light;
+  border-radius: 50%;
+  box-shadow: inset 0 0 0 2px none;
+  color: $color-white;
+  display: inline-block;
+  height: 30px;
+  line-height: 30px;
+  padding: 0 0 0 1px;
+  position: absolute;
+  right: -.5rem;
+  text-decoration: none;
+  top: -.5rem;
+  width: 30px;
+}

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -34,3 +34,4 @@
 @import 'responsive';
 @import 'overrides';
 @import 'spinner';
+@import 'dismiss';


### PR DESCRIPTION
Adds a component that can take `children` and wrap them in a functional button, primarily used for dismissing `Alert`s.