### PR TITLE
Limit CMSGov import to Spinner only

### DIFF
--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -8,7 +8,7 @@
 @import '../../node_modules/typeface-roboto/index.css';
 
 // CMSGov Design System Layout
-@import '../../node_modules/@cmsgov/design-system-core/dist/index.css';
+@import '../../node_modules/@cmsgov/design-system-core/dist/components/Spinner/Spinner.css';
 
 // USWDS
 @import '../../node_modules/uswds/dist/css/uswds.css';

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -7,7 +7,7 @@
 // Roboto
 @import '../../node_modules/typeface-roboto/index.css';
 
-// CMSGov Design System Layout
+// Spinner from the CMSGov Design System Layout
 @import '../../node_modules/@cmsgov/design-system-core/dist/components/Spinner/Spinner.css';
 
 // USWDS


### PR DESCRIPTION
Only import the needed components from CMSGov (just the Spinner in our case) in order to avoid the USWDS version used by CMSGov (1.4.x) clashing with the one that we import (1.3.x).