### PR TITLE
Incumbent and tour end date values from API

### DIFF
--- a/src/Components/PositionDetailsItem/PositionDetailsItem.jsx
+++ b/src/Components/PositionDetailsItem/PositionDetailsItem.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { NO_ORG, NO_POST, NO_BUREAU, NO_POST_DIFFERENTIAL, NO_DANGER_PAY } from '../../Constants/SystemMessages';
+import { NO_ORG, NO_POST, NO_BUREAU, NO_POST_DIFFERENTIAL,
+  NO_DANGER_PAY, NO_END_DATE, NO_USER_LISTED } from '../../Constants/SystemMessages';
 import { POSITION_DETAILS } from '../../Constants/PropTypes';
 import LanguageList from '../../Components/LanguageList/LanguageList';
 import PositionDetailsDataPoint from '../../Components/PositionDetailsDataPoint/PositionDetailsDataPoint';
@@ -71,11 +72,19 @@ const PositionDetailsItem = ({ details }) => (
             />
             <PositionDetailsDataPoint
               title="Tour End Date"
-              description={<StaticDevContent><span>09-19-2019</span></StaticDevContent>}
+              description={details.current_assignment &&
+                details.current_assignment.estimated_end_date ?
+                  details.current_assignment.estimated_end_date :
+                  NO_END_DATE
+              }
             />
             <PositionDetailsDataPoint
               title="Incumbent"
-              description={<StaticDevContent><span>Incumbent</span></StaticDevContent>}
+              description={details.current_assignment &&
+                details.current_assignment.user ?
+                  details.current_assignment.user :
+                  NO_USER_LISTED
+              }
             />
           </div>
         </div>

--- a/src/Components/PositionDetailsItem/__snapshots__/PositionDetailsItem.test.jsx.snap
+++ b/src/Components/PositionDetailsItem/__snapshots__/PositionDetailsItem.test.jsx.snap
@@ -107,23 +107,11 @@ exports[`PositionDetailsItem matches snapshot 1`] = `
             title="Danger Pay"
           />
           <PositionDetailsDataPoint
-            description={
-              <Connect(StaticDevContent)>
-                <span>
-                  09-19-2019
-                </span>
-              </Connect(StaticDevContent)>
-            }
+            description="None listed"
             title="Tour End Date"
           />
           <PositionDetailsDataPoint
-            description={
-              <Connect(StaticDevContent)>
-                <span>
-                  Incumbent
-                </span>
-              </Connect(StaticDevContent)>
-            }
+            description="None listed"
             title="Incumbent"
           />
         </div>

--- a/src/Constants/SystemMessages.js
+++ b/src/Constants/SystemMessages.js
@@ -31,3 +31,5 @@ export const NO_ASSIGNMENT_DATE = DEFAULT_TEXT;
 export const NO_EMAIL = DEFAULT_TEXT;
 export const NO_USER_SKILL_CODE = 'No skill listed';
 export const NO_BIRTHDAY = DEFAULT_TEXT;
+export const NO_END_DATE = DEFAULT_TEXT;
+export const NO_USER_LISTED = DEFAULT_TEXT;


### PR DESCRIPTION
Closes #1040 by using real values from the API response for Incumbent and Tour End Date on the Position Details page, instead of using hard-coded placeholder text.