### PR TITLE
Add conditional editing based on user’s permissions

### DIFF
--- a/src/Components/PositionTitle/PositionTitle.jsx
+++ b/src/Components/PositionTitle/PositionTitle.jsx
@@ -105,6 +105,8 @@ class PositionTitle extends Component {
       <a href={`tel:${plainTextPointOfContact}`}>{plainTextPointOfContact}</a> :
     SystemMessages.NO_POSITION_POC;
 
+    const isAllowedToEdit = !!(details.description && details.description.is_editable_by_user);
+
     return (
       <div className="position-details-header-container">
         <div className="position-details-header">
@@ -140,9 +142,12 @@ class PositionTitle extends Component {
                           description :
                           SystemMessages.NO_POSITION_DESCRIPTION
                       }
-                      <EditContentButton
-                        onToggle={this.toggleDescriptionEditor}
-                      />
+                      {
+                        isAllowedToEdit &&
+                          <EditContentButton
+                            onToggle={this.toggleDescriptionEditor}
+                          />
+                      }
                     </span>
                 }
                 {
@@ -161,6 +166,7 @@ class PositionTitle extends Component {
                 shouldShowEditor={shouldShowWebsiteEditor.value}
                 onSubmitText={this.submitWebsiteEdit}
                 toggleEditor={this.toggleWebsiteEditor}
+                isAllowedToEdit={isAllowedToEdit}
               />
               <PositionTitleSubDescription
                 title="Point of Contact"
@@ -169,6 +175,7 @@ class PositionTitle extends Component {
                 shouldShowEditor={shouldShowPocEditor.value}
                 onSubmitText={this.submitPocEdit}
                 toggleEditor={this.togglePocEditor}
+                isAllowedToEdit={isAllowedToEdit}
               />
             </div>
           </div>

--- a/src/Components/PositionTitle/PositionTitle.test.jsx
+++ b/src/Components/PositionTitle/PositionTitle.test.jsx
@@ -106,6 +106,44 @@ describe('PositionTitleComponent', () => {
     expect(link.text()).toEqual(goBackLink.text);
   });
 
+  it('shows the editor button when the user has permission', () => {
+    Object.assign(detailsObject, { description: { is_editable_by_user: true } });
+    const wrapper = shallow(
+      <PositionTitle
+        details={detailsObject}
+        isLoading={false}
+        hasErrored={false}
+        goBackLink={goBackLink}
+        bidList={bidList}
+        toggleBidPosition={() => {}}
+        editWebsiteContent={() => {}}
+        editPocContent={() => {}}
+        editDescriptionContent={() => {}}
+        resetDescriptionEditMessages={() => {}}
+      />,
+    );
+    expect(wrapper.find('EditContentButton')).toHaveLength(1);
+  });
+
+  it('hides the editor button when the user does not have permission', () => {
+    Object.assign(detailsObject, { description: { is_editable_by_user: false } });
+    const wrapper = shallow(
+      <PositionTitle
+        details={detailsObject}
+        isLoading={false}
+        hasErrored={false}
+        goBackLink={goBackLink}
+        bidList={bidList}
+        toggleBidPosition={() => {}}
+        editWebsiteContent={() => {}}
+        editPocContent={() => {}}
+        editDescriptionContent={() => {}}
+        resetDescriptionEditMessages={() => {}}
+      />,
+    );
+    expect(wrapper.find('EditContentButton')).toHaveLength(0);
+  });
+
   it('handles go back link click', () => {
     const stub = sinon.stub(window.history, 'back');
     const wrapper = shallow(

--- a/src/Components/PositionTitle/__snapshots__/PositionTitle.test.jsx.snap
+++ b/src/Components/PositionTitle/__snapshots__/PositionTitle.test.jsx.snap
@@ -49,9 +49,6 @@ exports[`PositionTitleComponent matches snapshot 1`] = `
             className="usa-grid-full"
           >
             a description
-            <EditContentButton
-              onToggle={[Function]}
-            />
           </span>
         </div>
         <PositionTitleSubDescription
@@ -62,6 +59,7 @@ exports[`PositionTitleComponent matches snapshot 1`] = `
               https://www.state.gov/post
             </a>
           }
+          isAllowedToEdit={false}
           onSubmitText={[Function]}
           plainContent="https://www.state.gov/post"
           shouldShowEditor={false}
@@ -76,6 +74,7 @@ exports[`PositionTitleComponent matches snapshot 1`] = `
               202-555-5555
             </a>
           }
+          isAllowedToEdit={false}
           onSubmitText={[Function]}
           plainContent="202-555-5555"
           shouldShowEditor={false}

--- a/src/Components/PositionTitleSubDescription/PositionTitleSubDescription.jsx
+++ b/src/Components/PositionTitleSubDescription/PositionTitleSubDescription.jsx
@@ -4,7 +4,7 @@ import TextEditor from '../TextEditor';
 import EditContentButton from '../EditContentButton';
 
 const PositionTitleSubDescription = ({ title, formattedContent, plainContent, shouldShowEditor,
-  onSubmitText, toggleEditor }) => (
+  onSubmitText, toggleEditor, isAllowedToEdit }) => (
     <div
       className="usa-width-one-half position-details-header-body editable-position-field"
     >
@@ -13,9 +13,12 @@ const PositionTitleSubDescription = ({ title, formattedContent, plainContent, sh
         !shouldShowEditor &&
           <div className="usa-grid-full">
             {formattedContent}
-            <EditContentButton
-              onToggle={toggleEditor}
-            />
+            {
+              isAllowedToEdit &&
+                <EditContentButton
+                  onToggle={toggleEditor}
+                />
+            }
           </div>
       }
       {
@@ -36,6 +39,7 @@ PositionTitleSubDescription.propTypes = {
   shouldShowEditor: PropTypes.bool.isRequired,
   onSubmitText: PropTypes.func.isRequired,
   toggleEditor: PropTypes.func.isRequired,
+  isAllowedToEdit: PropTypes.bool.isRequired,
 };
 
 export default PositionTitleSubDescription;

--- a/src/Components/PositionTitleSubDescription/PositionTitleSubDescription.test.jsx
+++ b/src/Components/PositionTitleSubDescription/PositionTitleSubDescription.test.jsx
@@ -14,9 +14,40 @@ describe('PositionTitleSubDescriptionComponent', () => {
         shouldShowEditor={false}
         onSubmitText={() => {}}
         toggleEditor={() => {}}
+        isAllowedToEdit
       />,
     );
     expect(wrapper.instance().props.title).toBe('title');
+  });
+
+  it('shows the editor button when the user has permission', () => {
+    const wrapper = shallow(
+      <PositionTitleSubDescription
+        title="title"
+        formattedContent={<span>content</span>}
+        plainContent="content"
+        shouldShowEditor={false}
+        onSubmitText={() => {}}
+        toggleEditor={() => {}}
+        isAllowedToEdit
+      />,
+    );
+    expect(wrapper.find('EditContentButton')).toHaveLength(1);
+  });
+
+  it('hides the editor button when the user does not have permission', () => {
+    const wrapper = shallow(
+      <PositionTitleSubDescription
+        title="title"
+        formattedContent={<span>content</span>}
+        plainContent="content"
+        shouldShowEditor={false}
+        onSubmitText={() => {}}
+        toggleEditor={() => {}}
+        isAllowedToEdit={false}
+      />,
+    );
+    expect(wrapper.find('EditContentButton')).toHaveLength(0);
   });
 
   it('matches snapshot when editor is hidden', () => {
@@ -28,6 +59,7 @@ describe('PositionTitleSubDescriptionComponent', () => {
         shouldShowEditor={false}
         onSubmitText={() => {}}
         toggleEditor={() => {}}
+        isAllowedToEdit
       />,
     );
     expect(toJSON(wrapper)).toMatchSnapshot();
@@ -42,6 +74,7 @@ describe('PositionTitleSubDescriptionComponent', () => {
         shouldShowEditor
         onSubmitText={() => {}}
         toggleEditor={() => {}}
+        isAllowedToEdit
       />,
     );
     expect(toJSON(wrapper)).toMatchSnapshot();


### PR DESCRIPTION
Adds conditional rendering of Edit buttons, so that users without sufficient authorization to edit a position's description won't see the Edit buttons.