### PR TITLE
StaticDevContent wrapper component

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,9 @@
       "src/**/*.{js,jsx}",
       "!src/registerServiceWorker.js",
       "!src/Components/**/index.js",
-      "!src/Components/StaticDevContent/*"
+      "!src/Components/StaticDevContent/*",
+      "!src/actions/showStaticContent.js",
+      "!src/reducers/showStaticContent.js"
     ],
     "coverageReporters": [
       "lcov"

--- a/package.json
+++ b/package.json
@@ -98,7 +98,8 @@
     "collectCoverageFrom": [
       "src/**/*.{js,jsx}",
       "!src/registerServiceWorker.js",
-      "!src/Components/**/index.js"
+      "!src/Components/**/index.js",
+      "!src/Components/StaticDevContent/*"
     ],
     "coverageReporters": [
       "lcov"

--- a/src/Components/Header/Header.jsx
+++ b/src/Components/Header/Header.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import FontAwesome from 'react-fontawesome';
 import close from 'uswds/dist/img/close.svg'; // close X icon
-import { toggleStaticContent } from '../../actions/showStaticContent';
+import ToggleContent from '../StaticDevContent/ToggleContent';
 import { userProfileFetchData } from '../../actions/userProfile';
 import { logoutRequest } from '../../login/actions';
 import { USER_PROFILE, EMPTY_FUNCTION } from '../../Constants/PropTypes';
@@ -52,9 +52,7 @@ export class Header extends Component {
 
     return (
       <header className="usa-header usa-header-extended tm-header" role="banner">
-        <span style={{ position: 'absolute', right: '0px', cursor: 'pointer', fontSize: '10px', color: 'gray' }} onClick={() => this.props.toggleStaticContent(!this.props.shouldShowStaticContent)} role="button" tabIndex="0">
-          Toggle static content
-        </span>
+        <ToggleContent />
         <GovBanner />
         <div className="usa-navbar">
           <button className="usa-menu-btn">Menu</button>
@@ -125,8 +123,6 @@ Header.propTypes = {
   isAuthorized: PropTypes.func.isRequired,
   userProfile: USER_PROFILE,
   logout: PropTypes.func,
-  toggleStaticContent: PropTypes.func.isRequired,
-  shouldShowStaticContent: PropTypes.bool.isRequired,
 };
 
 Header.defaultProps = {
@@ -139,13 +135,11 @@ const mapStateToProps = state => ({
   login: state.login,
   client: state.client,
   userProfile: state.userProfile,
-  shouldShowStaticContent: state.shouldShowStaticContent,
 });
 
 const mapDispatchToProps = dispatch => ({
   fetchData: url => dispatch(userProfileFetchData(url)),
   logout: () => dispatch(logoutRequest()),
-  toggleStaticContent: value => dispatch(toggleStaticContent(value)),
 });
 
 const connected = connect(mapStateToProps, mapDispatchToProps)(Header);

--- a/src/Components/Header/Header.jsx
+++ b/src/Components/Header/Header.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import FontAwesome from 'react-fontawesome';
 import close from 'uswds/dist/img/close.svg'; // close X icon
+import { toggleStaticContent } from '../../actions/showStaticContent';
 import { userProfileFetchData } from '../../actions/userProfile';
 import { logoutRequest } from '../../login/actions';
 import { USER_PROFILE, EMPTY_FUNCTION } from '../../Constants/PropTypes';
@@ -51,6 +52,9 @@ export class Header extends Component {
 
     return (
       <header className="usa-header usa-header-extended tm-header" role="banner">
+        <span style={{ position: 'absolute', right: '0px', cursor: 'pointer', fontSize: '10px', color: 'gray' }} onClick={() => this.props.toggleStaticContent(!this.props.shouldShowStaticContent)} role="button" tabIndex="0">
+          Toggle static content
+        </span>
         <GovBanner />
         <div className="usa-navbar">
           <button className="usa-menu-btn">Menu</button>
@@ -121,6 +125,8 @@ Header.propTypes = {
   isAuthorized: PropTypes.func.isRequired,
   userProfile: USER_PROFILE,
   logout: PropTypes.func,
+  toggleStaticContent: PropTypes.func.isRequired,
+  shouldShowStaticContent: PropTypes.bool.isRequired,
 };
 
 Header.defaultProps = {
@@ -133,11 +139,13 @@ const mapStateToProps = state => ({
   login: state.login,
   client: state.client,
   userProfile: state.userProfile,
+  shouldShowStaticContent: state.shouldShowStaticContent,
 });
 
 const mapDispatchToProps = dispatch => ({
   fetchData: url => dispatch(userProfileFetchData(url)),
   logout: () => dispatch(logoutRequest()),
+  toggleStaticContent: value => dispatch(toggleStaticContent(value)),
 });
 
 const connected = connect(mapStateToProps, mapDispatchToProps)(Header);

--- a/src/Components/Header/__snapshots__/Header.test.jsx.snap
+++ b/src/Components/Header/__snapshots__/Header.test.jsx.snap
@@ -5,6 +5,7 @@ exports[`Header matches snapshot when logged in 1`] = `
   className="usa-header usa-header-extended tm-header"
   role="banner"
 >
+  <Connect(Component) />
   <GovBanner />
   <div
     className="usa-navbar"
@@ -149,6 +150,7 @@ exports[`Header matches snapshot when logged out 1`] = `
   className="usa-header usa-header-extended tm-header"
   role="banner"
 >
+  <Connect(Component) />
   <GovBanner />
   <div
     className="usa-navbar"

--- a/src/Components/PositionDetailsItem/PositionDetailsItem.jsx
+++ b/src/Components/PositionDetailsItem/PositionDetailsItem.jsx
@@ -4,6 +4,7 @@ import { NO_ORG, NO_POST, NO_BUREAU, NO_POST_DIFFERENTIAL, NO_DANGER_PAY } from 
 import { POSITION_DETAILS } from '../../Constants/PropTypes';
 import LanguageList from '../../Components/LanguageList/LanguageList';
 import PositionDetailsDataPoint from '../../Components/PositionDetailsDataPoint/PositionDetailsDataPoint';
+import StaticDevContent from '../StaticDevContent/StaticDevContent';
 
 const PositionDetailsItem = ({ details }) => (
   <div className="usa-grid-full">
@@ -43,7 +44,7 @@ const PositionDetailsItem = ({ details }) => (
             />
             <PositionDetailsDataPoint
               title="Region"
-              description="Region"
+              description={<StaticDevContent><span>Region</span></StaticDevContent>}
             />
           </div>
         </div>
@@ -70,11 +71,11 @@ const PositionDetailsItem = ({ details }) => (
             />
             <PositionDetailsDataPoint
               title="Tour End Date"
-              description="09-01-2019"
+              description={<StaticDevContent><span>09-19-2019</span></StaticDevContent>}
             />
             <PositionDetailsDataPoint
               title="Incumbent"
-              description="Incumbent"
+              description={<StaticDevContent><span>Incumbent</span></StaticDevContent>}
             />
           </div>
         </div>

--- a/src/Components/PositionDetailsItem/PositionDetailsItem.jsx
+++ b/src/Components/PositionDetailsItem/PositionDetailsItem.jsx
@@ -4,7 +4,7 @@ import { NO_ORG, NO_POST, NO_BUREAU, NO_POST_DIFFERENTIAL, NO_DANGER_PAY } from 
 import { POSITION_DETAILS } from '../../Constants/PropTypes';
 import LanguageList from '../../Components/LanguageList/LanguageList';
 import PositionDetailsDataPoint from '../../Components/PositionDetailsDataPoint/PositionDetailsDataPoint';
-import StaticDevContent from '../StaticDevContent/StaticDevContent';
+import StaticDevContent from '../StaticDevContent';
 
 const PositionDetailsItem = ({ details }) => (
   <div className="usa-grid-full">

--- a/src/Components/PositionDetailsItem/__snapshots__/PositionDetailsItem.test.jsx.snap
+++ b/src/Components/PositionDetailsItem/__snapshots__/PositionDetailsItem.test.jsx.snap
@@ -50,7 +50,13 @@ exports[`PositionDetailsItem matches snapshot 1`] = `
             title="Overseas"
           />
           <PositionDetailsDataPoint
-            description="Region"
+            description={
+              <Connect(StaticDevContent)>
+                <span>
+                  Region
+                </span>
+              </Connect(StaticDevContent)>
+            }
             title="Region"
           />
         </div>
@@ -101,11 +107,23 @@ exports[`PositionDetailsItem matches snapshot 1`] = `
             title="Danger Pay"
           />
           <PositionDetailsDataPoint
-            description="09-01-2019"
+            description={
+              <Connect(StaticDevContent)>
+                <span>
+                  09-19-2019
+                </span>
+              </Connect(StaticDevContent)>
+            }
             title="Tour End Date"
           />
           <PositionDetailsDataPoint
-            description="Incumbent"
+            description={
+              <Connect(StaticDevContent)>
+                <span>
+                  Incumbent
+                </span>
+              </Connect(StaticDevContent)>
+            }
             title="Incumbent"
           />
         </div>

--- a/src/Components/ProfileDashboard/BidList/BidList.jsx
+++ b/src/Components/ProfileDashboard/BidList/BidList.jsx
@@ -6,6 +6,7 @@ import BorderedList from '../../BorderedList';
 import BidListResultsCard from '../../BidListResultsCard/';
 import BidListHeader from './BidListHeader';
 import { getStatusClass } from '../../../Constants/BidStatuses';
+import StaticDevContent from '../../StaticDevContent/StaticDevContent';
 
 const BidList = ({ bids }) => {
   const bidArray = [];
@@ -21,7 +22,9 @@ const BidList = ({ bids }) => {
   ));
   return (
     <div className="usa-grid-full">
-      <BidListHeader />
+      <StaticDevContent>
+        <BidListHeader />
+      </StaticDevContent>
       <div className="usa-grid-full section-padded-inner-container">
         <div className="usa-width-one-whole">
           <SectionTitle title={`Bid List (${bids.length}/10)`} icon="clipboard" />

--- a/src/Components/ProfileDashboard/BidList/BidList.jsx
+++ b/src/Components/ProfileDashboard/BidList/BidList.jsx
@@ -6,7 +6,7 @@ import BorderedList from '../../BorderedList';
 import BidListResultsCard from '../../BidListResultsCard/';
 import BidListHeader from './BidListHeader';
 import { getStatusClass } from '../../../Constants/BidStatuses';
-import StaticDevContent from '../../StaticDevContent/StaticDevContent';
+import StaticDevContent from '../../StaticDevContent';
 
 const BidList = ({ bids }) => {
   const bidArray = [];

--- a/src/Components/ProfileDashboard/BidList/__snapshots__/BidList.test.jsx.snap
+++ b/src/Components/ProfileDashboard/BidList/__snapshots__/BidList.test.jsx.snap
@@ -4,7 +4,9 @@ exports[`BidListComponent matches snapshot 1`] = `
 <div
   className="usa-grid-full"
 >
-  <BidListHeader />
+  <Connect(StaticDevContent)>
+    <BidListHeader />
+  </Connect(StaticDevContent)>
   <div
     className="usa-grid-full section-padded-inner-container"
   >
@@ -133,7 +135,9 @@ exports[`BidListComponent matches snapshot when there are no bids 1`] = `
 <div
   className="usa-grid-full"
 >
-  <BidListHeader />
+  <Connect(StaticDevContent)>
+    <BidListHeader />
+  </Connect(StaticDevContent)>
   <div
     className="usa-grid-full section-padded-inner-container"
   >

--- a/src/Components/ProfileDashboard/CurrentUser/CurrentUser.jsx
+++ b/src/Components/ProfileDashboard/CurrentUser/CurrentUser.jsx
@@ -6,14 +6,19 @@ import InformationDataPoint from '../InformationDataPoint';
 import Status from './Status';
 import EditProfile from './EditProfile';
 import ProfilePicture from '../../ProfilePicture';
+import StaticDevContent from '../../StaticDevContent/StaticDevContent';
 
 const CurrentUser = ({ userProfile }) => (
   <div className="usa-grid-full current-user">
     <div className="current-user-top">
       <div className="section-padded-inner-container">
-        <Status />
+        <StaticDevContent>
+          <Status />
+        </StaticDevContent>
         <ProfilePicture />
-        <EditProfile />
+        <StaticDevContent>
+          <EditProfile />
+        </StaticDevContent>
         <SectionTitle small title={`${userProfile.user.first_name} ${userProfile.user.last_name}`} className="current-user-name" />
         <InformationDataPoint
           content={userProfile.skill_code || NO_USER_SKILL_CODE}
@@ -24,12 +29,18 @@ const CurrentUser = ({ userProfile }) => (
       <div className="section-padded-inner-container">
         <SectionTitle small title="Contact Information" />
         <InformationDataPoint title="Email Address" content={userProfile.user.email || NO_EMAIL} />
-        <InformationDataPoint title="Office Number" content="+301-779-0379 ext. 3" />
-        <InformationDataPoint title="Personal Contact Number" content="+240-331-7189" />
-        <InformationDataPoint
-          title="Post/Office Address"
-          content="1234 Washington St. NW, Washington, DC 20009"
-        />
+        <StaticDevContent>
+          <InformationDataPoint title="Office Number" content="+301-779-0379 ext. 3" />
+        </StaticDevContent>
+        <StaticDevContent>
+          <InformationDataPoint title="Personal Contact Number" content="+240-331-7189" />
+        </StaticDevContent>
+        <StaticDevContent>
+          <InformationDataPoint
+            title="Post/Office Address"
+            content="1234 Washington St. NW, Washington, DC 20009"
+          />
+        </StaticDevContent>
       </div>
     </div>
   </div>

--- a/src/Components/ProfileDashboard/CurrentUser/CurrentUser.jsx
+++ b/src/Components/ProfileDashboard/CurrentUser/CurrentUser.jsx
@@ -6,7 +6,7 @@ import InformationDataPoint from '../InformationDataPoint';
 import Status from './Status';
 import EditProfile from './EditProfile';
 import ProfilePicture from '../../ProfilePicture';
-import StaticDevContent from '../../StaticDevContent/StaticDevContent';
+import StaticDevContent from '../../StaticDevContent';
 
 const CurrentUser = ({ userProfile }) => (
   <div className="usa-grid-full current-user">

--- a/src/Components/ProfileDashboard/CurrentUser/__snapshots__/CurrentUser.test.jsx.snap
+++ b/src/Components/ProfileDashboard/CurrentUser/__snapshots__/CurrentUser.test.jsx.snap
@@ -10,13 +10,17 @@ exports[`CurrentUserComponent matches snapshot 1`] = `
     <div
       className="section-padded-inner-container"
     >
-      <Status />
+      <Connect(StaticDevContent)>
+        <Status />
+      </Connect(StaticDevContent)>
       <ProfilePicture
         alt="avatar"
         className=""
         source="/assets/img/avatar.png"
       />
-      <EditProfile />
+      <Connect(StaticDevContent)>
+        <EditProfile />
+      </Connect(StaticDevContent)>
       <PositionInformation
         className="current-user-name"
         icon=""
@@ -49,24 +53,30 @@ exports[`CurrentUserComponent matches snapshot 1`] = `
         title="Email Address"
         titleOnBottom={false}
       />
-      <InformationDataPoint
-        className=""
-        content="+301-779-0379 ext. 3"
-        title="Office Number"
-        titleOnBottom={false}
-      />
-      <InformationDataPoint
-        className=""
-        content="+240-331-7189"
-        title="Personal Contact Number"
-        titleOnBottom={false}
-      />
-      <InformationDataPoint
-        className=""
-        content="1234 Washington St. NW, Washington, DC 20009"
-        title="Post/Office Address"
-        titleOnBottom={false}
-      />
+      <Connect(StaticDevContent)>
+        <InformationDataPoint
+          className=""
+          content="+301-779-0379 ext. 3"
+          title="Office Number"
+          titleOnBottom={false}
+        />
+      </Connect(StaticDevContent)>
+      <Connect(StaticDevContent)>
+        <InformationDataPoint
+          className=""
+          content="+240-331-7189"
+          title="Personal Contact Number"
+          titleOnBottom={false}
+        />
+      </Connect(StaticDevContent)>
+      <Connect(StaticDevContent)>
+        <InformationDataPoint
+          className=""
+          content="1234 Washington St. NW, Washington, DC 20009"
+          title="Post/Office Address"
+          titleOnBottom={false}
+        />
+      </Connect(StaticDevContent)>
     </div>
   </div>
 </div>

--- a/src/Components/ProfileDashboard/Notifications/Notifications.jsx
+++ b/src/Components/ProfileDashboard/Notifications/Notifications.jsx
@@ -4,6 +4,7 @@ import { NOTIFICATION_RESULTS } from '../../../Constants/PropTypes';
 import SectionTitle from '../SectionTitle';
 import BorderedList from '../../BorderedList';
 import NotificationItem from './NotificationItem';
+import StaticDevContent from '../../StaticDevContent/StaticDevContent';
 
 const Notifications = ({ notifications }) => {
   const notificationArray = [];
@@ -22,7 +23,9 @@ const Notifications = ({ notifications }) => {
           <SectionTitle title="Notifications" icon="globe" />
         </div>
         <div className="usa-width-one-fourth small-link-container small-link-container-settings">
-          <Link to="/profile/dashboard/">Settings</Link>
+          <StaticDevContent>
+            <Link to="/profile/dashboard/">Settings</Link>
+          </StaticDevContent>
         </div>
       </div>
       {

--- a/src/Components/ProfileDashboard/Notifications/Notifications.jsx
+++ b/src/Components/ProfileDashboard/Notifications/Notifications.jsx
@@ -4,7 +4,7 @@ import { NOTIFICATION_RESULTS } from '../../../Constants/PropTypes';
 import SectionTitle from '../SectionTitle';
 import BorderedList from '../../BorderedList';
 import NotificationItem from './NotificationItem';
-import StaticDevContent from '../../StaticDevContent/StaticDevContent';
+import StaticDevContent from '../../StaticDevContent';
 
 const Notifications = ({ notifications }) => {
   const notificationArray = [];

--- a/src/Components/ProfileDashboard/Notifications/__snapshots__/Notifications.test.jsx.snap
+++ b/src/Components/ProfileDashboard/Notifications/__snapshots__/Notifications.test.jsx.snap
@@ -20,12 +20,14 @@ exports[`NotificationsComponent matches snapshot 1`] = `
     <div
       className="usa-width-one-fourth small-link-container small-link-container-settings"
     >
-      <Link
-        replace={false}
-        to="/profile/dashboard/"
-      >
-        Settings
-      </Link>
+      <Connect(StaticDevContent)>
+        <Link
+          replace={false}
+          to="/profile/dashboard/"
+        >
+          Settings
+        </Link>
+      </Connect(StaticDevContent)>
     </div>
   </div>
   <BorderedList
@@ -83,12 +85,14 @@ exports[`NotificationsComponent matches snapshot when there are zero notificatio
     <div
       className="usa-width-one-fourth small-link-container small-link-container-settings"
     >
-      <Link
-        replace={false}
-        to="/profile/dashboard/"
-      >
-        Settings
-      </Link>
+      <Connect(StaticDevContent)>
+        <Link
+          replace={false}
+          to="/profile/dashboard/"
+        >
+          Settings
+        </Link>
+      </Connect(StaticDevContent)>
     </div>
   </div>
   <div

--- a/src/Components/ProfileDashboard/PositionInformation/PositionInformation.jsx
+++ b/src/Components/ProfileDashboard/PositionInformation/PositionInformation.jsx
@@ -4,6 +4,7 @@ import { NO_ASSIGNMENT_POSITION, NO_ASSIGNMENT_DATE } from '../../../Constants/S
 import SectionTitle from '../SectionTitle';
 import InformationDataPoint from '../InformationDataPoint';
 import StartEnd from './StartEnd';
+import StaticDevContent from '../../StaticDevContent/StaticDevContent';
 
 const PositionInformation = ({ assignment }) => (
   <div className="usa-grid-full">
@@ -24,7 +25,9 @@ const PositionInformation = ({ assignment }) => (
         title="Position Title"
         content={assignment.position || NO_ASSIGNMENT_POSITION}
       />
-      <InformationDataPoint title="Skill Code" content="Medical Technology (6145)" />
+      <StaticDevContent>
+        <InformationDataPoint title="Skill Code" content="Medical Technology (6145)" />
+      </StaticDevContent>
     </div>
   </div>
 );

--- a/src/Components/ProfileDashboard/PositionInformation/PositionInformation.jsx
+++ b/src/Components/ProfileDashboard/PositionInformation/PositionInformation.jsx
@@ -4,7 +4,7 @@ import { NO_ASSIGNMENT_POSITION, NO_ASSIGNMENT_DATE } from '../../../Constants/S
 import SectionTitle from '../SectionTitle';
 import InformationDataPoint from '../InformationDataPoint';
 import StartEnd from './StartEnd';
-import StaticDevContent from '../../StaticDevContent/StaticDevContent';
+import StaticDevContent from '../../StaticDevContent';
 
 const PositionInformation = ({ assignment }) => (
   <div className="usa-grid-full">

--- a/src/Components/ProfileDashboard/PositionInformation/__snapshots__/PositionInformation.test.jsx.snap
+++ b/src/Components/ProfileDashboard/PositionInformation/__snapshots__/PositionInformation.test.jsx.snap
@@ -36,12 +36,14 @@ exports[`PositionInformationComponent matches snapshot 1`] = `
       title="Position Title"
       titleOnBottom={false}
     />
-    <InformationDataPoint
-      className=""
-      content="Medical Technology (6145)"
-      title="Skill Code"
-      titleOnBottom={false}
-    />
+    <Connect(StaticDevContent)>
+      <InformationDataPoint
+        className=""
+        content="Medical Technology (6145)"
+        title="Skill Code"
+        titleOnBottom={false}
+      />
+    </Connect(StaticDevContent)>
   </div>
 </div>
 `;

--- a/src/Components/ProfileDashboard/ProfileDashboard.jsx
+++ b/src/Components/ProfileDashboard/ProfileDashboard.jsx
@@ -7,7 +7,7 @@ import BidList from './BidList';
 import PositionInformation from './PositionInformation';
 import Notifications from './Notifications';
 import Spinner from '../Spinner';
-import StaticDevContent from '../StaticDevContent/StaticDevContent';
+import StaticDevContent from '../StaticDevContent';
 
 const ProfileDashboard = ({ userProfile, isLoading, assignment, assignmentIsLoading, notifications,
   notificationsIsLoading, bidList, bidListIsLoading }) => (

--- a/src/Components/ProfileDashboard/ProfileDashboard.jsx
+++ b/src/Components/ProfileDashboard/ProfileDashboard.jsx
@@ -7,6 +7,7 @@ import BidList from './BidList';
 import PositionInformation from './PositionInformation';
 import Notifications from './Notifications';
 import Spinner from '../Spinner';
+import StaticDevContent from '../StaticDevContent/StaticDevContent';
 
 const ProfileDashboard = ({ userProfile, isLoading, assignment, assignmentIsLoading, notifications,
   notificationsIsLoading, bidList, bidListIsLoading }) => (
@@ -24,7 +25,9 @@ const ProfileDashboard = ({ userProfile, isLoading, assignment, assignmentIsLoad
                 <CurrentUser userProfile={userProfile} />
               </div>
               <div className="usa-width-one-whole user-dashboard-section cdo-section">
-                <CDOInfo name="Leah Shadtrach" />
+                <StaticDevContent>
+                  <CDOInfo name="Leah Shadtrach" />
+                </StaticDevContent>
               </div>
             </div>
             <div

--- a/src/Components/ProfileDashboard/__snapshots__/ProfileDashboard.test.jsx.snap
+++ b/src/Components/ProfileDashboard/__snapshots__/ProfileDashboard.test.jsx.snap
@@ -28,9 +28,11 @@ exports[`ProfileDashboardComponent matches snapshot when loaded 1`] = `
       <div
         className="usa-width-one-whole user-dashboard-section cdo-section"
       >
-        <CDOInfo
-          name="Leah Shadtrach"
-        />
+        <Connect(StaticDevContent)>
+          <CDOInfo
+            name="Leah Shadtrach"
+          />
+        </Connect(StaticDevContent)>
       </div>
     </div>
     <div

--- a/src/Components/StaticDevContent/StaticDevContent.jsx
+++ b/src/Components/StaticDevContent/StaticDevContent.jsx
@@ -1,3 +1,9 @@
+/*
+Use this component to wrap bits of static development
+content (like a hardcoded phone number) so that they
+can be easily detected during demos or user testing.
+*/
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';

--- a/src/Components/StaticDevContent/StaticDevContent.jsx
+++ b/src/Components/StaticDevContent/StaticDevContent.jsx
@@ -17,7 +17,7 @@ StaticDevContent.propTypes = {
 };
 
 StaticDevContent.defaultProps = {
-  showStaticContent: PropTypes.bool,
+  showStaticContent: false,
 };
 
 const mapStateToProps = state => ({

--- a/src/Components/StaticDevContent/StaticDevContent.jsx
+++ b/src/Components/StaticDevContent/StaticDevContent.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+const StaticDevContent = ({ children, showStaticContent }) => (
+  showStaticContent ?
+    <div style={{ boxShadow: '0px 0px 0px 2px red' }}>
+      { children }
+    </div>
+    :
+    children
+);
+
+StaticDevContent.propTypes = {
+  children: PropTypes.node.isRequired,
+  showStaticContent: PropTypes.bool,
+};
+
+StaticDevContent.defaultProps = {
+  showStaticContent: PropTypes.bool,
+};
+
+const mapStateToProps = state => ({
+  showStaticContent: state.shouldShowStaticContent,
+});
+
+export default connect(mapStateToProps)(StaticDevContent);

--- a/src/Components/StaticDevContent/ToggleContent.jsx
+++ b/src/Components/StaticDevContent/ToggleContent.jsx
@@ -1,5 +1,5 @@
 /*
-This component provided clickable text that toggles
+This component provides clickable text that toggles
 the "shouldShowStaticContent" state between true and false,
 so that the StaticDevContent component can conditionally wrap
 its child component in a border when true, or simply return the unmodified

--- a/src/Components/StaticDevContent/ToggleContent.jsx
+++ b/src/Components/StaticDevContent/ToggleContent.jsx
@@ -5,6 +5,9 @@ import { toggleStaticContent } from '../../actions/showStaticContent';
 import { EMPTY_FUNCTION } from '../../Constants/PropTypes';
 
 export const StaticDevContent = ({ toggle, showStaticContent }) => (
+  // At the time of writing, CodeClimate's version of eslint-a11y-plugin
+  // did not take role="button" into account with the following error:
+  // eslint-disable-next-line jsx-a11y/no-static-element-interactions
   <span style={{ position: 'absolute', right: '0px', cursor: 'pointer', fontSize: '10px' }} onClick={() => toggle(!showStaticContent)} role="button" tabIndex="0">
     Toggle static content
   </span>

--- a/src/Components/StaticDevContent/ToggleContent.jsx
+++ b/src/Components/StaticDevContent/ToggleContent.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { toggleStaticContent } from '../../actions/showStaticContent';
+import { EMPTY_FUNCTION } from '../../Constants/PropTypes';
+
+export const StaticDevContent = ({ toggle, showStaticContent }) => (
+  <span style={{ position: 'absolute', right: '0px', cursor: 'pointer', fontSize: '10px' }} onClick={() => toggle(!showStaticContent)} role="button" tabIndex="0">
+    Toggle static content
+  </span>
+);
+
+StaticDevContent.propTypes = {
+  toggle: PropTypes.func,
+  showStaticContent: PropTypes.bool,
+};
+
+StaticDevContent.defaultProps = {
+  toggle: EMPTY_FUNCTION,
+  showStaticContent: false,
+};
+
+const mapStateToProps = state => ({
+  showStaticContent: state.shouldShowStaticContent,
+});
+
+const mapDispatchToProps = dispatch => ({
+  toggle: value => dispatch(toggleStaticContent(value)),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(StaticDevContent);

--- a/src/Components/StaticDevContent/ToggleContent.jsx
+++ b/src/Components/StaticDevContent/ToggleContent.jsx
@@ -1,3 +1,11 @@
+/*
+This component provided clickable text that toggles
+the "shouldShowStaticContent" state between true and false,
+so that the StaticDevContent component can conditionally wrap
+its child component in a border when true, or simply return the unmodified
+child component when false.
+*/
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';

--- a/src/Components/StaticDevContent/index.js
+++ b/src/Components/StaticDevContent/index.js
@@ -1,0 +1,1 @@
+export { default } from './StaticDevContent';

--- a/src/actions/showStaticContent.js
+++ b/src/actions/showStaticContent.js
@@ -1,0 +1,12 @@
+export function shouldShowStaticContent(shouldShow) {
+  return {
+    type: 'SHOULD_SHOW_STATIC_CONTENT',
+    shouldShow,
+  };
+}
+
+export function toggleStaticContent(show = true) {
+  return (dispatch) => {
+    dispatch(shouldShowStaticContent(show));
+  };
+}

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -28,6 +28,7 @@ import { assignment, assignmentHasErrored, assignmentIsLoading } from './assignm
 import { notificationsHasErrored, notificationsIsLoading, notifications } from './notifications';
 import routerLocations from './routerLocations';
 import selectedAccordion from './selectedAccordion';
+import shouldShowStaticContent from './showStaticContent';
 
 
 export default combineReducers({
@@ -102,5 +103,6 @@ export default combineReducers({
   notificationsHasErrored,
   notificationsIsLoading,
   notifications,
+  shouldShowStaticContent,
   router: routerReducer,
 });

--- a/src/reducers/showStaticContent.js
+++ b/src/reducers/showStaticContent.js
@@ -1,0 +1,8 @@
+export default function shouldShowStaticContent(state = false, action) {
+  switch (action.type) {
+    case 'SHOULD_SHOW_STATIC_CONTENT':
+      return action.shouldShow;
+    default:
+      return state;
+  }
+}


### PR DESCRIPTION
A component to wrap known static/hard-coded values in. Adds a toggle link to the header so that static content can be toggled on or off. When on, static content receives a red, inner border. When off, which is the default state, no visual change is applied.

I've opted to ignore this file from testing which is why I've left this PR in WIP. If we think it's worth adding tests, I will add some in. I chose not to because it will ultimately not be a part of the finalized and delivered application.