### PR TITLE
Bid Type Count Explanations

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react-router-redux": "^5.0.0-alpha.6",
     "react-scroll": "^1.5.4",
     "react-simple-dropdown": "^3.0.0",
+    "react-tippy": "^1.2.2",
     "redux": "^3.7.1",
     "redux-form": "^7.0.1",
     "redux-saga": "^0.15.4",

--- a/src/Components/BidCount/BidCount.jsx
+++ b/src/Components/BidCount/BidCount.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import BidCountNumber from './BidCountNumber';
+
+const BidCount = ({ totalBids, inGradeBids, atSkillBids, inGradeAtSkillBids }) => (
+  <ul className="bid-count-list">
+    <BidCountNumber type="totalBids" number={totalBids} />
+    <BidCountNumber type="inGradeBids" number={inGradeBids} />
+    <BidCountNumber type="atSkillBids" number={atSkillBids} />
+    <BidCountNumber type="inGradeAtSkillBids" number={inGradeAtSkillBids} />
+  </ul>
+);
+
+BidCount.propTypes = {
+  totalBids: PropTypes.number.isRequired,
+  inGradeBids: PropTypes.number.isRequired,
+  atSkillBids: PropTypes.number.isRequired,
+  inGradeAtSkillBids: PropTypes.number.isRequired,
+};
+
+BidCount.defaultProps = {
+  totalBids: 0,
+  inGradeBids: 0,
+  atSkillBids: 0,
+  inGradeAtSkillBids: 0,
+};
+
+export default BidCount;

--- a/src/Components/BidCount/BidCount.test.jsx
+++ b/src/Components/BidCount/BidCount.test.jsx
@@ -1,0 +1,30 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import toJSON from 'enzyme-to-json';
+import BidCount from './BidCount';
+
+describe('BidCountComponent', () => {
+  it('is defined', () => {
+    const wrapper = shallow(
+      <BidCount
+        totalBids={5}
+        inGradeBids={5}
+        atSkillBids={5}
+        inGradeAtSkillBids={5}
+      />,
+    );
+    expect(wrapper).toBeDefined();
+  });
+
+  it('matches snapshot', () => {
+    const wrapper = shallow(
+      <BidCount
+        totalBids={5}
+        inGradeBids={5}
+        atSkillBids={5}
+        inGradeAtSkillBids={5}
+      />,
+    );
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/Components/BidCount/BidCountNumber/BidCountNumber.jsx
+++ b/src/Components/BidCount/BidCountNumber/BidCountNumber.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Tooltip } from 'react-tippy';
+import BID_COUNT_DEFINITIONS from '../../../Constants/BidCountDefinitions';
+
+const BidCountNumber = ({ type, number }) => (
+  <li className="bid-count-list-item">
+    <Tooltip
+      title={BID_COUNT_DEFINITIONS[type]}
+      arrow
+      offset={-50}
+      tabIndex="0"
+    >
+      <span className="bid-count-number">
+        {number}
+      </span>
+    </Tooltip>
+  </li>
+);
+
+BidCountNumber.propTypes = {
+  number: PropTypes.number.isRequired,
+  type: PropTypes.oneOf(['totalBids', 'inGradeBids', 'atSkillBids', 'inGradeAtSkillBids']).isRequired,
+};
+
+export default BidCountNumber;

--- a/src/Components/BidCount/BidCountNumber/BidCountNumber.test.jsx
+++ b/src/Components/BidCount/BidCountNumber/BidCountNumber.test.jsx
@@ -1,0 +1,22 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import toJSON from 'enzyme-to-json';
+import BidCountNumber from './BidCountNumber';
+
+describe('BidCountNumberComponent', () => {
+  ['totalBids', 'inGradeBids', 'atSkillBids', 'inGradeAtSkillBids'].forEach((type) => {
+    it(`is defined where type = ${type}`, () => {
+      const wrapper = shallow(
+        <BidCountNumber type={type} number={10} />,
+      );
+      expect(wrapper).toBeDefined();
+    });
+
+    it(`matches snapshot where type = ${type}`, () => {
+      const wrapper = shallow(
+        <BidCountNumber type={type} number={10} />,
+      );
+      expect(toJSON(wrapper)).toMatchSnapshot();
+    });
+  });
+});

--- a/src/Components/BidCount/BidCountNumber/__snapshots__/BidCountNumber.test.jsx.snap
+++ b/src/Components/BidCount/BidCountNumber/__snapshots__/BidCountNumber.test.jsx.snap
@@ -1,0 +1,205 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BidCountNumberComponent matches snapshot where type = atSkillBids 1`] = `
+<li
+  className="bid-count-list-item"
+>
+  <Tooltip
+    animateFill={true}
+    animation="shift"
+    arrow={true}
+    arrowSize="regular"
+    className=""
+    delay={0}
+    disabled={false}
+    distance={10}
+    duration={375}
+    followCursor={false}
+    hideDelay={0}
+    hideDuration={375}
+    hideOnClick={true}
+    html={null}
+    inertia={false}
+    interactive={false}
+    interactiveBorder={2}
+    multiple={false}
+    offset={-50}
+    onHidden={[Function]}
+    onHide={[Function]}
+    onRequestClose={[Function]}
+    onShow={[Function]}
+    onShown={[Function]}
+    popperOptions={Object {}}
+    position="top"
+    size="regular"
+    sticky={false}
+    stickyDuration={200}
+    style={Object {}}
+    tabIndex="0"
+    theme="dark"
+    title="Number of bidders who are at Skill Code."
+    touchHold={false}
+    trigger="click mouseenter focus"
+    unmountHTMLWhenHide={false}
+  >
+    <span
+      className="bid-count-number"
+    >
+      10
+    </span>
+  </Tooltip>
+</li>
+`;
+
+exports[`BidCountNumberComponent matches snapshot where type = inGradeAtSkillBids 1`] = `
+<li
+  className="bid-count-list-item"
+>
+  <Tooltip
+    animateFill={true}
+    animation="shift"
+    arrow={true}
+    arrowSize="regular"
+    className=""
+    delay={0}
+    disabled={false}
+    distance={10}
+    duration={375}
+    followCursor={false}
+    hideDelay={0}
+    hideDuration={375}
+    hideOnClick={true}
+    html={null}
+    inertia={false}
+    interactive={false}
+    interactiveBorder={2}
+    multiple={false}
+    offset={-50}
+    onHidden={[Function]}
+    onHide={[Function]}
+    onRequestClose={[Function]}
+    onShow={[Function]}
+    onShown={[Function]}
+    popperOptions={Object {}}
+    position="top"
+    size="regular"
+    sticky={false}
+    stickyDuration={200}
+    style={Object {}}
+    tabIndex="0"
+    theme="dark"
+    title="Number of bidders who are at Grade and Skill Code."
+    touchHold={false}
+    trigger="click mouseenter focus"
+    unmountHTMLWhenHide={false}
+  >
+    <span
+      className="bid-count-number"
+    >
+      10
+    </span>
+  </Tooltip>
+</li>
+`;
+
+exports[`BidCountNumberComponent matches snapshot where type = inGradeBids 1`] = `
+<li
+  className="bid-count-list-item"
+>
+  <Tooltip
+    animateFill={true}
+    animation="shift"
+    arrow={true}
+    arrowSize="regular"
+    className=""
+    delay={0}
+    disabled={false}
+    distance={10}
+    duration={375}
+    followCursor={false}
+    hideDelay={0}
+    hideDuration={375}
+    hideOnClick={true}
+    html={null}
+    inertia={false}
+    interactive={false}
+    interactiveBorder={2}
+    multiple={false}
+    offset={-50}
+    onHidden={[Function]}
+    onHide={[Function]}
+    onRequestClose={[Function]}
+    onShow={[Function]}
+    onShown={[Function]}
+    popperOptions={Object {}}
+    position="top"
+    size="regular"
+    sticky={false}
+    stickyDuration={200}
+    style={Object {}}
+    tabIndex="0"
+    theme="dark"
+    title="Number of bidders who are at Grade."
+    touchHold={false}
+    trigger="click mouseenter focus"
+    unmountHTMLWhenHide={false}
+  >
+    <span
+      className="bid-count-number"
+    >
+      10
+    </span>
+  </Tooltip>
+</li>
+`;
+
+exports[`BidCountNumberComponent matches snapshot where type = totalBids 1`] = `
+<li
+  className="bid-count-list-item"
+>
+  <Tooltip
+    animateFill={true}
+    animation="shift"
+    arrow={true}
+    arrowSize="regular"
+    className=""
+    delay={0}
+    disabled={false}
+    distance={10}
+    duration={375}
+    followCursor={false}
+    hideDelay={0}
+    hideDuration={375}
+    hideOnClick={true}
+    html={null}
+    inertia={false}
+    interactive={false}
+    interactiveBorder={2}
+    multiple={false}
+    offset={-50}
+    onHidden={[Function]}
+    onHide={[Function]}
+    onRequestClose={[Function]}
+    onShow={[Function]}
+    onShown={[Function]}
+    popperOptions={Object {}}
+    position="top"
+    size="regular"
+    sticky={false}
+    stickyDuration={200}
+    style={Object {}}
+    tabIndex="0"
+    theme="dark"
+    title="Number of bids on this position."
+    touchHold={false}
+    trigger="click mouseenter focus"
+    unmountHTMLWhenHide={false}
+  >
+    <span
+      className="bid-count-number"
+    >
+      10
+    </span>
+  </Tooltip>
+</li>
+`;

--- a/src/Components/BidCount/BidCountNumber/__snapshots__/BidCountNumber.test.jsx.snap
+++ b/src/Components/BidCount/BidCountNumber/__snapshots__/BidCountNumber.test.jsx.snap
@@ -39,7 +39,7 @@ exports[`BidCountNumberComponent matches snapshot where type = atSkillBids 1`] =
     theme="dark"
     title="Number of bidders who are at Skill Code."
     touchHold={false}
-    trigger="click mouseenter focus"
+    trigger="mouseenter focus"
     unmountHTMLWhenHide={false}
   >
     <span
@@ -90,7 +90,7 @@ exports[`BidCountNumberComponent matches snapshot where type = inGradeAtSkillBid
     theme="dark"
     title="Number of bidders who are at Grade and Skill Code."
     touchHold={false}
-    trigger="click mouseenter focus"
+    trigger="mouseenter focus"
     unmountHTMLWhenHide={false}
   >
     <span
@@ -141,7 +141,7 @@ exports[`BidCountNumberComponent matches snapshot where type = inGradeBids 1`] =
     theme="dark"
     title="Number of bidders who are at Grade."
     touchHold={false}
-    trigger="click mouseenter focus"
+    trigger="mouseenter focus"
     unmountHTMLWhenHide={false}
   >
     <span
@@ -192,7 +192,7 @@ exports[`BidCountNumberComponent matches snapshot where type = totalBids 1`] = `
     theme="dark"
     title="Number of bids on this position."
     touchHold={false}
-    trigger="click mouseenter focus"
+    trigger="mouseenter focus"
     unmountHTMLWhenHide={false}
   >
     <span

--- a/src/Components/BidCount/BidCountNumber/index.js
+++ b/src/Components/BidCount/BidCountNumber/index.js
@@ -1,0 +1,1 @@
+export { default } from './BidCountNumber';

--- a/src/Components/BidCount/__snapshots__/BidCount.test.jsx.snap
+++ b/src/Components/BidCount/__snapshots__/BidCount.test.jsx.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BidCountComponent matches snapshot 1`] = `
+<ul
+  className="bid-count-list"
+>
+  <BidCountNumber
+    number={5}
+    type="totalBids"
+  />
+  <BidCountNumber
+    number={5}
+    type="inGradeBids"
+  />
+  <BidCountNumber
+    number={5}
+    type="atSkillBids"
+  />
+  <BidCountNumber
+    number={5}
+    type="inGradeAtSkillBids"
+  />
+</ul>
+`;

--- a/src/Components/BidCount/index.js
+++ b/src/Components/BidCount/index.js
@@ -1,0 +1,1 @@
+export { default } from './BidCount';

--- a/src/Components/FavoritePositions/__snapshots__/FavoritePositions.test.jsx.snap
+++ b/src/Components/FavoritePositions/__snapshots__/FavoritePositions.test.jsx.snap
@@ -11,6 +11,16 @@ exports[`FavoritePositionsComponent matches snapshot 1`] = `
     favorites={
       Array [
         Object {
+          "bid_statistics": Array [
+            Object {
+              "at_skill": 0,
+              "bidcycle": 1,
+              "id": 1,
+              "in_grade": 0,
+              "in_grade_at_skill": 0,
+              "total_bids": 3,
+            },
+          ],
           "bureau": "150000",
           "create_date": "2006-09-20",
           "description": Object {
@@ -53,6 +63,16 @@ exports[`FavoritePositionsComponent matches snapshot 1`] = `
           "update_date": "2017-06-08",
         },
         Object {
+          "bid_statistics": Array [
+            Object {
+              "at_skill": 0,
+              "bidcycle": 1,
+              "id": 1,
+              "in_grade": 0,
+              "in_grade_at_skill": 0,
+              "total_bids": 3,
+            },
+          ],
           "bureau": "150000",
           "create_date": "2006-09-20",
           "grade": "03",

--- a/src/Components/FavoritePositionsList/__snapshots__/FavoritePositionsList.test.jsx.snap
+++ b/src/Components/FavoritePositionsList/__snapshots__/FavoritePositionsList.test.jsx.snap
@@ -11,6 +11,16 @@ exports[`FavoritePositionsListComponent matches snapshot 1`] = `
       favorites={
         Array [
           Object {
+            "bid_statistics": Array [
+              Object {
+                "at_skill": 0,
+                "bidcycle": 1,
+                "id": 1,
+                "in_grade": 0,
+                "in_grade_at_skill": 0,
+                "total_bids": 3,
+              },
+            ],
             "bureau": "150000",
             "create_date": "2006-09-20",
             "description": Object {
@@ -53,6 +63,16 @@ exports[`FavoritePositionsListComponent matches snapshot 1`] = `
             "update_date": "2017-06-08",
           },
           Object {
+            "bid_statistics": Array [
+              Object {
+                "at_skill": 0,
+                "bidcycle": 1,
+                "id": 1,
+                "in_grade": 0,
+                "in_grade_at_skill": 0,
+                "total_bids": 3,
+              },
+            ],
             "bureau": "150000",
             "create_date": "2006-09-20",
             "grade": "03",
@@ -69,6 +89,16 @@ exports[`FavoritePositionsListComponent matches snapshot 1`] = `
       }
       position={
         Object {
+          "bid_statistics": Array [
+            Object {
+              "at_skill": 0,
+              "bidcycle": 1,
+              "id": 1,
+              "in_grade": 0,
+              "in_grade_at_skill": 0,
+              "total_bids": 3,
+            },
+          ],
           "bureau": "150000",
           "create_date": "2006-09-20",
           "description": Object {
@@ -124,6 +154,16 @@ exports[`FavoritePositionsListComponent matches snapshot 1`] = `
       favorites={
         Array [
           Object {
+            "bid_statistics": Array [
+              Object {
+                "at_skill": 0,
+                "bidcycle": 1,
+                "id": 1,
+                "in_grade": 0,
+                "in_grade_at_skill": 0,
+                "total_bids": 3,
+              },
+            ],
             "bureau": "150000",
             "create_date": "2006-09-20",
             "description": Object {
@@ -166,6 +206,16 @@ exports[`FavoritePositionsListComponent matches snapshot 1`] = `
             "update_date": "2017-06-08",
           },
           Object {
+            "bid_statistics": Array [
+              Object {
+                "at_skill": 0,
+                "bidcycle": 1,
+                "id": 1,
+                "in_grade": 0,
+                "in_grade_at_skill": 0,
+                "total_bids": 3,
+              },
+            ],
             "bureau": "150000",
             "create_date": "2006-09-20",
             "grade": "03",
@@ -182,6 +232,16 @@ exports[`FavoritePositionsListComponent matches snapshot 1`] = `
       }
       position={
         Object {
+          "bid_statistics": Array [
+            Object {
+              "at_skill": 0,
+              "bidcycle": 1,
+              "id": 1,
+              "in_grade": 0,
+              "in_grade_at_skill": 0,
+              "total_bids": 3,
+            },
+          ],
           "bureau": "150000",
           "create_date": "2006-09-20",
           "grade": "03",

--- a/src/Components/HighlightedPositionsCardList/__snapshots__/HighlightedPositionsCardList.test.jsx.snap
+++ b/src/Components/HighlightedPositionsCardList/__snapshots__/HighlightedPositionsCardList.test.jsx.snap
@@ -11,6 +11,16 @@ exports[`HighlightedPositionsCardListComponent matches snapshot 1`] = `
       favorites={Array []}
       position={
         Object {
+          "bid_statistics": Array [
+            Object {
+              "at_skill": 0,
+              "bidcycle": 1,
+              "id": 1,
+              "in_grade": 0,
+              "in_grade_at_skill": 0,
+              "total_bids": 3,
+            },
+          ],
           "bureau": "150000",
           "create_date": "2006-09-20",
           "description": Object {
@@ -66,6 +76,16 @@ exports[`HighlightedPositionsCardListComponent matches snapshot 1`] = `
       favorites={Array []}
       position={
         Object {
+          "bid_statistics": Array [
+            Object {
+              "at_skill": 0,
+              "bidcycle": 1,
+              "id": 1,
+              "in_grade": 0,
+              "in_grade_at_skill": 0,
+              "total_bids": 3,
+            },
+          ],
           "bureau": "150000",
           "create_date": "2006-09-20",
           "grade": "03",

--- a/src/Components/HighlightedPositionsSection/__snapshots__/HighlightedPositionsSection.test.jsx.snap
+++ b/src/Components/HighlightedPositionsSection/__snapshots__/HighlightedPositionsSection.test.jsx.snap
@@ -23,6 +23,16 @@ exports[`HighlightedPositionsSectionComponent matches snapshot 1`] = `
     positions={
       Array [
         Object {
+          "bid_statistics": Array [
+            Object {
+              "at_skill": 0,
+              "bidcycle": 1,
+              "id": 1,
+              "in_grade": 0,
+              "in_grade_at_skill": 0,
+              "total_bids": 3,
+            },
+          ],
           "bureau": "150000",
           "create_date": "2006-09-20",
           "description": Object {
@@ -65,6 +75,16 @@ exports[`HighlightedPositionsSectionComponent matches snapshot 1`] = `
           "update_date": "2017-06-08",
         },
         Object {
+          "bid_statistics": Array [
+            Object {
+              "at_skill": 0,
+              "bidcycle": 1,
+              "id": 1,
+              "in_grade": 0,
+              "in_grade_at_skill": 0,
+              "total_bids": 3,
+            },
+          ],
           "bureau": "150000",
           "create_date": "2006-09-20",
           "grade": "03",

--- a/src/Components/NewPositionsCardList/__snapshots__/NewPositionsCardList.test.jsx.snap
+++ b/src/Components/NewPositionsCardList/__snapshots__/NewPositionsCardList.test.jsx.snap
@@ -14,6 +14,16 @@ exports[`NewPositionsCardListComponent matches snapshot 1`] = `
         favorites={Array []}
         position={
           Object {
+            "bid_statistics": Array [
+              Object {
+                "at_skill": 0,
+                "bidcycle": 1,
+                "id": 1,
+                "in_grade": 0,
+                "in_grade_at_skill": 0,
+                "total_bids": 3,
+              },
+            ],
             "bureau": "150000",
             "create_date": "2006-09-20",
             "description": Object {
@@ -73,6 +83,16 @@ exports[`NewPositionsCardListComponent matches snapshot 1`] = `
         favorites={Array []}
         position={
           Object {
+            "bid_statistics": Array [
+              Object {
+                "at_skill": 0,
+                "bidcycle": 1,
+                "id": 1,
+                "in_grade": 0,
+                "in_grade_at_skill": 0,
+                "total_bids": 3,
+              },
+            ],
             "bureau": "150000",
             "create_date": "2006-09-20",
             "grade": "03",

--- a/src/Components/NewPositionsSection/__snapshots__/NewPositionsSection.test.jsx.snap
+++ b/src/Components/NewPositionsSection/__snapshots__/NewPositionsSection.test.jsx.snap
@@ -23,6 +23,16 @@ exports[`NewPositionsSectionComponent matches snapshot 1`] = `
     positions={
       Array [
         Object {
+          "bid_statistics": Array [
+            Object {
+              "at_skill": 0,
+              "bidcycle": 1,
+              "id": 1,
+              "in_grade": 0,
+              "in_grade_at_skill": 0,
+              "total_bids": 3,
+            },
+          ],
           "bureau": "150000",
           "create_date": "2006-09-20",
           "description": Object {
@@ -65,6 +75,16 @@ exports[`NewPositionsSectionComponent matches snapshot 1`] = `
           "update_date": "2017-06-08",
         },
         Object {
+          "bid_statistics": Array [
+            Object {
+              "at_skill": 0,
+              "bidcycle": 1,
+              "id": 1,
+              "in_grade": 0,
+              "in_grade_at_skill": 0,
+              "total_bids": 3,
+            },
+          ],
           "bureau": "150000",
           "create_date": "2006-09-20",
           "grade": "03",

--- a/src/Components/PositionTitle/PositionTitle.jsx
+++ b/src/Components/PositionTitle/PositionTitle.jsx
@@ -108,6 +108,8 @@ class PositionTitle extends Component {
 
     const isAllowedToEdit = !!(details.description && details.description.is_editable_by_user);
 
+    const shouldShowBidStats = !!details.bid_statistics && !!details.bid_statistics[0];
+
     return (
       <div className="position-details-header-container">
         <div className="position-details-header">
@@ -189,13 +191,13 @@ class PositionTitle extends Component {
         <div className="offset-bid-button-container">
           <div className="offset-bid-button-container-count">
             {
-              !!details.bid_statistics && !!details.bid_statistics[0] &&
-              <BidCount
-                totalBids={details.bid_statistics[0].total_bids}
-                inGradeBids={details.bid_statistics[0].in_grade}
-                atSkillBids={details.bid_statistics[0].at_skill}
-                inGradeAtSkillBids={details.bid_statistics[0].in_grade_at_skill}
-              />
+              shouldShowBidStats &&
+                <BidCount
+                  totalBids={details.bid_statistics[0].total_bids}
+                  inGradeBids={details.bid_statistics[0].in_grade}
+                  atSkillBids={details.bid_statistics[0].at_skill}
+                  inGradeAtSkillBids={details.bid_statistics[0].in_grade_at_skill}
+                />
             }
           </div>
           <div className="offset-bid-button-container-button">

--- a/src/Components/PositionTitle/PositionTitle.jsx
+++ b/src/Components/PositionTitle/PositionTitle.jsx
@@ -5,6 +5,7 @@ import BidListButton from '../BidListButton';
 import TextEditor from '../TextEditor';
 import PositionTitleSubDescription from '../PositionTitleSubDescription';
 import EditContentButton from '../EditContentButton';
+import BidCount from '../BidCount';
 import { POSITION_DETAILS, GO_BACK_TO_LINK, BID_LIST } from '../../Constants/PropTypes';
 import { NO_POSITION_WEB_SITE, NO_POSITION_POC, NO_POSITION_DESCRIPTION } from '../../Constants/SystemMessages';
 import { shortenString } from '../../utilities';
@@ -186,12 +187,25 @@ class PositionTitle extends Component {
           />
         </div>
         <div className="offset-bid-button-container">
-          <BidListButton
-            toggleBidPosition={toggleBidPosition}
-            compareArray={bidList.results}
-            id={details.id}
-            isLoading={bidListToggleIsLoading}
-          />
+          <div className="offset-bid-button-container-count">
+            {
+              !!details.bid_statistics && !!details.bid_statistics[0] &&
+              <BidCount
+                totalBids={details.bid_statistics[0].total_bids}
+                inGradeBids={details.bid_statistics[0].in_grade}
+                atSkillBids={details.bid_statistics[0].at_skill}
+                inGradeAtSkillBids={details.bid_statistics[0].in_grade_at_skill}
+              />
+            }
+          </div>
+          <div className="offset-bid-button-container-button">
+            <BidListButton
+              toggleBidPosition={toggleBidPosition}
+              compareArray={bidList.results}
+              id={details.id}
+              isLoading={bidListToggleIsLoading}
+            />
+          </div>
         </div>
       </div>
     );

--- a/src/Components/PositionTitle/__snapshots__/PositionTitle.test.jsx.snap
+++ b/src/Components/PositionTitle/__snapshots__/PositionTitle.test.jsx.snap
@@ -92,12 +92,26 @@ exports[`PositionTitleComponent matches snapshot 1`] = `
   <div
     className="offset-bid-button-container"
   >
-    <BidListButton
-      compareArray={Array []}
-      id={6}
-      isLoading={false}
-      toggleBidPosition={[Function]}
-    />
+    <div
+      className="offset-bid-button-container-count"
+    >
+      <BidCount
+        atSkillBids={0}
+        inGradeAtSkillBids={0}
+        inGradeBids={0}
+        totalBids={3}
+      />
+    </div>
+    <div
+      className="offset-bid-button-container-button"
+    >
+      <BidListButton
+        compareArray={Array []}
+        id={6}
+        isLoading={false}
+        toggleBidPosition={[Function]}
+      />
+    </div>
   </div>
 </div>
 `;

--- a/src/Components/ResultsCard/ResultsCard.jsx
+++ b/src/Components/ResultsCard/ResultsCard.jsx
@@ -8,56 +8,59 @@ import ResultsCardDataSection from '../ResultsCardDataSection/ResultsCardDataSec
 import BidCount from '../BidCount';
 
 const ResultsCard = ({ result, onToggle, favorites, toggleFavorite,
-    userProfileFavoritePositionIsLoading, userProfileFavoritePositionHasErrored }) => (
-      <div id={result.id} className="usa-grid-full results-card">
-        <div className="usa-grid-full">
-          <div className="usa-width-one-half results-card-title">
-            Position Number: {result.position_number}
-          </div>
-          <div className="results-card-favorite">
-            {
-              !!favorites &&
-              <Favorite
-                isLoading={userProfileFavoritePositionIsLoading}
-                hasErrored={userProfileFavoritePositionHasErrored}
-                compareArray={favorites}
-                refKey={result.id}
-                onToggle={toggleFavorite}
-              />
-            }
-          </div>
+  userProfileFavoritePositionIsLoading, userProfileFavoritePositionHasErrored }) => {
+  const shouldShowBidStats = !!result.bid_statistics && !!result.bid_statistics[0];
+  return (
+    <div id={result.id} className="usa-grid-full results-card">
+      <div className="usa-grid-full">
+        <div className="usa-width-one-half results-card-title">
+          Position Number: {result.position_number}
         </div>
-        <div className="usa-grid-full">
-          <ResultsCardDataSection result={result} />
+        <div className="results-card-favorite">
+          {
+            !!favorites &&
+            <Favorite
+              isLoading={userProfileFavoritePositionIsLoading}
+              hasErrored={userProfileFavoritePositionHasErrored}
+              compareArray={favorites}
+              refKey={result.id}
+              onToggle={toggleFavorite}
+            />
+          }
         </div>
-        <div className="usa-width-one-whole bottom-section" >
-          <div className="button-link details-button-container">
-            <Link
-              className="usa-button usa-button-primary details-button"
-              type="submit"
-              role="button"
-              to={`/details/${result.position_number}`}
-            >
-              View details
-            </Link>
-          </div>
-          <div className="compare-check">
-            <CompareCheck refKey={result.position_number} onToggle={onToggle} />
-          </div>
-          <div className="bid-count-container">
-            {
-              !!result.bid_statistics && !!result.bid_statistics[0] &&
+      </div>
+      <div className="usa-grid-full">
+        <ResultsCardDataSection result={result} />
+      </div>
+      <div className="usa-width-one-whole bottom-section" >
+        <div className="button-link details-button-container">
+          <Link
+            className="usa-button usa-button-primary details-button"
+            type="submit"
+            role="button"
+            to={`/details/${result.position_number}`}
+          >
+            View details
+          </Link>
+        </div>
+        <div className="compare-check">
+          <CompareCheck refKey={result.position_number} onToggle={onToggle} />
+        </div>
+        <div className="bid-count-container">
+          {
+            shouldShowBidStats &&
               <BidCount
                 totalBids={result.bid_statistics[0].total_bids}
                 inGradeBids={result.bid_statistics[0].in_grade}
                 atSkillBids={result.bid_statistics[0].at_skill}
                 inGradeAtSkillBids={result.bid_statistics[0].in_grade_at_skill}
               />
-            }
-          </div>
+          }
         </div>
       </div>
-);
+    </div>
+  );
+};
 
 ResultsCard.propTypes = {
   result: POSITION_DETAILS.isRequired,

--- a/src/Components/ResultsCard/ResultsCard.jsx
+++ b/src/Components/ResultsCard/ResultsCard.jsx
@@ -5,6 +5,7 @@ import { POSITION_DETAILS, FAVORITE_POSITIONS_ARRAY } from '../../Constants/Prop
 import Favorite from '../Favorite/Favorite';
 import CompareCheck from '../CompareCheck/CompareCheck';
 import ResultsCardDataSection from '../ResultsCardDataSection/ResultsCardDataSection';
+import BidCount from '../BidCount';
 
 const ResultsCard = ({ result, onToggle, favorites, toggleFavorite,
     userProfileFavoritePositionIsLoading, userProfileFavoritePositionHasErrored }) => (
@@ -29,7 +30,7 @@ const ResultsCard = ({ result, onToggle, favorites, toggleFavorite,
         <div className="usa-grid-full">
           <ResultsCardDataSection result={result} />
         </div>
-        <div className="usa-grid-full bottom-section" >
+        <div className="usa-width-one-whole bottom-section" >
           <div className="button-link details-button-container">
             <Link
               className="usa-button usa-button-primary details-button"
@@ -37,11 +38,22 @@ const ResultsCard = ({ result, onToggle, favorites, toggleFavorite,
               role="button"
               to={`/details/${result.position_number}`}
             >
-        View details
-        </Link>
+              View details
+            </Link>
           </div>
           <div className="compare-check">
             <CompareCheck refKey={result.position_number} onToggle={onToggle} />
+          </div>
+          <div className="bid-count-container">
+            {
+              !!result.bid_statistics && !!result.bid_statistics[0] &&
+              <BidCount
+                totalBids={result.bid_statistics[0].total_bids}
+                inGradeBids={result.bid_statistics[0].in_grade}
+                atSkillBids={result.bid_statistics[0].at_skill}
+                inGradeAtSkillBids={result.bid_statistics[0].in_grade_at_skill}
+              />
+            }
           </div>
         </div>
       </div>

--- a/src/Components/ResultsCard/__snapshots__/ResultsCard.test.jsx.snap
+++ b/src/Components/ResultsCard/__snapshots__/ResultsCard.test.jsx.snap
@@ -33,6 +33,16 @@ exports[`ResultsCardComponent matches snapshot 1`] = `
     <ResultsCardDataSection
       result={
         Object {
+          "bid_statistics": Array [
+            Object {
+              "at_skill": 0,
+              "bidcycle": 1,
+              "id": 1,
+              "in_grade": 0,
+              "in_grade_at_skill": 0,
+              "total_bids": 3,
+            },
+          ],
           "bureau": "150000",
           "create_date": "2006-09-20",
           "description": Object {
@@ -78,7 +88,7 @@ exports[`ResultsCardComponent matches snapshot 1`] = `
     />
   </div>
   <div
-    className="usa-grid-full bottom-section"
+    className="usa-width-one-whole bottom-section"
   >
     <div
       className="button-link details-button-container"
@@ -101,6 +111,16 @@ exports[`ResultsCardComponent matches snapshot 1`] = `
         onToggle={[Function]}
         refKey="00025003"
         type="compare"
+      />
+    </div>
+    <div
+      className="bid-count-container"
+    >
+      <BidCount
+        atSkillBids={0}
+        inGradeAtSkillBids={0}
+        inGradeBids={0}
+        totalBids={3}
       />
     </div>
   </div>

--- a/src/Components/ResultsCondensedCard/__snapshots__/ResultsCondensedCard.test.jsx.snap
+++ b/src/Components/ResultsCondensedCard/__snapshots__/ResultsCondensedCard.test.jsx.snap
@@ -8,6 +8,16 @@ exports[`ResultsCondensedCardComponent matches snapshot 1`] = `
     favorites={Array []}
     position={
       Object {
+        "bid_statistics": Array [
+          Object {
+            "at_skill": 0,
+            "bidcycle": 1,
+            "id": 1,
+            "in_grade": 0,
+            "in_grade_at_skill": 0,
+            "total_bids": 3,
+          },
+        ],
         "bureau": "150000",
         "create_date": "2006-09-20",
         "description": Object {
@@ -61,6 +71,16 @@ exports[`ResultsCondensedCardComponent matches snapshot 1`] = `
     <ResultsCondensedCardBottom
       position={
         Object {
+          "bid_statistics": Array [
+            Object {
+              "at_skill": 0,
+              "bidcycle": 1,
+              "id": 1,
+              "in_grade": 0,
+              "in_grade_at_skill": 0,
+              "total_bids": 3,
+            },
+          ],
           "bureau": "150000",
           "create_date": "2006-09-20",
           "description": Object {

--- a/src/Components/ResultsCondensedCardBottom/__snapshots__/ResultsCondensedCardBottom.test.jsx.snap
+++ b/src/Components/ResultsCondensedCardBottom/__snapshots__/ResultsCondensedCardBottom.test.jsx.snap
@@ -7,6 +7,16 @@ exports[`ResultsCondensedCardBottomComponent matches snapshot 1`] = `
   <CondensedCardData
     position={
       Object {
+        "bid_statistics": Array [
+          Object {
+            "at_skill": 0,
+            "bidcycle": 1,
+            "id": 1,
+            "in_grade": 0,
+            "in_grade_at_skill": 0,
+            "total_bids": 3,
+          },
+        ],
         "bureau": "150000",
         "create_date": "2006-09-20",
         "description": Object {

--- a/src/Components/ResultsContainer/__snapshots__/ResultsContainer.test.jsx.snap
+++ b/src/Components/ResultsContainer/__snapshots__/ResultsContainer.test.jsx.snap
@@ -38,6 +38,16 @@ exports[`ResultsContainerComponent matches snapshot 1`] = `
         "count": 2,
         "results": Array [
           Object {
+            "bid_statistics": Array [
+              Object {
+                "at_skill": 0,
+                "bidcycle": 1,
+                "id": 1,
+                "in_grade": 0,
+                "in_grade_at_skill": 0,
+                "total_bids": 3,
+              },
+            ],
             "bureau": "150000",
             "create_date": "2006-09-20",
             "description": Object {
@@ -80,6 +90,16 @@ exports[`ResultsContainerComponent matches snapshot 1`] = `
             "update_date": "2017-06-08",
           },
           Object {
+            "bid_statistics": Array [
+              Object {
+                "at_skill": 0,
+                "bidcycle": 1,
+                "id": 1,
+                "in_grade": 0,
+                "in_grade_at_skill": 0,
+                "total_bids": 3,
+              },
+            ],
             "bureau": "150000",
             "create_date": "2006-09-20",
             "grade": "03",
@@ -124,6 +144,16 @@ exports[`ResultsContainerComponent matches snapshot 1`] = `
           "count": 2,
           "results": Array [
             Object {
+              "bid_statistics": Array [
+                Object {
+                  "at_skill": 0,
+                  "bidcycle": 1,
+                  "id": 1,
+                  "in_grade": 0,
+                  "in_grade_at_skill": 0,
+                  "total_bids": 3,
+                },
+              ],
               "bureau": "150000",
               "create_date": "2006-09-20",
               "description": Object {
@@ -166,6 +196,16 @@ exports[`ResultsContainerComponent matches snapshot 1`] = `
               "update_date": "2017-06-08",
             },
             Object {
+              "bid_statistics": Array [
+                Object {
+                  "at_skill": 0,
+                  "bidcycle": 1,
+                  "id": 1,
+                  "in_grade": 0,
+                  "in_grade_at_skill": 0,
+                  "total_bids": 3,
+                },
+              ],
               "bureau": "150000",
               "create_date": "2006-09-20",
               "grade": "03",

--- a/src/Components/ResultsList/__snapshots__/ResultsList.test.jsx.snap
+++ b/src/Components/ResultsList/__snapshots__/ResultsList.test.jsx.snap
@@ -15,6 +15,16 @@ exports[`ResultsListComponent matches a snapshot with results 1`] = `
     onToggle={[Function]}
     result={
       Object {
+        "bid_statistics": Array [
+          Object {
+            "at_skill": 0,
+            "bidcycle": 1,
+            "id": 1,
+            "in_grade": 0,
+            "in_grade_at_skill": 0,
+            "total_bids": 3,
+          },
+        ],
         "bureau": "150000",
         "create_date": "2006-09-20",
         "description": Object {
@@ -66,6 +76,16 @@ exports[`ResultsListComponent matches a snapshot with results 1`] = `
     onToggle={[Function]}
     result={
       Object {
+        "bid_statistics": Array [
+          Object {
+            "at_skill": 0,
+            "bidcycle": 1,
+            "id": 1,
+            "in_grade": 0,
+            "in_grade_at_skill": 0,
+            "total_bids": 3,
+          },
+        ],
         "bureau": "150000",
         "create_date": "2006-09-20",
         "grade": "03",

--- a/src/Constants/BidCountDefinitions.js
+++ b/src/Constants/BidCountDefinitions.js
@@ -1,0 +1,8 @@
+const BID_COUNT_DEFINITIONS = {
+  totalBids: 'Number of bids on this position.',
+  inGradeBids: 'Number of bidders who are at Grade.',
+  atSkillBids: 'Number of bidders who are at Skill Code.',
+  inGradeAtSkillBids: 'Number of bidders who are at Grade and Skill Code.',
+};
+
+export default BID_COUNT_DEFINITIONS;

--- a/src/Constants/BidCountDefinitions.test.js
+++ b/src/Constants/BidCountDefinitions.test.js
@@ -1,0 +1,10 @@
+import BID_COUNT_DEFINITIONS from './BidCountDefinitions';
+
+describe('BidCountDefinitions', () => {
+  it('should return a value for valid bid count property', () => {
+    expect(BID_COUNT_DEFINITIONS.totalBids).toBeDefined();
+    expect(BID_COUNT_DEFINITIONS.inGradeBids).toBeDefined();
+    expect(BID_COUNT_DEFINITIONS.atSkillBids).toBeDefined();
+    expect(BID_COUNT_DEFINITIONS.inGradeAtSkillBids).toBeDefined();
+  });
+});

--- a/src/__mocks__/detailsObject.js
+++ b/src/__mocks__/detailsObject.js
@@ -13,6 +13,16 @@ const detailsObject = {
     website: 'https://www.state.gov/post',
     point_of_contact: '202-555-5555',
   },
+  bid_statistics: [
+    {
+      id: 1,
+      total_bids: 3,
+      in_grade: 0,
+      at_skill: 0,
+      in_grade_at_skill: 0,
+      bidcycle: 1,
+    },
+  ],
   post: { id: 162, tour_of_duty: '2YRR', code: 'LT6000000', location: 'MASERU, LESOTHO', cost_of_living_adjustment: 0, differential_rate: 15, danger_pay: 0, rest_relaxation_point: 'London', has_consumable_allowance: false, has_service_needs_differential: false },
   languages: [{ id: 1, language: 'French (FR)', reading_proficiency: '2', spoken_proficiency: '2', representation: 'French (FR) 2/2' }],
 };

--- a/src/__mocks__/resultsObject.js
+++ b/src/__mocks__/resultsObject.js
@@ -10,6 +10,16 @@ const resultsObject = {
       is_overseas: true,
       create_date: '2006-09-20',
       update_date: '2017-06-08',
+      bid_statistics: [
+        {
+          id: 1,
+          total_bids: 3,
+          in_grade: 0,
+          at_skill: 0,
+          in_grade_at_skill: 0,
+          bidcycle: 1,
+        },
+      ],
       description: {
         content: 'The quick brown fox jumped over the lazy dog.',
       },
@@ -28,6 +38,16 @@ const resultsObject = {
       is_overseas: true,
       create_date: '2006-09-20',
       update_date: '2017-06-08',
+      bid_statistics: [
+        {
+          id: 1,
+          total_bids: 3,
+          in_grade: 0,
+          at_skill: 0,
+          in_grade_at_skill: 0,
+          bidcycle: 1,
+        },
+      ],
       post: null,
       languages: [],
     },

--- a/src/sass/_bidCount.scss
+++ b/src/sass/_bidCount.scss
@@ -1,0 +1,49 @@
+.bid-count-container {
+  margin-top: 5px;
+}
+
+.bid-count-list {
+  display: inline-block;
+
+  // override default uswds ul margins
+  margin-bottom: 0;
+  margin-top: 0;
+
+  $border-width: 2px;
+
+  // Set our borders
+  li {
+    border-bottom: solid;
+    border-left: solid;
+    border-right: 0;
+    border-top: solid;
+    border-width: $border-width;
+    color: $color-gray;
+    cursor: help;
+    display: inline-block;
+    text-align: center;
+  }
+
+  // The last element gets a border-right, unlike our general <li>s.
+  li:nth-last-child(1) {
+    border-right: solid;
+    border-right-width: $border-width;
+  }
+
+  .bid-count-number {
+    padding: .2em .5em;
+  }
+
+  @media screen and (max-width: 950px) {
+    // Set our borders
+    li {
+      width: 50%;
+    }
+
+    // The last element gets a border-right, unlike our general <li>s.
+    li:nth-last-child(3) {
+      border-right: solid;
+      border-right-width: $border-width;
+    }
+  }
+}

--- a/src/sass/_details.scss
+++ b/src/sass/_details.scss
@@ -128,7 +128,15 @@
 .offset-bid-button-container {
   left: 63%;
   position: absolute;
-  top: 85%;
+  top: 70%;
+
+  .offset-bid-button-container-count {
+    min-height: 38px;
+  }
+
+  .bid-count-list {
+    padding: 0;
+  }
 }
 
 .edit-description-alert-container {

--- a/src/sass/_results.scss
+++ b/src/sass/_results.scss
@@ -78,6 +78,14 @@
   margin-bottom: 1em;
   padding: 1em 1.2em;
 
+  .bid-count-container {
+    float: right;
+  }
+
+  .tippy-tooltip {
+    font-size: 2rem;
+  }
+
   .results-card-title {
     float: left;
     text-transform: uppercase;

--- a/src/sass/_results.scss
+++ b/src/sass/_results.scss
@@ -82,10 +82,6 @@
     float: right;
   }
 
-  .tippy-tooltip {
-    font-size: 2rem;
-  }
-
   .results-card-title {
     float: left;
     text-transform: uppercase;

--- a/src/sass/_tooltip.scss
+++ b/src/sass/_tooltip.scss
@@ -1,0 +1,3 @@
+.tippy-tooltip--regular {
+  font-size: .8em;
+}

--- a/src/sass/_tooltip.scss
+++ b/src/sass/_tooltip.scss
@@ -1,3 +1,4 @@
+// overrides vendor class
 .tippy-tooltip--regular {
   font-size: .8em;
 }

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -16,12 +16,16 @@
 // Draft.js
 @import '../../node_modules/draft-js/dist/Draft.css';
 
+// react-tippy tooltip
+@import '../../node_modules/react-tippy/dist/tippy.css';
+
 // Global
 @import 'variables';
 
 // Components
 @import 'containers';
 @import 'autosuggest';
+@import 'bidCount';
 @import 'condensedCard';
 @import 'whiteButton';
 @import 'bidListButton';
@@ -41,3 +45,4 @@
 @import 'spinner';
 @import 'editor';
 @import 'dismiss';
+@import 'tooltip';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5520,6 +5520,10 @@ pluralize@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
 
+popper.js@^1.11.1:
+  version "1.12.9"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.12.9.tgz#0dfbc2dff96c451bb332edcfcfaaf566d331d5b3"
+
 portfinder@^1.0.9:
   version "1.0.13"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.13.tgz#bb32ecd87c27104ae6ee44b5a3ccbf0ebb1aede9"
@@ -6166,6 +6170,12 @@ react-themeable@^1.1.0:
   resolved "https://registry.yarnpkg.com/react-themeable/-/react-themeable-1.1.0.tgz#7d4466dd9b2b5fa75058727825e9f152ba379a0e"
   dependencies:
     object-assign "^3.0.0"
+
+react-tippy@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/react-tippy/-/react-tippy-1.2.2.tgz#061467d34d29e7a5a9421822d125c451d6bb5153"
+  dependencies:
+    popper.js "^1.11.1"
 
 react@^15.0.0, react@^15.6.1:
   version "15.6.1"


### PR DESCRIPTION
Addresses #755 by displaying the bid counts on position results cards and details pages. Integrates with [react-tippy](https://tvkhoa.github.io/testlib/), a tooltip module, to show bid definitions within 
a tooltip on hover.