### PR TITLE
Add static values for Position TED and Incumbent

### DIFF
--- a/src/Components/PositionDetailsItem/PositionDetailsItem.jsx
+++ b/src/Components/PositionDetailsItem/PositionDetailsItem.jsx
@@ -68,6 +68,14 @@ const PositionDetailsItem = ({ details }) => (
               title="Danger Pay"
               description={details.post ? details.post.danger_pay : NO_DANGER_PAY}
             />
+            <PositionDetailsDataPoint
+              title="Tour End Date"
+              description="09-01-2019"
+            />
+            <PositionDetailsDataPoint
+              title="Incumbent"
+              description="Incumbent"
+            />
           </div>
         </div>
       </div>

--- a/src/Components/PositionDetailsItem/__snapshots__/PositionDetailsItem.test.jsx.snap
+++ b/src/Components/PositionDetailsItem/__snapshots__/PositionDetailsItem.test.jsx.snap
@@ -100,6 +100,14 @@ exports[`PositionDetailsItem matches snapshot 1`] = `
             description={0}
             title="Danger Pay"
           />
+          <PositionDetailsDataPoint
+            description="09-01-2019"
+            title="Tour End Date"
+          />
+          <PositionDetailsDataPoint
+            description="Incumbent"
+            title="Incumbent"
+          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
Adds static values to the Position details page with Tour End Date and Incumbent. These are static values for now, until they are exposed by the `/position/` endpoint.