### PR TITLE
Addresses feedback in PR #1124

### DIFF
--- a/src/Components/Header/NavLink/NavLink.jsx
+++ b/src/Components/Header/NavLink/NavLink.jsx
@@ -5,10 +5,10 @@ import { Link } from 'react-router-dom';
 import { ROUTER_LOCATION_OBJECT } from '../../../Constants/PropTypes';
 import { isCurrentPath } from '../../ProfileMenu/navigation';
 
-export const NavLink = ({ title, link, location, forceClass, navLinkClass }) => {
-  const isBold = isCurrentPath(location.pathname, link);
+export const NavLink = ({ title, link, location, navLinkClass }) => {
+  const isActive = isCurrentPath(location.pathname, link);
   return (
-    <div className={`header-nav-link-container ${forceClass.length ? forceClass : ''} ${isBold && !forceClass.length ? 'is-bolded' : 'is-not-bolded'}`}>
+    <div className={`header-nav-link-container ${isActive ? 'is-active' : 'is-not-active'}`}>
       <div className="header-nav-link">
         <div className={`header-nav-link-text ${navLinkClass}`}>
           <Link to={link}>
@@ -24,12 +24,10 @@ NavLink.propTypes = {
   title: PropTypes.string.isRequired,
   link: PropTypes.string.isRequired,
   location: ROUTER_LOCATION_OBJECT.isRequired,
-  forceClass: PropTypes.oneOf(['', 'is-bolded', 'is-not-bolded']),
   navLinkClass: PropTypes.string,
 };
 
 NavLink.defaultProps = {
-  forceClass: '',
   navLinkClass: '',
 };
 

--- a/src/Components/Header/NavLink/NavLink.test.jsx
+++ b/src/Components/Header/NavLink/NavLink.test.jsx
@@ -15,7 +15,7 @@ describe('NavLink', () => {
     expect(wrapper).toBeDefined();
   });
 
-  it('is bold when the link matches location pathname', () => {
+  it('is active when the link matches location pathname', () => {
     const wrapper = shallow(
       <NavLink
         title="test"
@@ -23,8 +23,8 @@ describe('NavLink', () => {
         location={{ pathname: '/' }}
       />,
     );
-    expect(wrapper.find('.is-bolded').exists()).toBe(true);
-    expect(wrapper.find('.is-not-bolded').exists()).toBe(false);
+    expect(wrapper.find('.is-active').exists()).toBe(true);
+    expect(wrapper.find('.is-not-active').exists()).toBe(false);
   });
 
   it('matches snapshot when the link matches location pathname', () => {
@@ -38,7 +38,7 @@ describe('NavLink', () => {
     expect(toJSON(wrapper)).toMatchSnapshot();
   });
 
-  it('is not bold when the link matches location pathname', () => {
+  it('is not active when the link matches location pathname', () => {
     const wrapper = shallow(
       <NavLink
         title="test"
@@ -46,11 +46,11 @@ describe('NavLink', () => {
         location={{ pathname: '/profile' }}
       />,
     );
-    expect(wrapper.find('.is-bolded').exists()).toBe(false);
-    expect(wrapper.find('.is-not-bolded').exists()).toBe(true);
+    expect(wrapper.find('.is-active').exists()).toBe(false);
+    expect(wrapper.find('.is-not-active').exists()).toBe(true);
   });
 
-  it('matches snapshot when the link does not matche location pathname', () => {
+  it('matches snapshot when the link does not match location pathname', () => {
     const wrapper = shallow(
       <NavLink
         title="test"

--- a/src/Components/Header/NavLink/__snapshots__/NavLink.test.jsx.snap
+++ b/src/Components/Header/NavLink/__snapshots__/NavLink.test.jsx.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`NavLink matches snapshot when the link does not matche location pathname 1`] = `
+exports[`NavLink matches snapshot when the link does not match location pathname 1`] = `
 <div
-  className="header-nav-link-container  is-not-bolded"
+  className="header-nav-link-container is-not-active"
 >
   <div
     className="header-nav-link"
@@ -23,7 +23,7 @@ exports[`NavLink matches snapshot when the link does not matche location pathnam
 
 exports[`NavLink matches snapshot when the link matches location pathname 1`] = `
 <div
-  className="header-nav-link-container  is-bolded"
+  className="header-nav-link-container is-active"
 >
   <div
     className="header-nav-link"

--- a/src/Components/Header/searchRoutes.js
+++ b/src/Components/Header/searchRoutes.js
@@ -1,8 +1,8 @@
 // routes to display the search bar by default
 export const searchBarRoutes = ['/', '/results'];
 
-// routes to always display the search bar
+// routes that contain their own search bar
 export const searchBarRoutesForce = ['/results'];
 
-// routes to always hide the search bar by default
-export const searchBarRoutesHidden = ['/details', '/post', '/compare', '/profile'];
+// routes to always force hide the search bar
+export const searchBarRoutesForceHidden = ['/login'];

--- a/src/Components/Header/searchRoutes.test.js
+++ b/src/Components/Header/searchRoutes.test.js
@@ -10,6 +10,6 @@ describe('searchRoutes', () => {
   });
 
   it('Should return searchBarRoutesHidden', () => {
-    expect(searchRoutes.searchBarRoutesHidden).toBeDefined();
+    expect(searchRoutes.searchBarRoutesForceHidden).toBeDefined();
   });
 });

--- a/src/Components/Header/searchRoutes.test.js
+++ b/src/Components/Header/searchRoutes.test.js
@@ -8,8 +8,4 @@ describe('searchRoutes', () => {
   it('Should return searchBarRoutesForce', () => {
     expect(searchRoutes.searchBarRoutesForce).toBeDefined();
   });
-
-  it('Should return searchBarRoutesHidden', () => {
-    expect(searchRoutes.searchBarRoutesHidden).toBeDefined();
-  });
 });

--- a/src/Components/Header/searchRoutes.test.js
+++ b/src/Components/Header/searchRoutes.test.js
@@ -8,4 +8,8 @@ describe('searchRoutes', () => {
   it('Should return searchBarRoutesForce', () => {
     expect(searchRoutes.searchBarRoutesForce).toBeDefined();
   });
+
+  it('Should return searchBarRoutesHidden', () => {
+    expect(searchRoutes.searchBarRoutesHidden).toBeDefined();
+  });
 });

--- a/src/Components/SkillCodeList/SkillCodeList.jsx
+++ b/src/Components/SkillCodeList/SkillCodeList.jsx
@@ -3,10 +3,8 @@ import { NO_USER_SKILL_CODE } from '../../Constants/SystemMessages';
 import { USER_SKILL_CODE_ARRAY } from '../../Constants/PropTypes';
 
 const SkillCodeList = ({ skillCodes }) => {
-  const skillCodeList = (skillCodes && skillCodes.length)
-    ? skillCodes.map((choice, i) => (
-      `${i > 0 ? ', ' : ''} ${choice}`
-    )) : NO_USER_SKILL_CODE;
+  const skillCodeList = (skillCodes && skillCodes.length) ?
+    skillCodes.join(', ') : NO_USER_SKILL_CODE;
   return (
     <span>
       {skillCodeList}

--- a/src/Components/SkillCodeList/SkillCodeList.test.jsx
+++ b/src/Components/SkillCodeList/SkillCodeList.test.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import toJSON from 'enzyme-to-json';
 import SkillCodeList from './SkillCodeList';
+import { NO_USER_SKILL_CODE } from '../../Constants/SystemMessages';
 
 describe('SkillCodeList', () => {
   const skillCodes = ['skill 1', 'skill 2'];
@@ -27,6 +28,21 @@ describe('SkillCodeList', () => {
   });
 
   it('matches snapshot with an array of one item', () => {
+    const wrapper = shallow(<SkillCodeList skillCodes={[skillCodes[0]]} />);
+    expect(wrapper.text()).toBe(skillCodes[0]);
+  });
+
+  it('renders content correctly with an array of three items', () => {
+    const wrapper = shallow(<SkillCodeList skillCodes={[...skillCodes, 'skill 3']} />);
+    expect(wrapper.text()).toBe(`${skillCodes[0]}, ${skillCodes[1]}, skill 3`);
+  });
+
+  it('renders content correctly with an empty array', () => {
+    const wrapper = shallow(<SkillCodeList skillCodes={[]} />);
+    expect(wrapper.text()).toBe(NO_USER_SKILL_CODE);
+  });
+
+  it('renders content correctly with an array of one item', () => {
     const wrapper = shallow(<SkillCodeList skillCodes={[skillCodes[0]]} />);
     expect(toJSON(wrapper)).toMatchSnapshot();
   });

--- a/src/Components/SkillCodeList/__snapshots__/SkillCodeList.test.jsx.snap
+++ b/src/Components/SkillCodeList/__snapshots__/SkillCodeList.test.jsx.snap
@@ -1,16 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SkillCodeList matches snapshot with an array of one item 1`] = `
-<span>
-   skill 1
-</span>
-`;
-
 exports[`SkillCodeList matches snapshot with an array of three items 1`] = `
 <span>
-   skill 1
-  ,  skill 2
-  ,  skill 3
+  skill 1, skill 2, skill 3
 </span>
 `;
 
@@ -20,9 +12,14 @@ exports[`SkillCodeList matches snapshot with an empty array 1`] = `
 </span>
 `;
 
+exports[`SkillCodeList renders content correctly with an array of one item 1`] = `
+<span>
+  skill 1
+</span>
+`;
+
 exports[`SkillCodeList takes props 1`] = `
 <span>
-   skill 1
-  ,  skill 2
+  skill 1, skill 2
 </span>
 `;

--- a/src/Containers/Home/Home.jsx
+++ b/src/Containers/Home/Home.jsx
@@ -119,7 +119,7 @@ const mapDispatchToProps = dispatch => ({
   toggleFavorite: (id, remove) => dispatch(userProfileToggleFavoritePosition(id, remove)),
   toggleBid: (id, remove) => dispatch(toggleBidPosition(id, remove)),
   bidListFetchData: () => dispatch(bidListFetchData()),
-  toggleSearchBarVisibility: bool => dispatch(toggleSearchBar(bool)),
+  toggleSearchBarVisibility: showHide => dispatch(toggleSearchBar(showHide)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Home);

--- a/src/sass/_header.scss
+++ b/src/sass/_header.scss
@@ -85,7 +85,7 @@
     color: $color-white;
   }
 
-  .is-bolded {
+  .is-active {
     a {
       color: $color-blue-active;
       font-weight: bold;


### PR DESCRIPTION
Addresses the following from #1124:

- Clarifies what the `isOnForceSearchRoute` function does, and uses an abstracted array of routes instead of a single hard-coded route.
- `.is-bolded` -> `.is-active` and remove the `forceClass` prop
- Fixed a bug where the history listener wasn't called if the user enters the site not logged in, causing the search bar to not display upon login. Also forces the search bar to be hidden on the login page.
- `.map() -> .join()` for skill codes
- Skill code `text()` checks
- `bool` -> `showHide`