### PR TITLE
Filter null locations in post autocomplete action

### DIFF
--- a/src/actions/autocomplete/postAutocomplete.js
+++ b/src/actions/autocomplete/postAutocomplete.js
@@ -36,7 +36,12 @@ export function postSearchFetchData(query) {
     )
       .then((response) => {
         dispatch(postSearchIsLoading(false));
-        return response.data.results;
+        let filteredResults = [];
+        if (response.data && response.data.results) {
+          // results should have a location
+          filteredResults = response.data.results.filter(post => post.location !== null);
+        }
+        return filteredResults;
       })
       .then(results => dispatch(postSearchSuccess(results)))
       .catch(() => {

--- a/src/actions/autocomplete/postAutocomplete.js
+++ b/src/actions/autocomplete/postAutocomplete.js
@@ -34,12 +34,12 @@ export function postSearchFetchData(query) {
       }),
     },
     )
-      .then((response) => {
+      .then(({ data }) => {
         dispatch(postSearchIsLoading(false));
         let filteredResults = [];
-        if (response.data && response.data.results) {
+        if (data.results) {
           // results should have a location
-          filteredResults = response.data.results.filter(post => post.location !== null);
+          filteredResults = data.results.filter(post => post.location !== null);
         }
         return filteredResults;
       })

--- a/src/actions/autocomplete/postAutocomplete.test.js
+++ b/src/actions/autocomplete/postAutocomplete.test.js
@@ -27,7 +27,7 @@ describe('async actions', () => {
     ];
 
     mockAdapter.onGet('http://localhost:8000/api/v1/orgpost/?q=Dubai&limit=3').reply(200,
-      results,
+      { results },
     );
 
     mockAdapter.onGet('http://localhost:8000/api/v1/orgpost/?q=fake&limit=3').reply(404,

--- a/src/actions/autocomplete/postAutocomplete.test.js
+++ b/src/actions/autocomplete/postAutocomplete.test.js
@@ -6,37 +6,55 @@ import * as actions from './postAutocomplete';
 
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
+const mockAdapter = new MockAdapter(axios);
+
+const results = [
+  {
+    id: 1,
+    code: 'AE1200000',
+    location: 'Dubai, United Arab Emirates',
+    tour_of_duty: '3 YRS ( 2 R & R )',
+    cost_of_living_adjustment: 25,
+    differential_rate: 5,
+    danger_pay: 0,
+    rest_relaxation_point: 'London',
+    has_consumable_allowance: false,
+    has_service_needs_differential: false,
+  },
+];
+
+mockAdapter.onGet('http://localhost:8000/api/v1/orgpost/?q=Dubai&limit=3').reply(200,
+  { results },
+);
+
+mockAdapter.onGet('http://localhost:8000/api/v1/orgpost/?q=fake&limit=3').reply(404,
+  null,
+);
 
 describe('async actions', () => {
-  beforeEach(() => {
-    const mockAdapter = new MockAdapter(axios);
-
-    const results = [
-      {
-        id: 1,
-        code: 'AE1200000',
-        location: 'Dubai, United Arab Emirates',
-        tour_of_duty: '3 YRS ( 2 R & R )',
-        cost_of_living_adjustment: 25,
-        differential_rate: 5,
-        danger_pay: 0,
-        rest_relaxation_point: 'London',
-        has_consumable_allowance: false,
-        has_service_needs_differential: false,
-      },
-    ];
-
-    mockAdapter.onGet('http://localhost:8000/api/v1/orgpost/?q=Dubai&limit=3').reply(200,
-      { results },
-    );
-
-    mockAdapter.onGet('http://localhost:8000/api/v1/orgpost/?q=fake&limit=3').reply(404,
-      null,
-    );
-  });
-
   it('can fetch post reuslts', (done) => {
     const store = mockStore({ results: [] });
+
+    const f = () => {
+      setTimeout(() => {
+        store.dispatch(actions.postSearchFetchData('Dubai'));
+        store.dispatch(actions.postSearchIsLoading());
+        done();
+      }, 0);
+    };
+    f();
+  });
+
+  it('can handle responses with null locations', (done) => {
+    const store = mockStore({ posts: [] });
+
+    mockAdapter.onGet('http://localhost:8000/api/v1/orgpost/?q=Dubai&limit=3').reply(200,
+      { results: [
+        Object.assign({}, results[0]),
+        Object.assign(results[0], { location: null }),
+      ],
+      },
+    );
 
     const f = () => {
       setTimeout(() => {


### PR DESCRIPTION
In some cases, posts with `"location": null` break the autosuggest template. While results such as this should not be returned in production, it's good to handle for the possibility so that the autosuggest list doesn't break when it does happen.

#860 