### PR TITLE
Add date-fns and use distanceInWords for the notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@cmsgov/design-system-core": "^1.1.0",
     "axios": "^0.16.2",
     "babel-polyfill": "^6.26.0",
+    "date-fns": "^1.29.0",
     "draft-js": "^0.10.3",
     "draft-js-plugins-editor": "^2.0.0-rc8",
     "font-awesome": "^4.7.0",

--- a/src/Components/ProfileDashboard/Notifications/NotificationItem/NotificationItem.jsx
+++ b/src/Components/ProfileDashboard/Notifications/NotificationItem/NotificationItem.jsx
@@ -1,12 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import InformationDataPoint from '../../InformationDataPoint';
+import { getTimeDistanceInWords } from '../../../../utilities';
 
-const NotificationItem = ({ content, notificationTime }) => (
-  <div className="usa-grid-full notification-card">
-    <InformationDataPoint content={content} title={notificationTime} titleOnBottom />
-  </div>
-);
+const NotificationItem = ({ content, notificationTime }) => {
+  const timeDistanceInWords = getTimeDistanceInWords(notificationTime);
+  return (
+    <div className="usa-grid-full notification-card">
+      <InformationDataPoint content={content} title={timeDistanceInWords} titleOnBottom />
+    </div>
+  );
+};
 
 NotificationItem.propTypes = {
   content: PropTypes.node.isRequired,

--- a/src/Components/ProfileDashboard/Notifications/NotificationItem/__snapshots__/NotificationItem.test.jsx.snap
+++ b/src/Components/ProfileDashboard/Notifications/NotificationItem/__snapshots__/NotificationItem.test.jsx.snap
@@ -7,7 +7,7 @@ exports[`NotificationItemComponent matches snapshot 1`] = `
   <InformationDataPoint
     className=""
     content="content"
-    title="10-10-2017"
+    title="about 1 month ago"
     titleOnBottom={true}
   />
 </div>

--- a/src/actions/notifications.js
+++ b/src/actions/notifications.js
@@ -21,9 +21,9 @@ export function notificationsFetchDataSuccess(notifications) {
   };
 }
 
-export function notificationsFetchData(limit = 3) {
+export function notificationsFetchData(limit = 3, ordering = '-date_updated') {
   return (dispatch) => {
-    axios.get(`${api}/notification/?limit=${limit}`, { headers: { Authorization: fetchUserToken() } })
+    axios.get(`${api}/notification/?limit=${limit}&ordering=${ordering}`, { headers: { Authorization: fetchUserToken() } })
             .then(({ data }) => data.results)
             .then((notifications) => {
               dispatch(notificationsFetchDataSuccess(notifications));

--- a/src/actions/notifications.test.js
+++ b/src/actions/notifications.test.js
@@ -7,10 +7,13 @@ const { mockStore, mockAdapter } = setupAsyncMocks();
 describe('async actions', () => {
   beforeEach(() => {
     // limit = 3 is the default param in the function
-    mockAdapter.onGet('http://localhost:8000/api/v1/notification/?limit=3').reply(200,
+    mockAdapter.onGet('http://localhost:8000/api/v1/notification/?limit=3&ordering=-date_updated').reply(200,
       notificationsObject,
     );
-    mockAdapter.onGet('http://localhost:8000/api/v1/notification/?limit=2').reply(200,
+    mockAdapter.onGet('http://localhost:8000/api/v1/notification/?limit=2&ordering=-date_updated').reply(200,
+      notificationsObject,
+    );
+    mockAdapter.onGet('http://localhost:8000/api/v1/notification/?limit=2&ordering=date_updated').reply(200,
       notificationsObject,
     );
   });
@@ -34,6 +37,19 @@ describe('async actions', () => {
     const f = () => {
       setTimeout(() => {
         store.dispatch(actions.notificationsFetchData(2));
+        store.dispatch(actions.notificationsIsLoading());
+        done();
+      }, 0);
+    };
+    f();
+  });
+
+  it('can fetch notifications of a custom ordering', (done) => {
+    const store = mockStore({ notifications: {} });
+
+    const f = () => {
+      setTimeout(() => {
+        store.dispatch(actions.notificationsFetchData(null, 'date_updated'));
         store.dispatch(actions.notificationsIsLoading());
         done();
       }, 0);

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -1,5 +1,6 @@
 import Scroll from 'react-scroll';
 import queryString from 'query-string';
+import distanceInWords from 'date-fns/distance_in_words';
 import { VALID_PARAMS } from './Constants/EndpointParams';
 
 const scroll = Scroll.animateScroll;
@@ -187,3 +188,8 @@ export const formQueryString = queryObject => queryString.stringify(queryObject)
 export const removeDuplicates = (myArr, prop) => (
     myArr.filter((obj, pos, arr) => arr.map(mapObj => mapObj[prop]).indexOf(obj[prop]) === pos)
 );
+
+// Format date for notifications.
+// We want to use minutes for recent notifications, but days for older ones.
+export const getTimeDistanceInWords = (dateToCompare, date = new Date(), options = {}) =>
+  `${distanceInWords(dateToCompare, date, options)} ago`;

--- a/src/utilities.test.js
+++ b/src/utilities.test.js
@@ -13,6 +13,7 @@ import { validStateEmail,
          propSort,
          existsInNestedObject,
          removeDuplicates,
+         getTimeDistanceInWords,
        } from './utilities';
 
 describe('local storage', () => {
@@ -211,5 +212,15 @@ describe('removeDuplicates', () => {
     expect(newArr[1].id).toBe(2);
     expect(newArr[2].id).toBe(1);
     expect(newArr[2].prop).toBe('c');
+  });
+});
+
+describe('distanceInWords', () => {
+  it('returns a defined value containg "ago" in the string', () => {
+    const timeDistanceInWords = getTimeDistanceInWords(new Date());
+    // we won't explicitly test for values since we can expect date-fns to work
+    expect(timeDistanceInWords).toBeDefined();
+    // but we will test that it contains ' ago' since that is custom text we added in
+    expect(timeDistanceInWords).toContain(' ago');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1978,6 +1978,10 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+date-fns@^1.29.0:
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.29.0.tgz#12e609cdcb935127311d04d33334e2960a2a54e6"
+
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"


### PR DESCRIPTION
Adds [date-fns](date-fns.org) and uses its [distanceInWords](https://date-fns.org/v1.29.0/docs/distanceInWords) function for the notifications. Also uses a default ordering for the notifications so that newest ones are at the top, but can be passed an optional param to order otherwise.