### PR TITLE
Sprint 10 CodeClimate Fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "redux-mock-store": "^1.2.3",
     "redux-saga-test-plan": "^3.1.0",
     "redux-testkit": "^1.0.6",
+    "sass-lint": "^1.12.1",
     "sass-loader": "^6.0.6",
     "sinon": "^2.4.1",
     "style-loader": "0.17.0",

--- a/src/Components/SearchFilters/MultiSelectFilter/MultiSelectFilter.jsx
+++ b/src/Components/SearchFilters/MultiSelectFilter/MultiSelectFilter.jsx
@@ -23,7 +23,7 @@ class MultiSelectFilter extends Component {
           item.data.map((itemData) => {
             const itemLabel = getItemLabel(itemData);
             return (<CheckBox
-              _id={itemData.id /* when we need the original id */}
+              _id={itemData.id} /* when we need the original id */
               id={`checkbox${itemLabel}`}
               key={`${item.item.selectionRef}-${itemData.code}`}
               label={itemLabel}

--- a/src/Components/TextEditor/TextEditor.jsx
+++ b/src/Components/TextEditor/TextEditor.jsx
@@ -41,7 +41,9 @@ export default class TextEditor extends Component {
     const { readOnly } = this.props;
     return (
       <div>
-        { /* eslint "jsx-a11y/no-static-element-interactions": 0 */ }
+        { /* outer div here exists to override styling & behavior of the interior component */ }
+        { /* this eslint rule seems to fire even though the role is defined */}
+        { /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */ }
         <div role="textbox" tabIndex="0" className={readOnly ? '' : 'editor'} onClick={this.focus}>
           <Editor
             editorState={this.state.editorState}

--- a/src/Components/TextEditor/TextEditor.jsx
+++ b/src/Components/TextEditor/TextEditor.jsx
@@ -41,6 +41,7 @@ export default class TextEditor extends Component {
     const { readOnly } = this.props;
     return (
       <div>
+        { /* eslint "jsx-a11y/no-static-element-interactions": 0 */ }
         <div role="textbox" tabIndex="0" className={readOnly ? '' : 'editor'} onClick={this.focus}>
           <Editor
             editorState={this.state.editorState}

--- a/src/sass/_editor.scss
+++ b/src/sass/_editor.scss
@@ -1,9 +1,9 @@
-// scss-lint:disable ColorVariable,SelectorFormat,VendorPrefix
+// scss-lint:disable SelectorFormat,VendorPrefix
 .editor {
-  background: #fefefe;
-  border: 1px solid #ddd;
+  background: $editor-background;
+  border: 1px solid $editor-border;
   border-radius: 2px;
-  box-shadow: inset 0 1px 8px -3px #ababab;
+  box-shadow: inset 0 1px 8px -3px $editor-box-shadow;
   box-sizing: border-box;
   cursor: text;
   margin-bottom: 2em;
@@ -19,9 +19,9 @@
 }
 
 .headlineButton {
-  background: #fbfbfb;
+  background: $editor-headline-background;
   border: 0;
-  color: #888;
+  color: $editor-headline-color;
   font-size: 18px;
   height: 34px;
   padding-top: 5px;
@@ -30,7 +30,7 @@
 
   :hover,
   :focus {
-    background: #f3f3f3;
+    background: $editor-headline-background-focus;
   }
 }
 

--- a/src/sass/_editor.scss
+++ b/src/sass/_editor.scss
@@ -1,4 +1,4 @@
-// scss-lint:disable all
+// scss-lint:disable ColorVariable,SelectorFormat,VendorPrefix
 .editor {
   background: #fefefe;
   border: 1px solid #ddd;
@@ -35,9 +35,9 @@
 }
 
 .draftJsToolbar__toolbar__dNtBH {
-  -webkit-transform: unset;
   left: unset;
   position: unset;
+  -webkit-transform: unset;
   transform: unset;
 
   button {

--- a/src/sass/_editor.scss
+++ b/src/sass/_editor.scss
@@ -1,12 +1,13 @@
+// scss-lint:disable all
 .editor {
-  box-sizing: border-box;
-  border: 1px solid #ddd;
-  cursor: text;
-  padding: 16px;
-  border-radius: 2px;
-  margin-bottom: 2em;
-  box-shadow: inset 0px 1px 8px -3px #ABABAB;
   background: #fefefe;
+  border: 1px solid #ddd;
+  border-radius: 2px;
+  box-shadow: inset 0 1px 8px -3px #ababab;
+  box-sizing: border-box;
+  cursor: text;
+  margin-bottom: 2em;
+  padding: 16px;
 }
 
 .editor :global(.public-DraftEditor-content) {
@@ -19,25 +20,25 @@
 
 .headlineButton {
   background: #fbfbfb;
+  border: 0;
   color: #888;
   font-size: 18px;
-  border: 0;
+  height: 34px;
   padding-top: 5px;
   vertical-align: bottom;
-  height: 34px;
   width: 36px;
-}
 
-.headlineButton:hover,
-.headlineButton:focus {
-  background: #f3f3f3;
+  :hover,
+  :focus {
+    background: #f3f3f3;
+  }
 }
 
 .draftJsToolbar__toolbar__dNtBH {
+  -webkit-transform: unset;
   left: unset;
   position: unset;
   transform: unset;
-  -webkit-transform: unset;
 
   button {
     cursor: pointer;

--- a/src/sass/_variables.scss
+++ b/src/sass/_variables.scss
@@ -19,6 +19,14 @@ $avatar-dropdown-border-top-color: rgba(0, 0, 0, .05);
 $avatar-dropdown-box-shadow-color: rgba(0, 0, 0, .15);
 $avatar-dropdown-account-segment-color: #e1e1e1;
 
+// editor
+$editor-background: #fefefe;
+$editor-border: #ddd;
+$editor-box-shadow: #ababab;
+$editor-headline-background: #fbfbfb;
+$editor-headline-background-focus: #f3f3f3;
+$editor-headline-color: #888;
+
 // z-index values
 // we'll use this section to keep track of and order them
 $autosuggest-suggestions-container-open-z: 2;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1626,7 +1626,7 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2.11.x, commander@^2.9.0, commander@~2.11.0:
+commander@2.11.x, commander@^2.8.1, commander@^2.9.0, commander@~2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
 
@@ -1674,7 +1674,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@1.6.0, concat-stream@^1.5.2:
+concat-stream@1.6.0, concat-stream@^1.4.6, concat-stream@^1.5.2:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
@@ -2119,7 +2119,7 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
-doctrine@1.5.0:
+doctrine@1.5.0, doctrine@^1.2.2:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
   dependencies:
@@ -2657,6 +2657,51 @@ eslint@3.19.0:
     text-table "~0.2.0"
     user-home "^2.0.0"
 
+eslint@^2.7.0:
+  version "2.13.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-2.13.1.tgz#e4cc8fa0f009fb829aaae23855a29360be1f6c11"
+  dependencies:
+    chalk "^1.1.3"
+    concat-stream "^1.4.6"
+    debug "^2.1.1"
+    doctrine "^1.2.2"
+    es6-map "^0.1.3"
+    escope "^3.6.0"
+    espree "^3.1.6"
+    estraverse "^4.2.0"
+    esutils "^2.0.2"
+    file-entry-cache "^1.1.1"
+    glob "^7.0.3"
+    globals "^9.2.0"
+    ignore "^3.1.2"
+    imurmurhash "^0.1.4"
+    inquirer "^0.12.0"
+    is-my-json-valid "^2.10.0"
+    is-resolvable "^1.0.0"
+    js-yaml "^3.5.1"
+    json-stable-stringify "^1.0.0"
+    levn "^0.3.0"
+    lodash "^4.0.0"
+    mkdirp "^0.5.0"
+    optionator "^0.8.1"
+    path-is-absolute "^1.0.0"
+    path-is-inside "^1.0.1"
+    pluralize "^1.2.1"
+    progress "^1.1.8"
+    require-uncached "^1.0.2"
+    shelljs "^0.6.0"
+    strip-json-comments "~1.0.1"
+    table "^3.7.8"
+    text-table "~0.2.0"
+    user-home "^2.0.0"
+
+espree@^3.1.6:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.1.tgz#0c988b8ab46db53100a1954ae4ba995ddd27d87e"
+  dependencies:
+    acorn "^5.1.1"
+    acorn-jsx "^3.0.0"
+
 espree@^3.4.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.0.tgz#98358625bdd055861ea27e2867ea729faf463d8d"
@@ -2908,6 +2953,13 @@ figures@^2.0.0:
   dependencies:
     escape-string-regexp "^1.0.5"
 
+file-entry-cache@^1.1.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-1.3.1.tgz#44c61ea607ae4be9c1402f41f44270cbfe334ff8"
+  dependencies:
+    flat-cache "^1.2.1"
+    object-assign "^4.0.1"
+
 file-entry-cache@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-2.0.0.tgz#c392990c3e684783d838b8c84a45d8a048458361"
@@ -3068,7 +3120,13 @@ fresh@0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.0.tgz#f474ca5e6a9246d6fd8e0953cfa9b9c805afa78e"
 
-fs-extra@3.0.1:
+front-matter@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/front-matter/-/front-matter-2.1.2.tgz#f75983b9f2f413be658c93dfd7bd8ce4078f5cdb"
+  dependencies:
+    js-yaml "^3.4.6"
+
+fs-extra@3.0.1, fs-extra@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-3.0.1.tgz#3794f378c58b342ea7dbbb23095109c4b3b62291"
   dependencies:
@@ -3223,7 +3281,7 @@ global-prefix@^1.0.1:
     is-windows "^1.0.1"
     which "^1.2.14"
 
-globals@^9.14.0, globals@^9.18.0:
+globals@^9.14.0, globals@^9.18.0, globals@^9.2.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
@@ -3245,6 +3303,12 @@ globule@^1.0.0:
     glob "~7.1.1"
     lodash "~4.17.4"
     minimatch "~3.0.2"
+
+gonzales-pe-sl@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/gonzales-pe-sl/-/gonzales-pe-sl-4.2.3.tgz#6a868bc380645f141feeb042c6f97fcc71b59fe6"
+  dependencies:
+    minimist "1.1.x"
 
 got@^5.0.0:
   version "5.7.1"
@@ -3553,6 +3617,10 @@ icss-replace-symbols@^1.1.0:
 ieee754@^1.1.4:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
+
+ignore@^3.1.2:
+  version "3.3.7"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
 
 ignore@^3.2.0:
   version "3.3.3"
@@ -4240,6 +4308,13 @@ js-yaml@^3.4.3, js-yaml@^3.5.1, js-yaml@^3.7.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@^3.4.6, js-yaml@^3.5.4:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 js-yaml@~3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
@@ -4402,6 +4477,10 @@ klaw@^1.0.0:
   optionalDependencies:
     graceful-fs "^4.1.9"
 
+known-css-properties@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.3.0.tgz#a3d135bbfc60ee8c6eacf2f7e7e6f2d4755e49a4"
+
 labeled-stream-splicer@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/labeled-stream-splicer/-/labeled-stream-splicer-2.0.0.tgz#a52e1d138024c00b86b1c0c91f677918b8ae0a59"
@@ -4529,6 +4608,10 @@ lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
 
+lodash.capitalize@^4.1.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz#f826c9b4e2a8511d84e3aca29db05e1a4f3b72a9"
+
 lodash.clonedeep@^4.3.2:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
@@ -4572,6 +4655,10 @@ lodash.isnil@^4.0.0:
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+
+lodash.kebabcase@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
 
 lodash.map@^4.4.0:
   version "4.6.0"
@@ -4742,7 +4829,7 @@ merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
 
-merge@^1.1.3:
+merge@^1.1.3, merge@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
 
@@ -4820,6 +4907,10 @@ minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4, minimatc
 minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+
+minimist@1.1.x:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.1.3.tgz#3bedfd91a92d39016fcfaa1c681e8faa1a1efda8"
 
 minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
@@ -6632,6 +6723,25 @@ sass-graph@^2.1.1:
     scss-tokenizer "^0.2.3"
     yargs "^7.0.0"
 
+sass-lint@^1.12.1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/sass-lint/-/sass-lint-1.12.1.tgz#630f69c216aa206b8232fb2aa907bdf3336b6d83"
+  dependencies:
+    commander "^2.8.1"
+    eslint "^2.7.0"
+    front-matter "2.1.2"
+    fs-extra "^3.0.1"
+    glob "^7.0.0"
+    globule "^1.0.0"
+    gonzales-pe-sl "^4.2.3"
+    js-yaml "^3.5.4"
+    known-css-properties "^0.3.0"
+    lodash.capitalize "^4.1.0"
+    lodash.kebabcase "^4.0.0"
+    merge "^1.2.0"
+    path-is-absolute "^1.0.0"
+    util "^0.10.3"
+
 sass-loader@^6.0.6:
   version "6.0.6"
   resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-6.0.6.tgz#e9d5e6c1f155faa32a4b26d7a9b7107c225e40f9"
@@ -6788,6 +6898,10 @@ shell-quote@1.6.1, shell-quote@^1.6.1:
     array-map "~0.0.0"
     array-reduce "~0.0.0"
     jsonify "~0.0.0"
+
+shelljs@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.6.1.tgz#ec6211bed1920442088fe0f70b2837232ed2c8a8"
 
 shelljs@^0.7.5:
   version "0.7.8"
@@ -7075,6 +7189,10 @@ strip-indent@^1.0.1:
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
   dependencies:
     get-stdin "^4.0.1"
+
+strip-json-comments@~1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-1.0.4.tgz#1e15fbcac97d3ee99bf2d73b4c656b082bbafb91"
 
 strip-json-comments@~2.0.1:
   version "2.0.1"


### PR DESCRIPTION
There's some questionable stuff in here that can be easily explained...

## ESLint
* Spacing fix
* Disabling `jsx-a11y` rule - I believe we're in compliance because we specify a `role`.  Additionally, we're way ahead of UI/UX on this.

## scss-lint
* So, I may have used `sass-lint` and not `scss-lint` locally
  * Recommending we move to `sass-lint` #814
* `_editor.scss` carries many dependencies from an external library