### PR TITLE
Move isHighlighted logic to the NavLink component

### DIFF
--- a/src/Components/ProfileMenu/NavLink/NavLink.jsx
+++ b/src/Components/ProfileMenu/NavLink/NavLink.jsx
@@ -87,7 +87,8 @@ class NavLink extends Component {
   }
 
   render() {
-    const { title, iconName, children, isHighlighted } = this.props;
+    const { title, iconName, children, link } = this.props;
+    const isHighlighted = isCurrentPath(this.props.location.pathname, link);
     const { showNestedLinks } = this.state;
     return (
       <li className={`usa-grid-full ${children ? 'expandable-link' : ''} ${isHighlighted ? 'link-highlighted' : 'link-unhighlighted'}`}>
@@ -131,17 +132,12 @@ NavLink.propTypes = {
   link: PropTypes.string, // ex: "/profile/", "/profile/favorites/", etc.
   children: PropTypes.node, // a group of child links. Should be rendered using this component
   location: ROUTER_LOCATION_OBJECT.isRequired,
-
-  // whether or not the item should be highlighted. Typically when pathname matches the link
-  isHighlighted: PropTypes.bool,
 };
 
 NavLink.defaultProps = {
   iconName: '',
   link: '',
   children: null,
-  currentPath: '',
-  isHighlighted: false,
 };
 
 export default withRouter(NavLink);

--- a/src/Components/ProfileMenu/NavLink/NavLink.test.jsx
+++ b/src/Components/ProfileMenu/NavLink/NavLink.test.jsx
@@ -60,7 +60,6 @@ describe('NavLinkComponent', () => {
         title="test"
         location={locationMock}
         link="/profile/favorites/"
-        isHighlighted
       />,
     );
     // should exist
@@ -74,8 +73,7 @@ describe('NavLinkComponent', () => {
       <NavLinkUnwrapped
         title="test"
         location={locationMock}
-        link="/profile/favorites/"
-        isHighlighted={false}
+        link="/profile/bidlist/"
       />,
     );
     // should not exist
@@ -126,7 +124,6 @@ describe('NavLinkComponent', () => {
         title="test"
         location={locationMock}
         link="/profile/favorites/"
-        isHighlighted
       />,
     );
     expect(toJSON(wrapper)).toMatchSnapshot();

--- a/src/Components/ProfileMenu/ProfileMenu.jsx
+++ b/src/Components/ProfileMenu/ProfileMenu.jsx
@@ -1,46 +1,26 @@
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { withRouter } from 'react-router';
-import { ROUTER_LOCATION_OBJECT } from '../../Constants/PropTypes';
+import React from 'react';
 import NavLinksContainer from './NavLinksContainer';
 import NavLink from './NavLink';
-import isCurrentPath from './navigation';
 
-class ProfileMenu extends Component {
-  checkForCurrentPath(pathName) {
-    return isCurrentPath(this.props.location.pathname, pathName);
-  }
-  render() {
-    const { location: { pathname } } = this.props;
-    return (
-      <div className="usa-grid-full profile-menu">
-        <div className="menu-title">
-          Menu
-        </div>
-        <NavLinksContainer>
-          <NavLink title="Home" iconName="home" link="/profile/" isHighlighted={this.checkForCurrentPath('/profile/')} />
-          <NavLink title="Profile" iconName="user" currentPath={pathname}>
-            <NavLink title="Dashboard" link="/profile/dashboard/" isHighlighted={this.checkForCurrentPath('/profile/dashboard/')} />
-            <NavLink title="Bid List" link="/profile/bidlist/" isHighlighted={this.checkForCurrentPath('/profile/bidlist/')} />
-            <NavLink title="Favorites" link="/profile/favorites/" isHighlighted={this.checkForCurrentPath('/profile/favorites/')} />
-            <NavLink title="Saved Searches" link="/profile/searches/" isHighlighted={this.checkForCurrentPath('/profile/searches/')} />
-          </NavLink>
-          <NavLink title="Inbox" iconName="comments-o" link="/profile/inbox/" isHighlighted={this.checkForCurrentPath('/profile/inbox/')} />
-          <NavLink title="Notifications" iconName="globe" link="/profile/notifications/" isHighlighted={this.checkForCurrentPath('/profile/notifications/')} />
-          <NavLink title="Contacts" iconName="users" link="/profile/contacts/" isHighlighted={this.checkForCurrentPath('/profile/contacts/')} />
-          <NavLink title="Documents" iconName="file-text" link="/profile/documents/" isHighlighted={this.checkForCurrentPath('/profile/documents/')} />
-        </NavLinksContainer>
-      </div>
-    );
-  }
-}
+const ProfileMenu = () => (
+  <div className="usa-grid-full profile-menu">
+    <div className="menu-title">
+      Menu
+    </div>
+    <NavLinksContainer>
+      <NavLink title="Home" iconName="home" link="/profile/" />
+      <NavLink title="Profile" iconName="user" >
+        <NavLink title="Dashboard" link="/profile/dashboard/" />
+        <NavLink title="Bid List" link="/profile/bidlist/" />
+        <NavLink title="Favorites" link="/profile/favorites/" />
+        <NavLink title="Saved Searches" link="/profile/searches/" />
+      </NavLink>
+      <NavLink title="Inbox" iconName="comments-o" link="/profile/inbox/" />
+      <NavLink title="Notifications" iconName="globe" link="/profile/notifications/" />
+      <NavLink title="Contacts" iconName="users" link="/profile/contacts/" />
+      <NavLink title="Documents" iconName="file-text" link="/profile/documents/" />
+    </NavLinksContainer>
+  </div>
+);
 
-ProfileMenu.propTypes = {
-  location: ROUTER_LOCATION_OBJECT.isRequired,
-};
-
-ProfileMenu.contextTypes = {
-  router: PropTypes.object,
-};
-
-export default withRouter(ProfileMenu);
+export default ProfileMenu;

--- a/src/Components/ProfileMenu/ProfileMenu.test.jsx
+++ b/src/Components/ProfileMenu/ProfileMenu.test.jsx
@@ -4,35 +4,16 @@ import toJSON from 'enzyme-to-json';
 import ProfileMenu from './ProfileMenu';
 
 describe('ProfileMenuComponent', () => {
-  const locationMock = {
-    pathname: '/profile/favorites/',
-  };
   it('is defined', () => {
     const wrapper = shallow(
-      <ProfileMenu.WrappedComponent
-        location={locationMock}
-      />,
+      <ProfileMenu />,
     );
     expect(wrapper).toBeDefined();
   });
 
-  it('it sets isHighlighted to correct values', () => {
-    const wrapper = shallow(
-      <ProfileMenu.WrappedComponent
-        location={locationMock}
-      />,
-    );
-    expect(wrapper.find('[title="Bid List"]').prop('isHighlighted')).toBe(false);
-    // Favorites should be the only highlighted link
-    expect(wrapper.find('[title="Favorites"]').prop('isHighlighted')).toBe(true);
-    expect(wrapper.find('[title="Inbox"]').prop('isHighlighted')).toBe(false);
-  });
-
   it('matches snapshot', () => {
     const wrapper = shallow(
-      <ProfileMenu.WrappedComponent
-        location={locationMock}
-      />,
+      <ProfileMenu />,
     );
     expect(toJSON(wrapper)).toMatchSnapshot();
   });

--- a/src/Components/ProfileMenu/__snapshots__/ProfileMenu.test.jsx.snap
+++ b/src/Components/ProfileMenu/__snapshots__/ProfileMenu.test.jsx.snap
@@ -12,57 +12,47 @@ exports[`ProfileMenuComponent matches snapshot 1`] = `
   <NavLinksContainer>
     <withRouter(NavLink)
       iconName="home"
-      isHighlighted={false}
       link="/profile/"
       title="Home"
     />
     <withRouter(NavLink)
-      currentPath="/profile/favorites/"
       iconName="user"
       title="Profile"
     >
       <withRouter(NavLink)
-        isHighlighted={false}
         link="/profile/dashboard/"
         title="Dashboard"
       />
       <withRouter(NavLink)
-        isHighlighted={false}
         link="/profile/bidlist/"
         title="Bid List"
       />
       <withRouter(NavLink)
-        isHighlighted={true}
         link="/profile/favorites/"
         title="Favorites"
       />
       <withRouter(NavLink)
-        isHighlighted={false}
         link="/profile/searches/"
         title="Saved Searches"
       />
     </withRouter(NavLink)>
     <withRouter(NavLink)
       iconName="comments-o"
-      isHighlighted={false}
       link="/profile/inbox/"
       title="Inbox"
     />
     <withRouter(NavLink)
       iconName="globe"
-      isHighlighted={false}
       link="/profile/notifications/"
       title="Notifications"
     />
     <withRouter(NavLink)
       iconName="users"
-      isHighlighted={false}
       link="/profile/contacts/"
       title="Contacts"
     />
     <withRouter(NavLink)
       iconName="file-text"
-      isHighlighted={false}
       link="/profile/documents/"
       title="Documents"
     />

--- a/src/Components/ProfilePage/__snapshots__/ProfilePage.test.jsx.snap
+++ b/src/Components/ProfilePage/__snapshots__/ProfilePage.test.jsx.snap
@@ -4,7 +4,7 @@ exports[`ProfilePageComponent matches snapshot 1`] = `
 <div
   className="profile-page"
 >
-  <withRouter(ProfileMenu) />
+  <ProfileMenu />
   <div
     className="usa-grid-full profile-content-container"
   >


### PR DESCRIPTION
Moves the logic for `isHighlighted` to the `NavLink` component. I think this is the best option because it means we only have one component that needs to be connected to `withRouter`.

Closes #929.