### PR TITLE
Available/"No handshakes" Filter for CDOs

### DIFF
--- a/src/Components/ProfileDashboard/__snapshots__/ProfileDashboard.test.jsx.snap
+++ b/src/Components/ProfileDashboard/__snapshots__/ProfileDashboard.test.jsx.snap
@@ -15,6 +15,7 @@ exports[`ProfileDashboardComponent matches snapshot when loaded 1`] = `
         <CurrentUser
           userProfile={
             Object {
+              "is_cdo": false,
               "skill_code": "INFORMATION MANAGEMENT (2880)",
               "user": Object {
                 "email": "doej@state.gov",

--- a/src/Components/ResultsFilterContainer/ResultsFilterContainer.jsx
+++ b/src/Components/ResultsFilterContainer/ResultsFilterContainer.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { FILTER_ITEMS_ARRAY, ACCORDION_SELECTION_OBJECT, MISSION_DETAILS_ARRAY, POST_DETAILS_ARRAY } from '../../Constants/PropTypes';
+import { FILTER_ITEMS_ARRAY, ACCORDION_SELECTION_OBJECT,
+  MISSION_DETAILS_ARRAY, POST_DETAILS_ARRAY, USER_PROFILE } from '../../Constants/PropTypes';
 import { ACCORDION_SELECTION } from '../../Constants/DefaultProps';
 import SearchFiltersContainer from '../SearchFilters/SearchFiltersContainer/SearchFiltersContainer';
 import ResetFilters from '../ResetFilters/ResetFilters';
@@ -25,7 +26,7 @@ class ResultsFilterContainer extends Component {
   render() {
     const { filters, resetFilters, setAccordion, selectedAccordion,
       fetchMissionAutocomplete, missionSearchResults, missionSearchIsLoading,
-      missionSearchHasErrored, fetchPostAutocomplete,
+      missionSearchHasErrored, fetchPostAutocomplete, userProfile,
       postSearchResults, postSearchIsLoading, postSearchHasErrored } = this.props;
     return (
       <div className="filter-container">
@@ -52,6 +53,7 @@ class ResultsFilterContainer extends Component {
               postSearchResults={postSearchResults}
               postSearchIsLoading={postSearchIsLoading}
               postSearchHasErrored={postSearchHasErrored}
+              isCDO={userProfile.is_cdo || false}
             />
           </div>
         </div>
@@ -76,6 +78,7 @@ ResultsFilterContainer.propTypes = {
   postSearchResults: POST_DETAILS_ARRAY.isRequired,
   postSearchIsLoading: PropTypes.bool.isRequired,
   postSearchHasErrored: PropTypes.bool.isRequired,
+  userProfile: USER_PROFILE.isRequired,
 };
 
 ResultsFilterContainer.defaultProps = {

--- a/src/Components/ResultsFilterContainer/ResultsFilterContainer.test.jsx
+++ b/src/Components/ResultsFilterContainer/ResultsFilterContainer.test.jsx
@@ -4,6 +4,7 @@ import toJSON from 'enzyme-to-json';
 import sinon from 'sinon';
 import ResultsFilterContainer from './ResultsFilterContainer';
 import { ACCORDION_SELECTION } from '../../Constants/DefaultProps';
+import userObject from '../../__mocks__/userObject';
 
 describe('ResultsFilterContainerComponent', () => {
   const items = [{
@@ -30,6 +31,7 @@ describe('ResultsFilterContainerComponent', () => {
         postSearchResults={[]}
         postSearchIsLoading={false}
         postSearchHasErrored={false}
+        userProfile={userObject}
       />);
     expect(wrapper).toBeDefined();
   });
@@ -51,6 +53,7 @@ describe('ResultsFilterContainerComponent', () => {
       postSearchResults={[]}
       postSearchIsLoading={false}
       postSearchHasErrored={false}
+      userProfile={userObject}
     />);
     expect(wrapper.instance().props.filters).toBe(items);
   });
@@ -75,6 +78,7 @@ describe('ResultsFilterContainerComponent', () => {
       postSearchResults={[]}
       postSearchIsLoading={false}
       postSearchHasErrored={false}
+      userProfile={userObject}
     />);
     wrapper.instance().onQueryParamUpdate(value);
     sinon.assert.calledOnce(queryUpdateSpy);
@@ -101,6 +105,7 @@ describe('ResultsFilterContainerComponent', () => {
       postSearchResults={[]}
       postSearchIsLoading={false}
       postSearchHasErrored={false}
+      userProfile={userObject}
     />);
     wrapper.instance().onQueryParamToggle(value, value, value);
     sinon.assert.calledOnce(queryToggleSpy);
@@ -124,6 +129,7 @@ describe('ResultsFilterContainerComponent', () => {
       postSearchResults={[]}
       postSearchIsLoading={false}
       postSearchHasErrored={false}
+      userProfile={userObject}
     />);
     expect(toJSON(wrapper)).toMatchSnapshot();
   });

--- a/src/Components/ResultsFilterContainer/__snapshots__/ResultsFilterContainer.test.jsx.snap
+++ b/src/Components/ResultsFilterContainer/__snapshots__/ResultsFilterContainer.test.jsx.snap
@@ -38,6 +38,7 @@ exports[`ResultsFilterContainerComponent matches snapshot 1`] = `
             },
           ]
         }
+        isCDO={false}
         missionSearchHasErrored={false}
         missionSearchIsLoading={false}
         missionSearchResults={Array []}

--- a/src/Components/ResultsPage/ResultsPage.jsx
+++ b/src/Components/ResultsPage/ResultsPage.jsx
@@ -71,6 +71,7 @@ class Results extends Component {
             postSearchResults={postSearchResults}
             postSearchIsLoading={postSearchIsLoading}
             postSearchHasErrored={postSearchHasErrored}
+            userProfile={userProfile}
           />
           <ResultsContainer
             results={results}

--- a/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.jsx
+++ b/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.jsx
@@ -45,16 +45,18 @@ class SearchFiltersContainer extends Component {
     const { fetchMissionAutocomplete, missionSearchResults, fetchPostAutocomplete,
     postSearchResults, isCDO } = this.props;
 
-    // get our boolean filter names
-    const sortedBooleanNames = ['Post Differential', 'Danger Pay', 'COLA', 'Domestic'];
+    // Get our boolean filter names.
+    // We use the "description" property because these are less likely
+    // to change (they're not UI elements).
+    const sortedBooleanNames = ['postDiff', 'dangerPay', 'COLA', 'domestic'];
     // if and only if it's a CDO, we'll show the 'Available' filter
-    if (isCDO) { sortedBooleanNames.push('Available'); }
+    if (isCDO) { sortedBooleanNames.push('available'); }
 
     // store filters in Map
     const booleanFiltersMap = new Map();
     this.props.filters.forEach((searchFilter) => {
       if (searchFilter.item.bool) {
-        booleanFiltersMap.set(searchFilter.item.title, searchFilter);
+        booleanFiltersMap.set(searchFilter.item.description, searchFilter);
       }
     });
 

--- a/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.jsx
+++ b/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.jsx
@@ -43,10 +43,12 @@ class SearchFiltersContainer extends Component {
   }
   render() {
     const { fetchMissionAutocomplete, missionSearchResults, fetchPostAutocomplete,
-    postSearchResults } = this.props;
+    postSearchResults, isCDO } = this.props;
 
     // get our boolean filter names
     const sortedBooleanNames = ['Post Differential', 'Danger Pay', 'COLA', 'Domestic'];
+    // if and only if it's a CDO, we'll show the 'Available' filter
+    if (isCDO) { sortedBooleanNames.push('Available'); }
 
     // store filters in Map
     const booleanFiltersMap = new Map();
@@ -209,6 +211,7 @@ SearchFiltersContainer.propTypes = {
   missionSearchResults: MISSION_DETAILS_ARRAY.isRequired,
   fetchPostAutocomplete: PropTypes.func.isRequired,
   postSearchResults: POST_DETAILS_ARRAY.isRequired,
+  isCDO: PropTypes.bool.isRequired,
 };
 
 export default SearchFiltersContainer;

--- a/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.test.jsx
+++ b/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.test.jsx
@@ -22,6 +22,42 @@ describe('SearchFiltersContainerComponent', () => {
 
   const accordion = ACCORDION_SELECTION;
 
+  it('is defined', () => {
+    const wrapper = shallow(
+      <SearchFiltersContainer
+        queryParamUpdate={() => {}}
+        queryParamToggle={() => {}}
+        selectedAccordion={accordion}
+        setAccordion={() => {}}
+        filters={items}
+        fetchMissionAutocomplete={() => {}}
+        missionSearchResults={[]}
+        fetchPostAutocomplete={() => {}}
+        postSearchResults={[]}
+        isCDO={false}
+      />,
+    );
+    expect(wrapper.instance()).toBeDefined();
+  });
+
+  it('is defined when isCDO is true', () => {
+    const wrapper = shallow(
+      <SearchFiltersContainer
+        queryParamUpdate={() => {}}
+        queryParamToggle={() => {}}
+        selectedAccordion={accordion}
+        setAccordion={() => {}}
+        filters={items}
+        fetchMissionAutocomplete={() => {}}
+        missionSearchResults={[]}
+        fetchPostAutocomplete={() => {}}
+        postSearchResults={[]}
+        isCDO
+      />,
+    );
+    expect(wrapper.instance()).toBeDefined();
+  });
+
   it('can receive props', () => {
     const wrapper = shallow(
       <SearchFiltersContainer
@@ -34,6 +70,7 @@ describe('SearchFiltersContainerComponent', () => {
         missionSearchResults={[]}
         fetchPostAutocomplete={() => {}}
         postSearchResults={[]}
+        isCDO={false}
       />,
     );
     expect(wrapper.instance().props.filters[0].item.title).toBe(items[0].item.title);
@@ -51,6 +88,7 @@ describe('SearchFiltersContainerComponent', () => {
         missionSearchResults={[]}
         fetchPostAutocomplete={() => {}}
         postSearchResults={[]}
+        isCDO={false}
       />,
     );
     expect(toJSON(wrapper)).toMatchSnapshot();
@@ -69,6 +107,7 @@ describe('SearchFiltersContainerComponent', () => {
         missionSearchResults={[]}
         fetchPostAutocomplete={() => {}}
         postSearchResults={[]}
+        isCDO={false}
       />,
     );
 
@@ -94,6 +133,7 @@ describe('SearchFiltersContainerComponent', () => {
         missionSearchResults={[]}
         fetchPostAutocomplete={() => {}}
         postSearchResults={[]}
+        isCDO={false}
       />,
     );
 
@@ -115,6 +155,7 @@ describe('SearchFiltersContainerComponent', () => {
         missionSearchResults={[]}
         fetchPostAutocomplete={() => {}}
         postSearchResults={[]}
+        isCDO={false}
       />,
     );
 
@@ -136,6 +177,7 @@ describe('SearchFiltersContainerComponent', () => {
         missionSearchResults={[]}
         fetchPostAutocomplete={() => {}}
         postSearchResults={[]}
+        isCDO={false}
       />,
     );
     wrapper.instance().onMissionSuggestionSelected(1);
@@ -160,6 +202,7 @@ describe('SearchFiltersContainerComponent', () => {
         missionSearchResults={[]}
         fetchPostAutocomplete={() => {}}
         postSearchResults={[]}
+        isCDO={false}
       />,
     );
     expect(wrapper.instance().props.filters[0].item.description).toBe('language');
@@ -193,6 +236,7 @@ describe('SearchFiltersContainerComponent', () => {
         missionSearchResults={[]}
         fetchPostAutocomplete={() => {}}
         postSearchResults={[]}
+        isCDO={false}
       />,
     );
     expect(wrapper.instance().props.filters[0].item.description).toBe('skill');

--- a/src/Components/SearchFilters/SearchFiltersContainer/__snapshots__/SearchFiltersContainer.test.jsx.snap
+++ b/src/Components/SearchFilters/SearchFiltersContainer/__snapshots__/SearchFiltersContainer.test.jsx.snap
@@ -63,22 +63,7 @@ exports[`SearchFiltersContainerComponent matches snapshot 1`] = `
     className="boolean-filter-container"
   >
     <BooleanFilterContainer
-      filters={
-        Array [
-          Object {
-            "data": Array [
-              Object {
-                "isSelected": false,
-              },
-            ],
-            "item": Object {
-              "bool": true,
-              "selectionRef": "ref2",
-              "title": "COLA",
-            },
-          },
-        ]
-      }
+      filters={Array []}
       onBooleanFilterClick={[Function]}
     />
   </div>

--- a/src/Constants/EndpointParams.js
+++ b/src/Constants/EndpointParams.js
@@ -12,6 +12,7 @@ export const ENDPOINT_PARAMS = {
   domestic: 'is_domestic',
   mission: 'post__location__country__in',
   post: 'post__in',
+  available: 'is_available',
 };
 
 export const VALID_PARAMS = [
@@ -26,6 +27,7 @@ export const VALID_PARAMS = [
   ENDPOINT_PARAMS.domestic,
   ENDPOINT_PARAMS.mission,
   ENDPOINT_PARAMS.post,
+  ENDPOINT_PARAMS.available,
   'q',
 ];
 

--- a/src/Constants/EndpointParams.js
+++ b/src/Constants/EndpointParams.js
@@ -12,7 +12,7 @@ export const ENDPOINT_PARAMS = {
   domestic: 'is_domestic',
   mission: 'post__location__country__in',
   post: 'post__in',
-  available: 'is_available',
+  available: 'is_available_in_current_bidcycle',
 };
 
 export const VALID_PARAMS = [

--- a/src/Constants/PropTypes.js
+++ b/src/Constants/PropTypes.js
@@ -154,6 +154,7 @@ export const USER_PROFILE = PropTypes.shape({
     first_name: PropTypes.string,
     last_name: PropTypes.string,
   }),
+  is_cdo: PropTypes.bool,
   language_qualifications: PropTypes.arrayOf(
     PropTypes.number,
   ),

--- a/src/__mocks__/userObject.js
+++ b/src/__mocks__/userObject.js
@@ -5,6 +5,7 @@ const userObject = {
     last_name: 'Doe',
     email: 'doej@state.gov',
   },
+  is_cdo: false,
 };
 
 export default userObject;

--- a/src/actions/filters/helpers.js
+++ b/src/actions/filters/helpers.js
@@ -52,7 +52,8 @@ export function isBooleanFilter(description) {
     description === 'COLA' ||
     description === 'postDiff' ||
     description === 'dangerPay' ||
-    description === 'domestic'
+    description === 'domestic' ||
+    description === 'available'
   ) {
     return true;
   }

--- a/src/actions/filters/helpers.test.js
+++ b/src/actions/filters/helpers.test.js
@@ -54,6 +54,7 @@ describe('filter helpers', () => {
     expect(isBooleanFilter('postDiff')).toBe(true);
     expect(isBooleanFilter('dangerPay')).toBe(true);
     expect(isBooleanFilter('domestic')).toBe(true);
+    expect(isBooleanFilter('available')).toBe(true);
     expect(isBooleanFilter('invalud')).toBe(false);
   });
 });

--- a/src/reducers/filters.js
+++ b/src/reducers/filters.js
@@ -129,6 +129,21 @@ const items =
       },
       {
         item: {
+          title: 'Available',
+          sort: 950,
+          bool: true,
+          description: 'available',
+          selectionRef: ENDPOINT_PARAMS.available,
+          text: 'Include only available positions',
+          choices: [
+          ],
+        },
+        data: [
+          { code: 'true', short_description: 'Yes' },
+        ],
+      },
+      {
+        item: {
           title: 'Mission',
           sort: 1000,
           bool: false,

--- a/src/reducers/filters.js
+++ b/src/reducers/filters.js
@@ -129,7 +129,7 @@ const items =
       },
       {
         item: {
-          title: 'Available',
+          title: 'Available (No handshakes)',
           sort: 950,
           bool: true,
           description: 'available',


### PR DESCRIPTION
Addresses #877 by adding a filter to the results page that is only accessible by CDOs. New filter is a boolean for "Available (No handshakes)" which uses the `?is_available_in_current_bidcycle` added in https://github.com/18F/State-TalentMAP-API/pull/228