### PR TITLE
Profile dashboard grid

### DIFF
--- a/src/Components/ProfileDashboard/BidList/BidList.jsx
+++ b/src/Components/ProfileDashboard/BidList/BidList.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const BidList = () => (
+  <div className="usa-grid-full">
+    Bid list
+  </div>
+);
+
+export default BidList;

--- a/src/Components/ProfileDashboard/BidList/BidList.test.jsx
+++ b/src/Components/ProfileDashboard/BidList/BidList.test.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import toJSON from 'enzyme-to-json';
+import BidList from './BidList';
+
+describe('BidListComponent', () => {
+  it('is defined', () => {
+    const wrapper = shallow(<BidList />);
+    expect(wrapper).toBeDefined();
+  });
+
+  it('matches snapshot when editor is shown', () => {
+    const wrapper = shallow(<BidList />);
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/Components/ProfileDashboard/BidList/__snapshots__/BidList.test.jsx.snap
+++ b/src/Components/ProfileDashboard/BidList/__snapshots__/BidList.test.jsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BidListComponent matches snapshot when editor is shown 1`] = `
+<div
+  className="usa-grid-full"
+>
+  Bid list
+</div>
+`;

--- a/src/Components/ProfileDashboard/BidList/index.js
+++ b/src/Components/ProfileDashboard/BidList/index.js
@@ -1,0 +1,1 @@
+export { default } from './BidList';

--- a/src/Components/ProfileDashboard/CDOInfo/CDOInfo.jsx
+++ b/src/Components/ProfileDashboard/CDOInfo/CDOInfo.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const CDOInfo = () => (
+  <div className="usa-grid-full">
+    CDO information
+  </div>
+);
+
+export default CDOInfo;

--- a/src/Components/ProfileDashboard/CDOInfo/CDOInfo.test.jsx
+++ b/src/Components/ProfileDashboard/CDOInfo/CDOInfo.test.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import toJSON from 'enzyme-to-json';
+import CDOInfo from './CDOInfo';
+
+describe('CDOInfoComponent', () => {
+  it('is defined', () => {
+    const wrapper = shallow(<CDOInfo />);
+    expect(wrapper).toBeDefined();
+  });
+
+  it('matches snapshot when editor is shown', () => {
+    const wrapper = shallow(<CDOInfo />);
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/Components/ProfileDashboard/CDOInfo/__snapshots__/CDOInfo.test.jsx.snap
+++ b/src/Components/ProfileDashboard/CDOInfo/__snapshots__/CDOInfo.test.jsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CDOInfoComponent matches snapshot when editor is shown 1`] = `
+<div
+  className="usa-grid-full"
+>
+  CDO information
+</div>
+`;

--- a/src/Components/ProfileDashboard/CDOInfo/index.js
+++ b/src/Components/ProfileDashboard/CDOInfo/index.js
@@ -1,0 +1,1 @@
+export { default } from './CDOInfo';

--- a/src/Components/ProfileDashboard/CurrentUser/CurrentUser.jsx
+++ b/src/Components/ProfileDashboard/CurrentUser/CurrentUser.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const CurrentUser = () => (
+  <div className="usa-grid-full">
+    Current user information
+  </div>
+);
+
+export default CurrentUser;

--- a/src/Components/ProfileDashboard/CurrentUser/CurrentUser.test.jsx
+++ b/src/Components/ProfileDashboard/CurrentUser/CurrentUser.test.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import toJSON from 'enzyme-to-json';
+import CurrentUser from './CurrentUser';
+
+describe('CurrentUserComponent', () => {
+  it('is defined', () => {
+    const wrapper = shallow(<CurrentUser />);
+    expect(wrapper).toBeDefined();
+  });
+
+  it('matches snapshot when editor is shown', () => {
+    const wrapper = shallow(<CurrentUser />);
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/Components/ProfileDashboard/CurrentUser/__snapshots__/CurrentUser.test.jsx.snap
+++ b/src/Components/ProfileDashboard/CurrentUser/__snapshots__/CurrentUser.test.jsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CurrentUserComponent matches snapshot when editor is shown 1`] = `
+<div
+  className="usa-grid-full"
+>
+  Current user information
+</div>
+`;

--- a/src/Components/ProfileDashboard/CurrentUser/index.js
+++ b/src/Components/ProfileDashboard/CurrentUser/index.js
@@ -1,0 +1,1 @@
+export { default } from './CurrentUser';

--- a/src/Components/ProfileDashboard/Inbox/Inbox.jsx
+++ b/src/Components/ProfileDashboard/Inbox/Inbox.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
-const CDOInfo = () => (
+const Inbox = () => (
   <div className="usa-grid-full">
     Inbox
   </div>
 );
 
-export default CDOInfo;
+export default Inbox;

--- a/src/Components/ProfileDashboard/Inbox/Inbox.jsx
+++ b/src/Components/ProfileDashboard/Inbox/Inbox.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const CDOInfo = () => (
+  <div className="usa-grid-full">
+    Inbox
+  </div>
+);
+
+export default CDOInfo;

--- a/src/Components/ProfileDashboard/Inbox/Inbox.test.jsx
+++ b/src/Components/ProfileDashboard/Inbox/Inbox.test.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import toJSON from 'enzyme-to-json';
+import Inbox from './Inbox';
+
+describe('InboxComponent', () => {
+  it('is defined', () => {
+    const wrapper = shallow(<Inbox />);
+    expect(wrapper).toBeDefined();
+  });
+
+  it('matches snapshot when editor is shown', () => {
+    const wrapper = shallow(<Inbox />);
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/Components/ProfileDashboard/Inbox/__snapshots__/Inbox.test.jsx.snap
+++ b/src/Components/ProfileDashboard/Inbox/__snapshots__/Inbox.test.jsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`InboxComponent matches snapshot when editor is shown 1`] = `
+<div
+  className="usa-grid-full"
+>
+  Inbox
+</div>
+`;

--- a/src/Components/ProfileDashboard/Inbox/index.js
+++ b/src/Components/ProfileDashboard/Inbox/index.js
@@ -1,0 +1,1 @@
+export { default } from './Inbox';

--- a/src/Components/ProfileDashboard/Notifications/Notifications.jsx
+++ b/src/Components/ProfileDashboard/Notifications/Notifications.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const Notifications = () => (
+  <div className="usa-grid-full">
+    Notifications
+  </div>
+);
+
+export default Notifications;

--- a/src/Components/ProfileDashboard/Notifications/Notifications.test.jsx
+++ b/src/Components/ProfileDashboard/Notifications/Notifications.test.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import toJSON from 'enzyme-to-json';
+import Notifications from './Notifications';
+
+describe('NotificationsComponent', () => {
+  it('is defined', () => {
+    const wrapper = shallow(<Notifications />);
+    expect(wrapper).toBeDefined();
+  });
+
+  it('matches snapshot when editor is shown', () => {
+    const wrapper = shallow(<Notifications />);
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/Components/ProfileDashboard/Notifications/__snapshots__/Notifications.test.jsx.snap
+++ b/src/Components/ProfileDashboard/Notifications/__snapshots__/Notifications.test.jsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NotificationsComponent matches snapshot when editor is shown 1`] = `
+<div
+  className="usa-grid-full"
+>
+  Notifications
+</div>
+`;

--- a/src/Components/ProfileDashboard/Notifications/index.js
+++ b/src/Components/ProfileDashboard/Notifications/index.js
@@ -1,0 +1,1 @@
+export { default } from './Notifications';

--- a/src/Components/ProfileDashboard/PositionInformation/PositionInformation.jsx
+++ b/src/Components/ProfileDashboard/PositionInformation/PositionInformation.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const PositionInformation = () => (
+  <div className="usa-grid-full">
+    Position Information
+  </div>
+);
+
+export default PositionInformation;

--- a/src/Components/ProfileDashboard/PositionInformation/PositionInformation.test.jsx
+++ b/src/Components/ProfileDashboard/PositionInformation/PositionInformation.test.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import toJSON from 'enzyme-to-json';
+import PositionInformation from './PositionInformation';
+
+describe('PositionInformationComponent', () => {
+  it('is defined', () => {
+    const wrapper = shallow(<PositionInformation />);
+    expect(wrapper).toBeDefined();
+  });
+
+  it('matches snapshot when editor is shown', () => {
+    const wrapper = shallow(<PositionInformation />);
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/Components/ProfileDashboard/PositionInformation/__snapshots__/PositionInformation.test.jsx.snap
+++ b/src/Components/ProfileDashboard/PositionInformation/__snapshots__/PositionInformation.test.jsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PositionInformationComponent matches snapshot when editor is shown 1`] = `
+<div
+  className="usa-grid-full"
+>
+  Position Information
+</div>
+`;

--- a/src/Components/ProfileDashboard/PositionInformation/index.js
+++ b/src/Components/ProfileDashboard/PositionInformation/index.js
@@ -1,0 +1,1 @@
+export { default } from './PositionInformation';

--- a/src/Components/ProfileDashboard/ProfileDashboard.jsx
+++ b/src/Components/ProfileDashboard/ProfileDashboard.jsx
@@ -1,0 +1,49 @@
+import React, { Component } from 'react';
+import CurrentUser from './CurrentUser';
+import CDOInfo from './CDOInfo';
+import BidList from './BidList';
+import PositionInformation from './PositionInformation';
+import Notifications from './Notifications';
+import Inbox from './Inbox';
+
+// eslint-disable-next-line
+class ProfileDashboard extends Component {
+  render() {
+    return (
+      <div className="usa-grid-full user-dashboard">
+        <div
+          className="usa-width-one-fourth user-dashboard-section-container user-dashboard-column-1"
+        >
+          <div className="usa-width-one-whole user-dashboard-section current-user-section">
+            <CurrentUser />
+          </div>
+          <div className="usa-width-one-whole user-dashboard-section cdo-section">
+            <CDOInfo />
+          </div>
+        </div>
+        <div
+          className="usa-width-one-fourth user-dashboard-section-container user-dashboard-column-2"
+        >
+          <div className="usa-width-one-whole user-dashboard-section position-info-section">
+            <PositionInformation />
+          </div>
+          <div className="usa-width-one-whole user-dashboard-section notifications-section">
+            <Notifications />
+          </div>
+        </div>
+        <div
+          className="usa-width-one-half user-dashboard-section-container user-dashboard-column-3"
+        >
+          <div className="usa-width-one-whole user-dashboard-section bidlist-section">
+            <BidList />
+          </div>
+          <div className="usa-width-one-whole user-dashboard-section inbox-section">
+            <Inbox />
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default ProfileDashboard;

--- a/src/Components/ProfileDashboard/ProfileDashboard.test.jsx
+++ b/src/Components/ProfileDashboard/ProfileDashboard.test.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import toJSON from 'enzyme-to-json';
+import ProfileDashboard from './ProfileDashboard';
+
+describe('ProfileDashboardComponent', () => {
+  it('is defined', () => {
+    const wrapper = shallow(<ProfileDashboard />);
+    expect(wrapper).toBeDefined();
+  });
+
+  it('matches snapshot when editor is shown', () => {
+    const wrapper = shallow(<ProfileDashboard />);
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/Components/ProfileDashboard/__snapshots__/ProfileDashboard.test.jsx.snap
+++ b/src/Components/ProfileDashboard/__snapshots__/ProfileDashboard.test.jsx.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ProfileDashboardComponent matches snapshot when editor is shown 1`] = `
+<div
+  className="usa-grid-full user-dashboard"
+>
+  <div
+    className="usa-width-one-fourth user-dashboard-section-container user-dashboard-column-1"
+  >
+    <div
+      className="usa-width-one-whole user-dashboard-section current-user-section"
+    >
+      <CurrentUser />
+    </div>
+    <div
+      className="usa-width-one-whole user-dashboard-section cdo-section"
+    >
+      <CDOInfo />
+    </div>
+  </div>
+  <div
+    className="usa-width-one-fourth user-dashboard-section-container user-dashboard-column-2"
+  >
+    <div
+      className="usa-width-one-whole user-dashboard-section position-info-section"
+    >
+      <PositionInformation />
+    </div>
+    <div
+      className="usa-width-one-whole user-dashboard-section notifications-section"
+    >
+      <Notifications />
+    </div>
+  </div>
+  <div
+    className="usa-width-one-half user-dashboard-section-container user-dashboard-column-3"
+  >
+    <div
+      className="usa-width-one-whole user-dashboard-section bidlist-section"
+    >
+      <BidList />
+    </div>
+    <div
+      className="usa-width-one-whole user-dashboard-section inbox-section"
+    >
+      <CDOInfo />
+    </div>
+  </div>
+</div>
+`;

--- a/src/Components/ProfileDashboard/__snapshots__/ProfileDashboard.test.jsx.snap
+++ b/src/Components/ProfileDashboard/__snapshots__/ProfileDashboard.test.jsx.snap
@@ -43,7 +43,7 @@ exports[`ProfileDashboardComponent matches snapshot when editor is shown 1`] = `
     <div
       className="usa-width-one-whole user-dashboard-section inbox-section"
     >
-      <CDOInfo />
+      <Inbox />
     </div>
   </div>
 </div>

--- a/src/Components/ProfileDashboard/index.js
+++ b/src/Components/ProfileDashboard/index.js
@@ -1,0 +1,1 @@
+export { default } from './ProfileDashboard';

--- a/src/Components/ProfileMenu/NavLink/NavLink.jsx
+++ b/src/Components/ProfileMenu/NavLink/NavLink.jsx
@@ -1,0 +1,140 @@
+import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import FontAwesome from 'react-fontawesome';
+import { ifEnter } from '../../../utilities';
+
+class NavLink extends Component {
+  constructor(props) {
+    super(props);
+    this.toggleNestedLinksVisibility = this.toggleNestedLinksVisibility.bind(this);
+    this.state = {
+      showNestedLinks: { value: false },
+    };
+  }
+
+  componentWillMount() {
+    this.shouldExpandIfChildActive();
+  }
+
+  // Checks if any of the children links match the current path.
+  // If so, we'll toggle the visibility to true
+  shouldExpandIfChildActive() {
+    const { children, currentPath } = this.props;
+    let found = false;
+    // Iterate through the children.
+    // When there's only one child, we can't use forEach...
+    if (children && children.length > 1) {
+      children.forEach((c) => {
+        if (c.props && c.props.link && c.props.link && c.props.link === currentPath) {
+          found = true;
+        }
+      });
+    // So we'll check here and act directly on the only child, if it exists
+    } else if (children) {
+      if (children.props && children.props.link && children.props.link &&
+          children.props.link === currentPath) {
+        found = true;
+      }
+    }
+    if (found) {
+      const { showNestedLinks } = this.state;
+      showNestedLinks.value = true;
+      this.setState({ showNestedLinks });
+    }
+  }
+
+  // This function
+  wrapInLink(element) {
+    const { link, children, iconName } = this.props;
+    // If there's no link prop, then we don't want to wrap the element in a <Link>
+    if (link.length) {
+      return (
+        <Link to={link} className={iconName ? 'icon-padding' : ''}>{element}</Link>
+      );
+    } else if (children) {
+      // Else, this must be a grouping of children, so we'll wrap it accordingly.
+      return (
+        <div // eslint-disable-line jsx-a11y/no-static-element-interactions
+          className={`usa-grid-full ${iconName ? 'icon-padding' : ''}`}
+          onClick={this.toggleNestedLinksVisibility}
+          onKeyUp={(e) => { if (ifEnter(e)) { this.toggleNestedLinksVisibility(); } }}
+          role="link"
+          tabIndex="0"
+        >
+          {element}
+        </div>
+      );
+    }
+    // but if neither criteria is met, we'll simply return the element
+    return element;
+  }
+
+  // toggles visibility of grouped children links
+  toggleNestedLinksVisibility() {
+    if (this.props.children) {
+      const { showNestedLinks } = this.state;
+      showNestedLinks.value = !showNestedLinks.value;
+      this.setState({ showNestedLinks });
+    }
+  }
+
+  render() {
+    const { title, iconName, children, isHighlighted } = this.props;
+    const { showNestedLinks } = this.state;
+    return (
+      <li className={`usa-grid-full ${children ? 'expandable-link' : ''} ${isHighlighted ? 'link-highlighted' : 'link-unhighlighted'}`}>
+        <div className="list-item-wrapper">
+          {
+            this.wrapInLink( // wrap our element
+              <span>
+                {
+                  <span className="fa-container">
+                    {iconName ? <FontAwesome name={iconName} /> : null}
+                  </span>
+                }
+                <span className="title-container">
+                  {title}
+                </span>
+                {
+                  !!children && // if there are children, pass an angle-down/angle-right icon
+                  <span className="fa-container angle-container">
+                    <FontAwesome name={showNestedLinks.value ? 'angle-down' : 'angle-right'} />
+                  </span>
+                }
+              </span>,
+            )
+          }
+        </div>
+        {
+          // if the group was clicked and children exist, show the children
+          showNestedLinks.value &&
+          <ul className="children-ul">
+            {children}
+          </ul>
+        }
+      </li>
+    );
+  }
+}
+
+NavLink.propTypes = {
+  title: PropTypes.string.isRequired,
+  iconName: PropTypes.string,
+  link: PropTypes.string, // ex: "/profile/", "/profile/favorites/", etc.
+  children: PropTypes.node, // a group of child links. Should be rendered using this component
+  currentPath: PropTypes.string, // path the user is currently on
+
+  // whether or not the item should be highlighted. Typically when pathname matches the link
+  isHighlighted: PropTypes.bool,
+};
+
+NavLink.defaultProps = {
+  iconName: '',
+  link: '',
+  children: null,
+  currentPath: '',
+  isHighlighted: false,
+};
+
+export default NavLink;

--- a/src/Components/ProfileMenu/NavLink/NavLink.test.jsx
+++ b/src/Components/ProfileMenu/NavLink/NavLink.test.jsx
@@ -47,7 +47,7 @@ describe('NavLinkComponent', () => {
     expect(wrapper).toBeDefined();
   });
 
-  it('can apply link-highlighted class when isHighlighted is true', () => {
+  it('applies link-highlighted class when isHighlighted is true', () => {
     const wrapper = shallow(
       <NavLink
         title="test"
@@ -62,7 +62,7 @@ describe('NavLinkComponent', () => {
     expect(wrapper.find('.link-unhighlighted')).toHaveLength(0);
   });
 
-  it('can apply link-unhighlighted class when isHighlighted is false', () => {
+  it('applies link-unhighlighted class when isHighlighted is false', () => {
     const wrapper = shallow(
       <NavLink
         title="test"

--- a/src/Components/ProfileMenu/NavLink/NavLink.test.jsx
+++ b/src/Components/ProfileMenu/NavLink/NavLink.test.jsx
@@ -1,0 +1,123 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import toJSON from 'enzyme-to-json';
+import NavLink from './NavLink';
+
+describe('NavLinkComponent', () => {
+  it('is defined with no children', () => {
+    const wrapper = shallow(
+      <NavLink
+        title="test"
+      />,
+    );
+    expect(wrapper).toBeDefined();
+  });
+
+  it('is defined with one child', () => {
+    const wrapper = shallow(
+      <NavLink
+        title="test"
+        currentPath="/profile/favorites/"
+      >
+        <NavLink
+          title="test2"
+          link="/profile/favorites/"
+        />
+      </NavLink>,
+    );
+    expect(wrapper).toBeDefined();
+  });
+
+  it('is defined with multiple children', () => {
+    const wrapper = shallow(
+      <NavLink
+        title="test"
+        currentPath="/profile/favorites/"
+      >
+        <NavLink
+          title="test2"
+          link="/profile/favorites/"
+        />
+        <NavLink
+          title="test3"
+          link="/profile/searches/"
+        />
+      </NavLink>,
+    );
+    expect(wrapper).toBeDefined();
+  });
+
+  it('can apply link-highlighted class when isHighlighted is true', () => {
+    const wrapper = shallow(
+      <NavLink
+        title="test"
+        currentPath="/profile/favorites/"
+        link="/profile/favorites/"
+        isHighlighted
+      />,
+    );
+    // should exist
+    expect(wrapper.find('.link-highlighted')).toHaveLength(1);
+    // should not exist
+    expect(wrapper.find('.link-unhighlighted')).toHaveLength(0);
+  });
+
+  it('can apply link-unhighlighted class when isHighlighted is false', () => {
+    const wrapper = shallow(
+      <NavLink
+        title="test"
+        currentPath="/profile/favorites/"
+        link="/profile/favorites/"
+        isHighlighted={false}
+      />,
+    );
+    // should not exist
+    expect(wrapper.find('.link-highlighted')).toHaveLength(0);
+    // should exist
+    expect(wrapper.find('.link-unhighlighted')).toHaveLength(1);
+  });
+
+  it('can expand and close a grouped list', () => {
+    const wrapper = shallow(
+      <NavLink
+        title="test"
+        currentPath="/profile/favorites/"
+      >
+        <NavLink
+          title="test2"
+          link="/profile/favorites/"
+        />
+        <NavLink
+          title="test3"
+          link="/profile/searches/"
+        />
+      </NavLink>,
+    );
+    // children should be rendered, since we have a child link that matches the current path
+    expect(wrapper.find('.children-ul')).toHaveLength(1);
+    // click the div
+    wrapper.find('[role="link"]').simulate('click');
+    // should change showNestedLinks.value to false
+    expect(wrapper.instance().state.showNestedLinks.value).toBe(false);
+    // children should disappear
+    expect(wrapper.find('.children-ul')).toHaveLength(0);
+    // click/enter again
+    wrapper.find('[role="link"]').simulate('keyUp', { keyCode: 13 });
+    // should change showNestedLinks.value to true
+    expect(wrapper.instance().state.showNestedLinks.value).toBe(true);
+    // children should re-appear
+    expect(wrapper.find('.children-ul')).toHaveLength(1);
+  });
+
+  it('matches snapshot without children', () => {
+    const wrapper = shallow(
+      <NavLink
+        title="test"
+        currentPath="/profile/favorites/"
+        link="/profile/favorites/"
+        isHighlighted
+      />,
+    );
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/Components/ProfileMenu/NavLink/__snapshots__/NavLink.test.jsx.snap
+++ b/src/Components/ProfileMenu/NavLink/__snapshots__/NavLink.test.jsx.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NavLinkComponent matches snapshot without children 1`] = `
+<li
+  className="usa-grid-full  link-highlighted"
+>
+  <div
+    className="list-item-wrapper"
+  >
+    <Link
+      className=""
+      replace={false}
+      to="/profile/favorites/"
+    >
+      <span>
+        <span
+          className="fa-container"
+        />
+        <span
+          className="title-container"
+        >
+          test
+        </span>
+      </span>
+    </Link>
+  </div>
+</li>
+`;

--- a/src/Components/ProfileMenu/NavLink/index.js
+++ b/src/Components/ProfileMenu/NavLink/index.js
@@ -1,0 +1,1 @@
+export { default } from './NavLink';

--- a/src/Components/ProfileMenu/NavLinksContainer/NavLinksContainer.jsx
+++ b/src/Components/ProfileMenu/NavLinksContainer/NavLinksContainer.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const NavLinksContainer = ({ children }) => (
+  <ul>
+    {children}
+  </ul>
+);
+
+NavLinksContainer.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default NavLinksContainer;

--- a/src/Components/ProfileMenu/NavLinksContainer/NavLinksContainer.test.jsx
+++ b/src/Components/ProfileMenu/NavLinksContainer/NavLinksContainer.test.jsx
@@ -1,0 +1,26 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import toJSON from 'enzyme-to-json';
+import NavLinksContainer from './NavLinksContainer';
+
+describe('NavLinksContainerComponent', () => {
+  const element = (
+    <NavLinksContainer>
+      <li>test 1</li>
+      <li>test 2</li>
+    </NavLinksContainer>
+  );
+  it('is defined', () => {
+    const wrapper = shallow(
+      element,
+    );
+    expect(wrapper).toBeDefined();
+  });
+
+  it('matches snapshot', () => {
+    const wrapper = shallow(
+      element,
+    );
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/Components/ProfileMenu/NavLinksContainer/__snapshots__/NavLinksContainer.test.jsx.snap
+++ b/src/Components/ProfileMenu/NavLinksContainer/__snapshots__/NavLinksContainer.test.jsx.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NavLinksContainerComponent matches snapshot 1`] = `
+<ul>
+  <li>
+    test 1
+  </li>
+  <li>
+    test 2
+  </li>
+</ul>
+`;

--- a/src/Components/ProfileMenu/NavLinksContainer/index.js
+++ b/src/Components/ProfileMenu/NavLinksContainer/index.js
@@ -1,0 +1,1 @@
+export { default } from './NavLinksContainer';

--- a/src/Components/ProfileMenu/ProfileMenu.jsx
+++ b/src/Components/ProfileMenu/ProfileMenu.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import NavLinksContainer from './NavLinksContainer';
+import NavLink from './NavLink';
+
+const ProfileMenu = ({ currentPath }) => (
+  <div className="usa-grid-full profile-menu">
+    <div className="menu-title">
+      Menu
+    </div>
+    <NavLinksContainer>
+      <NavLink title="Home" iconName="home" link="/profile/" isHighlighted={currentPath === '/profile/'} />
+      <NavLink title="Profile" iconName="user" currentPath={currentPath}>
+        <NavLink title="Dashboard" link="/profile/dashboard/" isHighlighted={currentPath === '/profile/dashboard/'} />
+        <NavLink title="Bid List" link="/profile/bidlist/" isHighlighted={currentPath === '/profile/bidlist/'} />
+        <NavLink title="Favorites" link="/profile/favorites/" isHighlighted={currentPath === '/profile/favorites/'} />
+        <NavLink title="Saved Searches" link="/profile/searches/" isHighlighted={currentPath === '/profile/searches/'} />
+      </NavLink>
+      <NavLink title="Inbox" iconName="comments-o" link="/profile/inbox/" isHighlighted={currentPath === '/profile/inbox/'} />
+      <NavLink title="Notifications" iconName="globe" link="/profile/notifications/" isHighlighted={currentPath === '/profile/notifications/'} />
+      <NavLink title="Contacts" iconName="users" link="/profile/contacts/" isHighlighted={currentPath === '/profile/contacts/'} />
+      <NavLink title="Documents" iconName="file-text" link="/profile/documents/" isHighlighted={currentPath === '/profile/documents/'} />
+    </NavLinksContainer>
+  </div>
+);
+
+ProfileMenu.propTypes = {
+  currentPath: PropTypes.string.isRequired,
+};
+
+export default ProfileMenu;

--- a/src/Components/ProfileMenu/ProfileMenu.test.jsx
+++ b/src/Components/ProfileMenu/ProfileMenu.test.jsx
@@ -1,0 +1,36 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import toJSON from 'enzyme-to-json';
+import ProfileMenu from './ProfileMenu';
+
+describe('ProfileMenuComponent', () => {
+  it('is defined', () => {
+    const wrapper = shallow(
+      <ProfileMenu
+        currentPath="/profile/favorites/"
+      />,
+    );
+    expect(wrapper).toBeDefined();
+  });
+
+  it('it sets isHighlighted to correct values', () => {
+    const wrapper = shallow(
+      <ProfileMenu
+        currentPath="/profile/favorites/"
+      />,
+    );
+    expect(wrapper.find('[title="Bid List"]').prop('isHighlighted')).toBe(false);
+    // Favorites should be the only highlighted link
+    expect(wrapper.find('[title="Favorites"]').prop('isHighlighted')).toBe(true);
+    expect(wrapper.find('[title="Inbox"]').prop('isHighlighted')).toBe(false);
+  });
+
+  it('matches snapshot', () => {
+    const wrapper = shallow(
+      <ProfileMenu
+        currentPath="/profile/favorites/"
+      />,
+    );
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/Components/ProfileMenu/__snapshots__/ProfileMenu.test.jsx.snap
+++ b/src/Components/ProfileMenu/__snapshots__/ProfileMenu.test.jsx.snap
@@ -1,0 +1,86 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ProfileMenuComponent matches snapshot 1`] = `
+<div
+  className="usa-grid-full profile-menu"
+>
+  <div
+    className="menu-title"
+  >
+    Menu
+  </div>
+  <NavLinksContainer>
+    <NavLink
+      currentPath=""
+      iconName="home"
+      isHighlighted={false}
+      link="/profile/"
+      title="Home"
+    />
+    <NavLink
+      currentPath="/profile/favorites/"
+      iconName="user"
+      isHighlighted={false}
+      link=""
+      title="Profile"
+    >
+      <NavLink
+        currentPath=""
+        iconName=""
+        isHighlighted={false}
+        link="/profile/dashboard/"
+        title="Dashboard"
+      />
+      <NavLink
+        currentPath=""
+        iconName=""
+        isHighlighted={false}
+        link="/profile/bidlist/"
+        title="Bid List"
+      />
+      <NavLink
+        currentPath=""
+        iconName=""
+        isHighlighted={true}
+        link="/profile/favorites/"
+        title="Favorites"
+      />
+      <NavLink
+        currentPath=""
+        iconName=""
+        isHighlighted={false}
+        link="/profile/searches/"
+        title="Saved Searches"
+      />
+    </NavLink>
+    <NavLink
+      currentPath=""
+      iconName="comments-o"
+      isHighlighted={false}
+      link="/profile/inbox/"
+      title="Inbox"
+    />
+    <NavLink
+      currentPath=""
+      iconName="globe"
+      isHighlighted={false}
+      link="/profile/notifications/"
+      title="Notifications"
+    />
+    <NavLink
+      currentPath=""
+      iconName="users"
+      isHighlighted={false}
+      link="/profile/contacts/"
+      title="Contacts"
+    />
+    <NavLink
+      currentPath=""
+      iconName="file-text"
+      isHighlighted={false}
+      link="/profile/documents/"
+      title="Documents"
+    />
+  </NavLinksContainer>
+</div>
+`;

--- a/src/Components/ProfileMenu/index.js
+++ b/src/Components/ProfileMenu/index.js
@@ -1,0 +1,1 @@
+export { default } from './ProfileMenu';

--- a/src/Components/ProfilePage/ProfilePage.jsx
+++ b/src/Components/ProfilePage/ProfilePage.jsx
@@ -1,44 +1,50 @@
 import React from 'react';
 import { Route, Switch } from 'react-router-dom';
+import PropTypes from 'prop-types';
 import ProfileNavigation from '../ProfileNavigation';
 import ProfileLanding from '../ProfileLanding';
 import BidListContainer from '../../Containers/BidList/BidList';
 import FavoritePositionsContainer from '../../Containers/Favorites/Favorites';
 import SavedSearchesContainer from '../../Containers/SavedSearches/SavedSearches';
+import ProfileMenu from '../ProfileMenu';
 import { USER_PROFILE } from '../../Constants/PropTypes';
 
-const ProfilePage = ({ user }) => (
-  <div className="usa-grid-full">
-    <h1>
-      {
-        `Hello, ${user.user.username}!`
-      }
-    </h1>
-    <div className="usa-width-one-fourth">
-      <ProfileNavigation />
-    </div>
-    <div className="usa-grid-full usa-width-three-fourths profile-subroute-container">
-      <Switch>
-        <Route path="/profile" exact component={ProfileLanding} />
-        <Route
-          path="/profile/favorites"
-          component={FavoritePositionsContainer}
-        />
-        <Route
-          path="/profile/searches"
-          component={SavedSearchesContainer}
-        />
-        <Route
-          path="/profile/bidlist"
-          component={BidListContainer}
-        />
-      </Switch>
+const ProfilePage = ({ user, currentPath }) => (
+  <div className="profile-page">
+    <ProfileMenu currentPath={currentPath} />
+    <div className="usa-grid-full profile-content-container">
+      <h1>
+        {
+          `Hello, ${user.user.username}!`
+        }
+      </h1>
+      <div className="usa-width-one-fourth">
+        <ProfileNavigation />
+      </div>
+      <div className="usa-grid-full usa-width-three-fourths profile-subroute-container">
+        <Switch>
+          <Route path="/profile" exact component={ProfileLanding} />
+          <Route
+            path="/profile/favorites"
+            component={FavoritePositionsContainer}
+          />
+          <Route
+            path="/profile/searches"
+            component={SavedSearchesContainer}
+          />
+          <Route
+            path="/profile/bidlist"
+            component={BidListContainer}
+          />
+        </Switch>
+      </div>
     </div>
   </div>
 );
 
 ProfilePage.propTypes = {
   user: USER_PROFILE.isRequired,
+  currentPath: PropTypes.string.isRequired,
 };
 
 export default ProfilePage;

--- a/src/Components/ProfilePage/ProfilePage.jsx
+++ b/src/Components/ProfilePage/ProfilePage.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Route, Switch } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import ProfileNavigation from '../ProfileNavigation';
 import ProfileLanding from '../ProfileLanding';
 import BidListContainer from '../../Containers/BidList/BidList';
 import FavoritePositionsContainer from '../../Containers/Favorites/Favorites';
 import SavedSearchesContainer from '../../Containers/SavedSearches/SavedSearches';
+import Dashboard from '../../Containers/Dashboard/Dashboard';
 import ProfileMenu from '../ProfileMenu';
 import { USER_PROFILE } from '../../Constants/PropTypes';
 
@@ -13,31 +13,27 @@ const ProfilePage = ({ user, currentPath }) => (
   <div className="profile-page">
     <ProfileMenu currentPath={currentPath} />
     <div className="usa-grid-full profile-content-container">
-      <h1>
+      <div className="hello-greeting">
         {
-          `Hello, ${user.user.username}!`
+          `Hello, ${user.user.username}`
         }
-      </h1>
-      <div className="usa-width-one-fourth">
-        <ProfileNavigation />
       </div>
-      <div className="usa-grid-full usa-width-three-fourths profile-subroute-container">
-        <Switch>
-          <Route path="/profile" exact component={ProfileLanding} />
-          <Route
-            path="/profile/favorites"
-            component={FavoritePositionsContainer}
-          />
-          <Route
-            path="/profile/searches"
-            component={SavedSearchesContainer}
-          />
-          <Route
-            path="/profile/bidlist"
-            component={BidListContainer}
-          />
-        </Switch>
-      </div>
+      <Switch>
+        <Route path="/profile" exact component={ProfileLanding} />
+        <Route path="/profile/dashboard" exact component={Dashboard} />
+        <Route
+          path="/profile/favorites"
+          component={FavoritePositionsContainer}
+        />
+        <Route
+          path="/profile/searches"
+          component={SavedSearchesContainer}
+        />
+        <Route
+          path="/profile/bidlist"
+          component={BidListContainer}
+        />
+      </Switch>
     </div>
   </div>
 );

--- a/src/Components/ProfilePage/ProfilePage.jsx
+++ b/src/Components/ProfilePage/ProfilePage.jsx
@@ -20,7 +20,7 @@ const ProfilePage = ({ user, currentPath }) => (
       </div>
       <Switch>
         <Route path="/profile" exact component={ProfileLanding} />
-        <Route path="/profile/dashboard" exact component={Dashboard} />
+        <Route path="/profile/dashboard" component={Dashboard} />
         <Route
           path="/profile/favorites"
           component={FavoritePositionsContainer}

--- a/src/Components/ProfilePage/ProfilePage.test.jsx
+++ b/src/Components/ProfilePage/ProfilePage.test.jsx
@@ -43,6 +43,7 @@ describe('ProfilePageComponent', () => {
     submitBidHasErrored: false,
     submitBidIsLoading: false,
     submitBidSuccess: false,
+    currentPath: '/profile/favorites/',
   };
 
   it('is defined', () => {

--- a/src/Components/ProfilePage/__snapshots__/ProfilePage.test.jsx.snap
+++ b/src/Components/ProfilePage/__snapshots__/ProfilePage.test.jsx.snap
@@ -2,38 +2,45 @@
 
 exports[`ProfilePageComponent matches snapshot 1`] = `
 <div
-  className="usa-grid-full"
+  className="profile-page"
 >
-  <h1>
-    Hello, john!
-  </h1>
+  <ProfileMenu
+    currentPath="/profile/favorites/"
+  />
   <div
-    className="usa-width-one-fourth"
+    className="usa-grid-full profile-content-container"
   >
-    <ProfileNavigation />
-  </div>
-  <div
-    className="usa-grid-full usa-width-three-fourths profile-subroute-container"
-  >
-    <Switch>
-      <Route
-        component={[Function]}
-        exact={true}
-        path="/profile"
-      />
-      <Route
-        component={[Function]}
-        path="/profile/favorites"
-      />
-      <Route
-        component={[Function]}
-        path="/profile/searches"
-      />
-      <Route
-        component={[Function]}
-        path="/profile/bidlist"
-      />
-    </Switch>
+    <h1>
+      Hello, john!
+    </h1>
+    <div
+      className="usa-width-one-fourth"
+    >
+      <ProfileNavigation />
+    </div>
+    <div
+      className="usa-grid-full usa-width-three-fourths profile-subroute-container"
+    >
+      <Switch>
+        <Route
+          component={[Function]}
+          exact={true}
+          path="/profile"
+        />
+        <Route
+          component={[Function]}
+          path="/profile/favorites"
+        />
+        <Route
+          component={[Function]}
+          path="/profile/searches"
+        />
+        <Route
+          component={[Function]}
+          path="/profile/bidlist"
+        />
+      </Switch>
+    </div>
   </div>
 </div>
 `;

--- a/src/Components/ProfilePage/__snapshots__/ProfilePage.test.jsx.snap
+++ b/src/Components/ProfilePage/__snapshots__/ProfilePage.test.jsx.snap
@@ -23,7 +23,6 @@ exports[`ProfilePageComponent matches snapshot 1`] = `
       />
       <Route
         component={[Function]}
-        exact={true}
         path="/profile/dashboard"
       />
       <Route

--- a/src/Components/ProfilePage/__snapshots__/ProfilePage.test.jsx.snap
+++ b/src/Components/ProfilePage/__snapshots__/ProfilePage.test.jsx.snap
@@ -10,37 +10,35 @@ exports[`ProfilePageComponent matches snapshot 1`] = `
   <div
     className="usa-grid-full profile-content-container"
   >
-    <h1>
-      Hello, john!
-    </h1>
     <div
-      className="usa-width-one-fourth"
+      className="hello-greeting"
     >
-      <ProfileNavigation />
+      Hello, john
     </div>
-    <div
-      className="usa-grid-full usa-width-three-fourths profile-subroute-container"
-    >
-      <Switch>
-        <Route
-          component={[Function]}
-          exact={true}
-          path="/profile"
-        />
-        <Route
-          component={[Function]}
-          path="/profile/favorites"
-        />
-        <Route
-          component={[Function]}
-          path="/profile/searches"
-        />
-        <Route
-          component={[Function]}
-          path="/profile/bidlist"
-        />
-      </Switch>
-    </div>
+    <Switch>
+      <Route
+        component={[Function]}
+        exact={true}
+        path="/profile"
+      />
+      <Route
+        component={[Function]}
+        exact={true}
+        path="/profile/dashboard"
+      />
+      <Route
+        component={[Function]}
+        path="/profile/favorites"
+      />
+      <Route
+        component={[Function]}
+        path="/profile/searches"
+      />
+      <Route
+        component={[Function]}
+        path="/profile/bidlist"
+      />
+    </Switch>
   </div>
 </div>
 `;

--- a/src/Containers/Dashboard/Dashboard.jsx
+++ b/src/Containers/Dashboard/Dashboard.jsx
@@ -1,0 +1,41 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router';
+import ProfileDashboard from '../../Components/ProfileDashboard';
+
+class DashboardContainer extends Component {
+  // eslint-disable-next-line
+  constructor(props) {
+    super(props);
+  }
+
+  componentWillMount() {
+  }
+
+  render() {
+    return (
+      <ProfileDashboard />
+    );
+  }
+}
+
+DashboardContainer.propTypes = {
+};
+
+DashboardContainer.defaultProps = {
+};
+
+DashboardContainer.contextTypes = {
+  router: PropTypes.object,
+};
+
+// eslint-disable-next-line
+const mapStateToProps = state => ({
+});
+
+// eslint-disable-next-line
+const mapDispatchToProps = dispatch => ({
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(withRouter(DashboardContainer));

--- a/src/Containers/Dashboard/Dashboard.test.jsx
+++ b/src/Containers/Dashboard/Dashboard.test.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import TestUtils from 'react-dom/test-utils';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import DashboardContainer from './Dashboard';
+
+const middlewares = [thunk];
+const mockStore = configureStore(middlewares);
+
+describe('DashboardContainer', () => {
+  it('is defined', () => {
+    const wrapper = TestUtils.renderIntoDocument(<Provider store={mockStore({})}><MemoryRouter>
+      <DashboardContainer />
+    </MemoryRouter></Provider>);
+    expect(wrapper).toBeDefined();
+  });
+});

--- a/src/Containers/Profile/Profile.jsx
+++ b/src/Containers/Profile/Profile.jsx
@@ -19,11 +19,10 @@ class Profile extends Component {
   render() {
     const { userProfile } = this.props;
     return (
-      <div>
-        <ProfilePage
-          user={userProfile}
-        />
-      </div>
+      <ProfilePage
+        user={userProfile}
+        currentPath={this.props.location.pathname}
+      />
     );
   }
 }
@@ -32,11 +31,15 @@ Profile.propTypes = {
   onNavigateTo: PropTypes.func.isRequired,
   isAuthorized: PropTypes.func.isRequired,
   userProfile: USER_PROFILE,
+  location: PropTypes.shape({
+    pathname: PropTypes.string,
+  }),
 };
 
 Profile.defaultProps = {
   isLoading: true,
   userProfile: DEFAULT_USER_PROFILE,
+  location: { pathname: '' },
 };
 
 Profile.contextTypes = {

--- a/src/sass/_overrides.scss
+++ b/src/sass/_overrides.scss
@@ -4,3 +4,8 @@
     color: $color-white;
   }
 }
+
+.unstyled-button {
+  background-color: unset;
+  color: unset;
+}

--- a/src/sass/_profile.scss
+++ b/src/sass/_profile.scss
@@ -6,6 +6,11 @@
   border: solid 1px $color-gray-light;
   position: relative;
 
+  .hello-greeting {
+    font-family: Merriweather;
+    margin-bottom: 10px;
+  }
+
   .usa-grid-full {
     max-width: unset;
   }
@@ -34,12 +39,61 @@
   }
 
   .profile-content-container {
+    background-color: $tm-white-smoke-light;
     height: 700px;
     margin-left: 200px;
     overflow-y: auto;
-    padding: 35px;
+    padding: 20px 35px;
     right: 0;
     width: auto;
+  }
+}
+
+.user-dashboard {
+  .user-dashboard-section-container {
+    float: left;
+  }
+
+  .user-dashboard-section {
+    background-color: $color-white;
+    border: solid 1px $color-gray-light;
+    margin-bottom: 25px;
+  }
+
+  .user-dashboard-column-1 {
+    min-height: 500px;
+  }
+
+  .user-dashboard-column-2 {
+    min-height: 500px;
+  }
+
+  .user-dashboard-column-3 {
+    min-height: 700px;
+  }
+
+  .current-user-section {
+    min-height: 450px;
+  }
+
+  .cdo-section {
+    min-height: 50px;
+  }
+
+  .position-info-section {
+    min-height: 250px;
+  }
+
+  .notifications-section {
+    min-height: 250px;
+  }
+
+  .bidlist-section {
+    min-height: 400px;
+  }
+
+  .inbox-section {
+    min-height: 300px;
   }
 }
 

--- a/src/sass/_profile.scss
+++ b/src/sass/_profile.scss
@@ -1,22 +1,143 @@
-.favorite-positions-container {
+// scss-lint:disable SelectorDepth
+// scss-lint:disable NestingDepth
+// Nesting depth was needed, otherwise styles broke if placed outside of parent class (.expandable-link)
+
+.profile-page {
+  border: solid 1px $color-gray-light;
   position: relative;
+
+  .usa-grid-full {
+    max-width: unset;
+  }
+
+  .favorite-positions-container {
+    position: relative;
+  }
+
+  .profile-subroute-container {
+    border: 1px solid $color-gray;
+    min-height: 300px;
+  }
+
+  .saved-search-card {
+    border-top: 1px solid $color-black;
+    min-height: 50px;
+    padding: 10px;
+  }
+
+  .saved-searches-container {
+    position: relative;
+  }
+
+  .bid-list-delete-button-container {
+    margin-top: .5em;
+  }
+
+  .profile-content-container {
+    height: 700px;
+    margin-left: 200px;
+    overflow-y: auto;
+    padding: 35px;
+    right: 0;
+    width: auto;
+  }
 }
 
-.profile-subroute-container {
-  border: 1px solid $color-gray;
-  min-height: 300px;
-}
+$total-padding: 28px;
+$border: 5px;
+$padding-no-border: $total-padding - $border;
 
-.saved-search-card {
-  border-top: 1px solid $color-black;
-  min-height: 50px;
-  padding: 10px;
-}
+.profile-menu {
 
-.saved-searches-container {
-  position: relative;
-}
+  border-right: solid 1px $color-gray-light;
+  font-size: 15px;
+  height: 100%;
+  position: absolute;
+  width: 200px;
 
-.bid-list-delete-button-container {
-  margin-top: .5em;
+  .fa-container {
+    float: left;
+    min-width: $total-padding;
+  }
+
+  .title-container {
+    float: left;
+  }
+
+  .angle-container {
+    float: right;
+  }
+
+  .icon-padding {
+    padding: 3px 0;
+  }
+
+  .link-unhighlighted {
+    border-left: $border solid transparent;
+  }
+
+  .link-highlighted {
+    background-color: $color-blue-light;
+    border-left: $border solid $blue-primary;
+
+    .title-container {
+      font-weight: bold;
+    }
+  }
+
+  .list-item-wrapper {
+    padding-left: $padding-no-border;
+    padding-top: 5px;
+  }
+
+  .expandable-link {
+    border-left: unset;
+    margin-bottom: 7px;
+
+    .list-item-wrapper {
+      padding-left: $total-padding;
+    }
+
+    ul {
+      .link-unhighlighted {
+        border-left: unset;
+        padding-left: $border;
+      }
+    }
+  }
+
+  .children-ul {
+    margin-top: .5em;
+
+    .list-item-wrapper {
+      padding-left: 50px;
+    }
+  }
+
+  .menu-title {
+    font-weight: bold;
+    padding: 10px 0 0 30px;
+  }
+
+  a {
+    color: unset;
+    display: inline-block;
+    width: 100%;
+  }
+
+  li {
+    cursor: pointer;
+    line-height: 1.5;
+    margin-bottom: unset;
+    width: 100%;
+  }
+
+  ul {
+    list-style-type: none;
+    padding: 0;
+
+    .fa {
+      margin-right: 10px;
+    }
+  }
 }

--- a/src/sass/_variables.scss
+++ b/src/sass/_variables.scss
@@ -12,6 +12,7 @@ $tm-white-smoke: #f5f5f5;
 $tm-navy: #215493;
 $color-primary-alt-light: #9bdaf1;
 $color-primary-alt-lightest: #e1f3f8;
+$color-blue-light: #e6f0f9;
 
 //avatar dropdown
 $avatar-background: #fff;

--- a/src/sass/_variables.scss
+++ b/src/sass/_variables.scss
@@ -9,6 +9,7 @@ $color-black: #000;
 $color-gray: #5b616b;
 $tm-dark-blue: #00293f;
 $tm-white-smoke: #f5f5f5;
+$tm-white-smoke-light: #f7f7f7;
 $tm-navy: #215493;
 $color-primary-alt-light: #9bdaf1;
 $color-primary-alt-lightest: #e1f3f8;


### PR DESCRIPTION
Adds the base container and grid for the profile dashboard. Uses dummy components which will eventually be filled with data. Used with a `connect`ed container, but not pulling any thing from redux state (will be one of the next steps).

Dependent on #894