### PR TITLE
Update react-simple-dropdown version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "react-router-dom": "^4.1.1",
     "react-router-redux": "^5.0.0-alpha.6",
     "react-scroll": "^1.5.4",
-    "react-simple-dropdown": "^3.0.0",
+    "react-simple-dropdown": "^3.2.0",
     "react-tippy": "^1.2.2",
     "redux": "^3.7.1",
     "redux-form": "^7.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6151,9 +6151,9 @@ react-scroll@^1.5.4:
     object-assign "^4.1.1"
     prop-types "^15.5.8"
 
-react-simple-dropdown@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/react-simple-dropdown/-/react-simple-dropdown-3.0.0.tgz#5a2cac441748a090a3b7009b4807ea206002b7c3"
+react-simple-dropdown@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-simple-dropdown/-/react-simple-dropdown-3.2.0.tgz#9867916aa677b9820e07e140252eeee829d01372"
   dependencies:
     classnames "^2.1.2"
     prop-types "^15.5.8"


### PR DESCRIPTION
Somewhere along the way, changing this version didn't stick and the `removeElement` prop wasn't causing the account dropdown to be destroyed and recreated on click. This upgrades the version in `package.json` and updates `yarn.lock`.