### PR TITLE
CDO Bidder Portfolio - Updated Queries

### DIFF
--- a/src/Components/BidderPortfolio/BidControls/__snapshots__/BidControls.test.jsx.snap
+++ b/src/Components/BidderPortfolio/BidControls/__snapshots__/BidControls.test.jsx.snap
@@ -32,7 +32,7 @@ exports[`BidControlsComponent matches snapshot when isLoading is false 1`] = `
             },
             Object {
               "text": "Age",
-              "value": "age_param",
+              "value": "date_of_birth",
             },
           ]
         }
@@ -78,7 +78,7 @@ exports[`BidControlsComponent matches snapshot when isLoading is true 1`] = `
             },
             Object {
               "text": "Age",
-              "value": "age_param",
+              "value": "date_of_birth",
             },
           ]
         }

--- a/src/Components/BidderPortfolio/BidderPortfolioPage/BidderPortfolioPage.jsx
+++ b/src/Components/BidderPortfolio/BidderPortfolioPage/BidderPortfolioPage.jsx
@@ -27,10 +27,10 @@ class BidderPortfolioPage extends Component {
     // Here we just want to check that the 'all' prop exists,
     // because we want the nav section to appear
     // even when we reload the counts.
-    let navDataIsLoading = !bidderPortfolioCounts.all;
+    let navDataIsLoading = !bidderPortfolioCounts.all_clients;
     // If we can determine that the all prop is zero, then we'll change navDataIsLoading to false,
     // since zero normally evaluates as false.
-    if (bidderPortfolioCounts.all === 0) { navDataIsLoading = false; }
+    if (bidderPortfolioCounts.all_clients === 0) { navDataIsLoading = false; }
     // for bidder results, however, we'll wait until everything is loaded
     const isLoading = (bidderPortfolioIsLoading && !bidderPortfolioHasErrored) ||
       navDataIsLoading;
@@ -47,7 +47,7 @@ class BidderPortfolioPage extends Component {
               <BidControls
                 queryParamUpdate={queryParamUpdate}
                 biddersNumerator={bidderPortfolio.count || 0 /* pass zero if waiting on value */}
-                biddersDenominator={bidderPortfolioCounts.all}
+                biddersDenominator={bidderPortfolioCounts.all_clients}
                 isLoading={isLoading}
                 viewType={this.state.viewType.value}
                 changeViewType={this.changeViewType}

--- a/src/Components/BidderPortfolio/BidderPortfolioPage/__snapshots__/BidderPortfolioPage.test.jsx.snap
+++ b/src/Components/BidderPortfolio/BidderPortfolioPage/__snapshots__/BidderPortfolioPage.test.jsx.snap
@@ -14,10 +14,10 @@ exports[`BidderPortfolioPageComponent matches snapshot 1`] = `
       <TopNav
         bidderPortfolioCounts={
           Object {
-            "all": 100,
-            "bidding": 50,
-            "inpanel": 20,
-            "inpost": 30,
+            "all_clients": 100,
+            "bidding_clients": 50,
+            "in_panel_clients": 20,
+            "on_post_clients": 30,
           }
         }
       />

--- a/src/Components/BidderPortfolio/TopNav/Navigation/NavigationList/NavigationList.jsx
+++ b/src/Components/BidderPortfolio/TopNav/Navigation/NavigationList/NavigationList.jsx
@@ -6,27 +6,27 @@ const NavigationList = ({ counts }) => (
   <div className="usa-grid-full">
     <NavigationItem
       title="All Clients"
-      numerator={counts.all}
-      denominator={counts.all}
+      numerator={counts.all_clients}
+      denominator={counts.all_clients}
       link="?type=all"
     />
     <NavigationItem
       title="Clients Bidding"
-      numerator={counts.bidding}
-      denominator={counts.all}
+      numerator={counts.bidding_clients}
+      denominator={counts.all_clients}
       link="?type=bidding"
     />
     <NavigationItem
       title="Clients in Panel"
-      numerator={counts.inpanel}
-      denominator={counts.all}
+      numerator={counts.in_panel_clients}
+      denominator={counts.all_clients}
       link="?type=inpanel"
     />
     <NavigationItem
       title="Clients in Post"
-      numerator={counts.inpost}
-      denominator={counts.all}
-      link="?type=inpost"
+      numerator={counts.on_post_clients}
+      denominator={counts.all_clients}
+      link="?type=onpost"
     />
   </div>
 );

--- a/src/Components/BidderPortfolio/TopNav/Navigation/NavigationList/__snapshots__/NavigationList.test.jsx.snap
+++ b/src/Components/BidderPortfolio/TopNav/Navigation/NavigationList/__snapshots__/NavigationList.test.jsx.snap
@@ -24,7 +24,7 @@ exports[`NavigationListComponent matches snapshot 1`] = `
   />
   <withRouter()
     denominator={100}
-    link="?type=inpost"
+    link="?type=onpost"
     numerator={30}
     title="Clients in Post"
   />

--- a/src/Components/BidderPortfolio/TopNav/Navigation/__snapshots__/Navigation.test.jsx.snap
+++ b/src/Components/BidderPortfolio/TopNav/Navigation/__snapshots__/Navigation.test.jsx.snap
@@ -7,10 +7,10 @@ exports[`NavigationComponent matches snapshot 1`] = `
   <NavigationList
     counts={
       Object {
-        "all": 100,
-        "bidding": 50,
-        "inpanel": 20,
-        "inpost": 30,
+        "all_clients": 100,
+        "bidding_clients": 50,
+        "in_panel_clients": 20,
+        "on_post_clients": 30,
       }
     }
   />

--- a/src/Components/BidderPortfolio/TopNav/__snapshots__/TopNav.test.jsx.snap
+++ b/src/Components/BidderPortfolio/TopNav/__snapshots__/TopNav.test.jsx.snap
@@ -10,10 +10,10 @@ exports[`TopNavComponent matches snapshot 1`] = `
     <Navigation
       counts={
         Object {
-          "all": 100,
-          "bidding": 50,
-          "inpanel": 20,
-          "inpost": 30,
+          "all_clients": 100,
+          "bidding_clients": 50,
+          "in_panel_clients": 20,
+          "on_post_clients": 30,
         }
       }
     />

--- a/src/Constants/EndpointParams.js
+++ b/src/Constants/EndpointParams.js
@@ -17,9 +17,9 @@ export const ENDPOINT_PARAMS = {
 
 export const BIDDER_PORTFOLIO_PARAM_OBJECTS = {
   all: {},
-  bidding: { bidding: true },
-  inpanel: { inpanel: true },
-  inpost: { inpost: true },
+  bidding: { is_bidding: true },
+  inpanel: { is_in_panel: true },
+  onpost: { is_on_post: true },
 };
 
 export const VALID_PARAMS = [

--- a/src/Constants/PropTypes.js
+++ b/src/Constants/PropTypes.js
@@ -349,7 +349,7 @@ export const BIDDER_PORTFOLIO_COUNTS = PropTypes.shape({
   all: PropTypes.number,
   bidding: PropTypes.number,
   inpanel: PropTypes.number,
-  inpost: PropTypes.number,
+  onpost: PropTypes.number,
 });
 
 export const DESCRIPTION_EDIT_HAS_ERRORED = STRING_OR_BOOL;

--- a/src/Constants/Sort.js
+++ b/src/Constants/Sort.js
@@ -25,7 +25,7 @@ POSITION_PAGE_SIZES.defaultSort = POSITION_PAGE_SIZES.options[0].value;
 export const BID_PORTFOLIO_SORTS = {
   options: [
     { value: '', text: 'Default sorting' },
-    { value: 'age_param', text: 'Age' },
+    { value: 'date_of_birth', text: 'Age' },
   ],
 };
 

--- a/src/__mocks__/bidderPortfolioCountsObject.js
+++ b/src/__mocks__/bidderPortfolioCountsObject.js
@@ -1,8 +1,8 @@
 const bidderPortfolioCountsObject = {
-  all: 100,
-  bidding: 50,
-  inpanel: 20,
-  inpost: 30,
+  all_clients: 100,
+  bidding_clients: 50,
+  in_panel_clients: 20,
+  on_post_clients: 30,
 };
 
 export default bidderPortfolioCountsObject;

--- a/src/actions/bidderPortfolio.test.js
+++ b/src/actions/bidderPortfolio.test.js
@@ -1,6 +1,7 @@
 import setupAsyncMocks from './setupAsyncMocks';
 import * as actions from './bidderPortfolio';
 import bidderListObject from '../__mocks__/bidderListObject';
+import bidderPortfolioCountsObject from '../__mocks__/bidderPortfolioCountsObject';
 
 const { mockStore, mockAdapter } = setupAsyncMocks();
 
@@ -10,20 +11,8 @@ describe('bidderPortfolio async actions', () => {
       bidderListObject,
     );
 
-    mockAdapter.onGet('http://localhost:8000/api/v1/client/?limit=1&bidding=true').reply(200,
-      bidderListObject,
-    );
-
-    mockAdapter.onGet('http://localhost:8000/api/v1/client/?limit=1&inpanel=true').reply(200,
-      bidderListObject,
-    );
-
-    mockAdapter.onGet('http://localhost:8000/api/v1/client/?limit=1&inpost=true').reply(200,
-      bidderListObject,
-    );
-
-    mockAdapter.onGet('http://localhost:8000/api/v1/client/?limit=1&').reply(200,
-      bidderListObject,
+    mockAdapter.onGet('http://localhost:8000/api/v1/client/statistics/').reply(200,
+      bidderPortfolioCountsObject,
     );
 
     mockAdapter.onGet('http://localhost:8000/api/v1/client/?q=failure').reply(404,
@@ -57,8 +46,8 @@ describe('bidderPortfolio async actions', () => {
     f();
   });
 
-  it('can fetch the counts of different portfolio queries', (done) => {
-    const store = mockStore({ results: [] });
+  it('can fetch client statistics', (done) => {
+    const store = mockStore({});
 
     const f = () => {
       setTimeout(() => {
@@ -70,8 +59,8 @@ describe('bidderPortfolio async actions', () => {
     f();
   });
 
-  it('can handle failures when fetching the counts of different portfolio queries', (done) => {
-    const store = mockStore({ results: [] });
+  it('can handle failures when fetching client statistics', (done) => {
+    const store = mockStore({});
 
     // reset() so that http requests fail.
     mockAdapter.reset();


### PR DESCRIPTION
Uses updated queries found in https://github.com/18F/State-TalentMAP-API/pull/240 including:
* Using `/client/statistics/` instead of making individual queries
* Using `is_bidding`, `is_in_panel` and `is_on_post` filters
* Using `q` for free text search
* Using `date_of_birth` as a sort option

This wraps up end to end functionality for the Bidder Portfolio.

Relies on #1029, #1022 and #1029.