### PR TITLE
Mobile responsive logo fix

### DIFF
--- a/src/Components/Header/Header.jsx
+++ b/src/Components/Header/Header.jsx
@@ -57,7 +57,7 @@ export class Header extends Component {
           <div className="usa-logo" id="logo">
             <div className="usa-logo-text">
               <Link to="/">
-                <img src={logo} alt="TalentMAP logo" />
+                <img src={logo} width="200" alt="TalentMAP logo" />
               </Link>
             </div>
           </div>

--- a/src/Components/Header/__snapshots__/Header.test.jsx.snap
+++ b/src/Components/Header/__snapshots__/Header.test.jsx.snap
@@ -28,6 +28,7 @@ exports[`Header matches snapshot when logged in 1`] = `
           <img
             alt="TalentMAP logo"
             src="horizontal_color.png"
+            width="200"
           />
         </Link>
       </div>
@@ -171,6 +172,7 @@ exports[`Header matches snapshot when logged out 1`] = `
           <img
             alt="TalentMAP logo"
             src="horizontal_color.png"
+            width="200"
           />
         </Link>
       </div>

--- a/src/sass/_header.scss
+++ b/src/sass/_header.scss
@@ -1,6 +1,12 @@
 // header container
 .tm-header {
 
+  .usa-logo {
+    a {
+      display: inline-block;
+    }
+  }
+
   @media screen and (min-width: 951px) {
     .usa-logo {
       line-height: 7.5rem;
@@ -29,9 +35,6 @@
   @media screen and (max-width: 950px) {
 
     .usa-logo {
-      a {
-        font-size: 5.0rem;
-      }
       img {
         padding-top: 5px;
       }
@@ -42,12 +45,6 @@
     }
 
     .usa-logo {
-      line-height: unset;
-      margin-left: unset;
-      background-color: #ffffff;
-    }
-
-    .usa-logo-text {
       line-height: unset;
     }
   }


### PR DESCRIPTION
The logo still seemed a bit off after https://github.com/18F/State-TalentMAP/pull/776 so I made some tweaks to go from this:

<img width="945" alt="screen shot 2017-10-23 at 11 35 29 am" src="https://user-images.githubusercontent.com/11576347/31898174-71b91308-b7e6-11e7-95aa-4808af2875e8.png">

To this:

<img width="943" alt="screen shot 2017-10-23 at 11 35 44 am" src="https://user-images.githubusercontent.com/11576347/31898182-76219708-b7e6-11e7-97ab-da69eeee29a9.png">
