### PR TITLE
Improved test coverage for #935 by resetting mockAdapter

### DIFF
--- a/src/actions/bidList.test.js
+++ b/src/actions/bidList.test.js
@@ -28,7 +28,7 @@ describe('async actions', () => {
     ],
   };
 
-// reset the mockAdapter since we repeat specific requests
+  // reset the mockAdapter since we repeat specific requests
   beforeEach(() => {
     mockAdapter.reset();
   });

--- a/src/actions/bidList.test.js
+++ b/src/actions/bidList.test.js
@@ -28,6 +28,11 @@ describe('async actions', () => {
     ],
   };
 
+// reset the mockAdapter since we repeat specific requests
+  beforeEach(() => {
+    mockAdapter.reset();
+  });
+
   it('can fetch a bid list', (done) => {
     const store = mockStore({ });
 

--- a/src/actions/descriptionEdit.test.js
+++ b/src/actions/descriptionEdit.test.js
@@ -4,6 +4,11 @@ import * as actions from './descriptionEdit';
 const { mockStore, mockAdapter } = setupAsyncMocks();
 
 describe('async actions', () => {
+  // reset the mockAdapter since we repeat specific requests
+  beforeEach(() => {
+    mockAdapter.reset();
+  });
+
   it('can call the editDescriptionContent function', (done) => {
     const store = mockStore({});
 

--- a/src/actions/savedSearch.test.js
+++ b/src/actions/savedSearch.test.js
@@ -5,6 +5,11 @@ import searchObjectParent from '../__mocks__/searchObjectParent';
 const { mockStore, mockAdapter } = setupAsyncMocks();
 
 describe('saved search async actions', () => {
+  // reset the mockAdapter since we repeat specific requests
+  beforeEach(() => {
+    mockAdapter.reset();
+  });
+
   it('can submit request to save a search', (done) => {
     const store = mockStore({ share: false });
 

--- a/src/actions/share.test.js
+++ b/src/actions/share.test.js
@@ -2,10 +2,13 @@ import setupAsyncMocks from './setupAsyncMocks';
 import * as actions from './share';
 
 const { mockStore, mockAdapter } = setupAsyncMocks();
-
 const testEmail = 'test@email.com';
 
 describe('async actions', () => {
+  // reset the mockAdapter since we repeat specific requests
+  beforeEach(() => {
+    mockAdapter.reset();
+  });
   it('can submit request to send email', (done) => {
     const store = mockStore({ share: false });
 

--- a/src/actions/userProfile.test.js
+++ b/src/actions/userProfile.test.js
@@ -17,6 +17,11 @@ describe('async actions', () => {
     received_shares: [],
   };
 
+  // reset the mockAdapter since we repeat specific requests
+  beforeEach(() => {
+    mockAdapter.reset();
+  });
+
   it('can fetch a position', (done) => {
     const store = mockStore({ profile: {} });
 


### PR DESCRIPTION
Brings code coverage back up from #935 by resetting the `mockAdapter` between tests.