### PR TITLE
Glossary

### DIFF
--- a/src/Components/Accordion/AccordionItem/AccordionItem.jsx
+++ b/src/Components/Accordion/AccordionItem/AccordionItem.jsx
@@ -2,21 +2,24 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { EMPTY_FUNCTION } from '../../../Constants/PropTypes';
 
-const AccordionItem = ({ id, title, expanded, setAccordion, children, className }) => (
-  <li className={className}>
-    <button
-      className="usa-accordion-button"
-      aria-expanded={expanded}
-      aria-controls={id}
-      onClick={() => setAccordion(expanded || !title ? '' : title)}
-    >
-      {title}
-    </button>
-    <div id={id} className={`usa-accordion-content accordion-${(id || 'accordion').toLowerCase()}`} aria-hidden={!expanded}>
-      {children}
-    </div>
-  </li>
-);
+const AccordionItem = ({ id, title, expanded, setAccordion, children, className, useIdClass }) => {
+  const idClass = useIdClass ? `accordion-${(id || 'accordion').toLowerCase()}` : '';
+  return (
+    <li className={className}>
+      <button
+        className="usa-accordion-button"
+        aria-expanded={expanded}
+        aria-controls={id}
+        onClick={() => setAccordion(expanded || !title ? '' : title)}
+      >
+        <div className="accordion-item-title">{title}</div>
+      </button>
+      <div id={id} className={`usa-accordion-content ${idClass}`} aria-hidden={!expanded}>
+        {children}
+      </div>
+    </li>
+  );
+};
 
 AccordionItem.propTypes = {
   id: PropTypes.string.isRequired,
@@ -25,6 +28,7 @@ AccordionItem.propTypes = {
   setAccordion: PropTypes.func,
   children: PropTypes.node,
   className: PropTypes.string,
+  useIdClass: PropTypes.bool,
 };
 
 AccordionItem.defaultProps = {
@@ -33,6 +37,7 @@ AccordionItem.defaultProps = {
   expanded: false,
   children: null,
   className: '',
+  useIdClass: true,
 };
 
 export default AccordionItem;

--- a/src/Components/Accordion/AccordionItem/__snapshots__/AccordionItem.test.jsx.snap
+++ b/src/Components/Accordion/AccordionItem/__snapshots__/AccordionItem.test.jsx.snap
@@ -9,7 +9,11 @@ exports[`AccordionItemComponent matches snapshot 1`] = `
     aria-expanded={true}
     className="usa-accordion-button"
     onClick={[Function]}
-  />
+  >
+    <div
+      className="accordion-item-title"
+    />
+  </button>
   <div
     aria-hidden={false}
     className="usa-accordion-content accordion-accordion"

--- a/src/Components/Form/Form.jsx
+++ b/src/Components/Form/Form.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { EMPTY_FUNCTION } from '../../Constants/PropTypes';
 
 const Form = ({ children, className, onFormSubmit }) => (
   <form className={className} onSubmit={onFormSubmit}>
@@ -10,11 +11,12 @@ const Form = ({ children, className, onFormSubmit }) => (
 Form.propTypes = {
   children: PropTypes.node.isRequired, // should be valid form children
   className: PropTypes.string,
-  onFormSubmit: PropTypes.func.isRequired,
+  onFormSubmit: PropTypes.func,
 };
 
 Form.defaultProps = {
   className: '',
+  onFormSubmit: EMPTY_FUNCTION,
 };
 
 export default Form;

--- a/src/Components/Glossary/Glossary.jsx
+++ b/src/Components/Glossary/Glossary.jsx
@@ -1,0 +1,89 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import FontAwesome from 'react-fontawesome';
+import GlossarySearch from './GlossarySearch';
+import GlossaryListing from './GlossaryListing';
+import Spinner from '../Spinner';
+import { GLOSSARY_ARRAY } from '../../Constants/PropTypes';
+import { filterByProps } from '../../utilities';
+
+class GlossaryComponent extends Component {
+  constructor(props) {
+    super(props);
+    this.changeText = this.changeText.bind(this);
+    this.state = {
+      searchText: { value: '' },
+    };
+  }
+
+  changeText(text) {
+    const { searchText } = this.state;
+    searchText.value = text;
+    this.setState({ searchText });
+  }
+
+  filteredGlossary() {
+    const { searchText } = this.state;
+    const { glossaryItems } = this.props;
+    // filter where the keyword matches part of the title or definition
+    return filterByProps(searchText.value, ['title', 'definition'], glossaryItems);
+  }
+
+  render() {
+    const { visible, toggleVisibility, glossaryIsLoading } = this.props;
+    const { searchText } = this.state;
+    const filteredGlossary = this.filteredGlossary();
+    return (
+      <div className="tm-glossary">
+        <div
+          id="glossary"
+          className={`glossary ${visible ? 'glossary-visible' : 'glossary-hidden'}`}
+          aria-describedby="glossary-title"
+          aria-hidden={!visible}
+        >
+          <button
+            title="Close glossary"
+            className="js-glossary-close"
+            onClick={toggleVisibility}
+          >
+            <FontAwesome name="times" />
+            <span className="usa-sr-only">Close Glossary</span>
+          </button>
+          <div style={{ position: 'relative' }}>
+            <h2 id="glossary-title">Glossary</h2>
+            {
+              glossaryIsLoading &&
+                <Spinner type="glossary" size="big" />
+            }
+            {
+              !glossaryIsLoading &&
+              <div>
+                <GlossarySearch
+                  changeText={this.changeText}
+                  searchTextValue={searchText.value}
+                />
+                <div className="glossary-content">
+                  <GlossaryListing glossaryItems={filteredGlossary} />
+                </div>
+              </div>
+            }
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+GlossaryComponent.propTypes = {
+  visible: PropTypes.bool,
+  toggleVisibility: PropTypes.func.isRequired,
+  glossaryItems: GLOSSARY_ARRAY.isRequired,
+  glossaryIsLoading: PropTypes.bool,
+};
+
+GlossaryComponent.defaultProps = {
+  visible: false,
+  glossaryIsLoading: false,
+};
+
+export default GlossaryComponent;

--- a/src/Components/Glossary/Glossary.jsx
+++ b/src/Components/Glossary/Glossary.jsx
@@ -43,7 +43,7 @@ class GlossaryComponent extends Component {
         >
           <button
             title="Close glossary"
-            className="js-glossary-close"
+            className="glossary-close"
             onClick={toggleVisibility}
           >
             <FontAwesome name="times" />

--- a/src/Components/Glossary/Glossary.test.jsx
+++ b/src/Components/Glossary/Glossary.test.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+import toJSON from 'enzyme-to-json';
+import Glossary from './Glossary';
+import glossaryItems from '../../__mocks__/glossaryItems';
+
+describe('GlossaryComponent', () => {
+  const props = {
+    visible: true,
+    toggleVisibility: () => {},
+    glossaryItems,
+  };
+
+  it('is defined', () => {
+    const wrapper = shallow(
+      <Glossary
+        {...props}
+      />,
+    );
+    expect(wrapper).toBeDefined();
+  });
+
+  it('can enter a keyword', () => {
+    const wrapper = shallow(
+      <Glossary
+        {...props}
+      />,
+    );
+    wrapper.instance().changeText('test');
+    // wrapper.find('input').simulate('change', { target: { value: 'test' } });
+    expect(wrapper.instance().state.searchText.value).toBe('test');
+  });
+
+  it('can close the glossary', () => {
+    const spy = sinon.spy();
+    const wrapper = shallow(
+      <Glossary
+        {...props}
+        toggleVisibility={spy}
+      />,
+    );
+    wrapper.find('button').simulate('click');
+    sinon.assert.calledOnce(spy);
+  });
+
+  it('matches snapshot', () => {
+    const wrapper = shallow(
+      <Glossary
+        {...props}
+      />,
+    );
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+
+  it('matches snapshot when visible is false', () => {
+    const wrapper = shallow(
+      <Glossary
+        {...props}
+        visible={false}
+      />,
+    );
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/Components/Glossary/Glossary.test.jsx
+++ b/src/Components/Glossary/Glossary.test.jsx
@@ -28,7 +28,6 @@ describe('GlossaryComponent', () => {
       />,
     );
     wrapper.instance().changeText('test');
-    // wrapper.find('input').simulate('change', { target: { value: 'test' } });
     expect(wrapper.instance().state.searchText.value).toBe('test');
   });
 

--- a/src/Components/Glossary/GlossaryListing/GlossaryListing.jsx
+++ b/src/Components/Glossary/GlossaryListing/GlossaryListing.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Accordion from '../../Accordion/Accordion';
+import AccordionItem from '../../Accordion/AccordionItem/AccordionItem';
+import { GLOSSARY_ARRAY } from '../../../Constants/PropTypes';
+
+const GlossaryComponent = ({ glossaryItems }) => (
+  <Accordion>
+    {
+      glossaryItems.map(item =>
+        (<AccordionItem key={item.id} title={item.title} id={item.title} useIdClass={false}>
+          {item.definition}
+        </AccordionItem>),
+     )
+    }
+  </Accordion>
+);
+
+GlossaryComponent.propTypes = {
+  glossaryItems: GLOSSARY_ARRAY.isRequired,
+};
+
+export default GlossaryComponent;

--- a/src/Components/Glossary/GlossaryListing/GlossaryListing.test.jsx
+++ b/src/Components/Glossary/GlossaryListing/GlossaryListing.test.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import toJSON from 'enzyme-to-json';
+import GlossaryListing from './GlossaryListing';
+import glossaryItems from '../../../__mocks__/glossaryItems';
+
+describe('GlossaryListingComponent', () => {
+  const props = {
+    glossaryItems,
+  };
+
+  it('is defined', () => {
+    const wrapper = shallow(
+      <GlossaryListing
+        {...props}
+      />,
+    );
+    expect(wrapper).toBeDefined();
+  });
+
+  it('matches snapshot', () => {
+    const wrapper = shallow(
+      <GlossaryListing
+        {...props}
+      />,
+    );
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/Components/Glossary/GlossaryListing/__snapshots__/GlossaryListing.test.jsx.snap
+++ b/src/Components/Glossary/GlossaryListing/__snapshots__/GlossaryListing.test.jsx.snap
@@ -1,0 +1,86 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GlossaryListingComponent matches snapshot 1`] = `
+<Accordion>
+  <AccordionItem
+    className=""
+    expanded={false}
+    id="Assignment Officer (AO)"
+    setAccordion={[Function]}
+    title="Assignment Officer (AO)"
+    useIdClass={false}
+  >
+    The employee responsible for filling the position.
+  </AccordionItem>
+  <AccordionItem
+    className=""
+    expanded={false}
+    id="Bidder"
+    setAccordion={[Function]}
+    title="Bidder"
+    useIdClass={false}
+  >
+    An employee who is applying for a position.
+  </AccordionItem>
+  <AccordionItem
+    className=""
+    expanded={false}
+    id="Cable"
+    setAccordion={[Function]}
+    title="Cable"
+    useIdClass={false}
+  >
+    A secure text-based message sent from one State department location to another.
+  </AccordionItem>
+  <AccordionItem
+    className=""
+    expanded={false}
+    id="Bureau"
+    setAccordion={[Function]}
+    title="Bureau"
+    useIdClass={false}
+  >
+    The organization sponsoring a position. Most bureaus oversee regional areas, such as Western Europe. Others, such as the Bureau of Consular Affairs, oversee functional groups. If referring to a regional bureau, include the acronym -- State Department employees often use acronyms to refer to regional bureaus. In UI copy, put the acronym before the full name, eg: (WHA) Bureau of Western Hemispheric Affairs.
+  </AccordionItem>
+  <AccordionItem
+    className=""
+    expanded={false}
+    id="Career development officer (CDO)"
+    setAccordion={[Function]}
+    title="Career development officer (CDO)"
+    useIdClass={false}
+  >
+    An employee responsible for helping others find and successfully bid for appropriate positions for their career goals.
+  </AccordionItem>
+  <AccordionItem
+    className=""
+    expanded={false}
+    id="Career Track"
+    setAccordion={[Function]}
+    title="Career Track"
+    useIdClass={false}
+  >
+    A chosen professional competency.
+  </AccordionItem>
+  <AccordionItem
+    className=""
+    expanded={false}
+    id="Cone"
+    setAccordion={[Function]}
+    title="Cone"
+    useIdClass={false}
+  >
+    A cone is a colloquial synonym for a generalist or specialist functional field. Bids can be "in cone" (for a position whose skill code belongs to the bidders' specialization) or "out of cone." Each cone contains multiple skill codes.
+  </AccordionItem>
+  <AccordionItem
+    className=""
+    expanded={false}
+    id="Cost of living allowance (COLA)"
+    setAccordion={[Function]}
+    title="Cost of living allowance (COLA)"
+    useIdClass={false}
+  >
+    A salary increase to reimburse employees for prices at a foreign post that are higher than same costs in Washington, DC. The specific value of the allowance changes based on local prices. COLA is a colloquial shorthand for what is officially known as post allowance.
+  </AccordionItem>
+</Accordion>
+`;

--- a/src/Components/Glossary/GlossaryListing/index.js
+++ b/src/Components/Glossary/GlossaryListing/index.js
@@ -1,0 +1,1 @@
+export { default } from './GlossaryListing';

--- a/src/Components/Glossary/GlossarySearch/GlossarySearch.jsx
+++ b/src/Components/Glossary/GlossarySearch/GlossarySearch.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Form from '../../Form';
+import FieldSet from '../../FieldSet/FieldSet';
+import TextInput from '../../TextInput';
+
+const GlossarySearch = ({ changeText, searchTextValue }) => (
+  <Form className="usa-grid-full glossary-form">
+    <FieldSet
+      className="glossary-fieldset"
+      legend="Enter a keyword to search"
+      legendSrOnly
+    >
+      <TextInput
+        id="glossary-search"
+        label="Enter a keyword to search"
+        changeText={changeText}
+        value={searchTextValue}
+        labelSrOnly
+        placeholder="Search for terms"
+      />
+    </FieldSet>
+  </Form>
+);
+
+GlossarySearch.propTypes = {
+  changeText: PropTypes.func.isRequired,
+  searchTextValue: PropTypes.string,
+};
+
+GlossarySearch.defaultProps = {
+  searchTextValue: '',
+};
+
+export default GlossarySearch;

--- a/src/Components/Glossary/GlossarySearch/GlossarySearch.jsx
+++ b/src/Components/Glossary/GlossarySearch/GlossarySearch.jsx
@@ -1,26 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Form from '../../Form';
 import FieldSet from '../../FieldSet/FieldSet';
 import TextInput from '../../TextInput';
 
 const GlossarySearch = ({ changeText, searchTextValue }) => (
-  <Form className="usa-grid-full glossary-form">
-    <FieldSet
-      className="glossary-fieldset"
-      legend="Enter a keyword to search"
-      legendSrOnly
-    >
-      <TextInput
-        id="glossary-search"
-        label="Enter a keyword to search"
-        changeText={changeText}
-        value={searchTextValue}
-        labelSrOnly
-        placeholder="Search for terms"
-      />
-    </FieldSet>
-  </Form>
+  <FieldSet
+    className="glossary-fieldset"
+    legend="Enter a keyword to search"
+    legendSrOnly
+  >
+    <TextInput
+      id="glossary-search"
+      label="Enter a keyword to search"
+      changeText={changeText}
+      value={searchTextValue}
+      labelSrOnly
+      placeholder="Search for terms"
+    />
+  </FieldSet>
 );
 
 GlossarySearch.propTypes = {

--- a/src/Components/Glossary/GlossarySearch/GlossarySearch.test.jsx
+++ b/src/Components/Glossary/GlossarySearch/GlossarySearch.test.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import toJSON from 'enzyme-to-json';
+import GlossarySearch from './GlossarySearch';
+
+describe('GlossaryComponent', () => {
+  const props = {
+    changeText: () => {},
+    searchTextValue: 'test',
+  };
+
+  it('is defined', () => {
+    const wrapper = shallow(
+      <GlossarySearch
+        {...props}
+      />,
+    );
+    expect(wrapper).toBeDefined();
+  });
+
+  it('matches snapshot', () => {
+    const wrapper = shallow(
+      <GlossarySearch
+        {...props}
+      />,
+    );
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/Components/Glossary/GlossarySearch/__snapshots__/GlossarySearch.test.jsx.snap
+++ b/src/Components/Glossary/GlossarySearch/__snapshots__/GlossarySearch.test.jsx.snap
@@ -1,24 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`GlossaryComponent matches snapshot 1`] = `
-<Form
-  className="usa-grid-full glossary-form"
-  onFormSubmit={[Function]}
+<FieldSet
+  className="glossary-fieldset"
+  legend="Enter a keyword to search"
+  legendSrOnly={true}
 >
-  <FieldSet
-    className="glossary-fieldset"
-    legend="Enter a keyword to search"
-    legendSrOnly={true}
-  >
-    <TextInput
-      changeText={[Function]}
-      id="glossary-search"
-      label="Enter a keyword to search"
-      labelMessage=""
-      labelSrOnly={true}
-      placeholder="Search for terms"
-      value="test"
-    />
-  </FieldSet>
-</Form>
+  <TextInput
+    changeText={[Function]}
+    id="glossary-search"
+    label="Enter a keyword to search"
+    labelMessage=""
+    labelSrOnly={true}
+    placeholder="Search for terms"
+    value="test"
+  />
+</FieldSet>
 `;

--- a/src/Components/Glossary/GlossarySearch/__snapshots__/GlossarySearch.test.jsx.snap
+++ b/src/Components/Glossary/GlossarySearch/__snapshots__/GlossarySearch.test.jsx.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GlossaryComponent matches snapshot 1`] = `
+<Form
+  className="usa-grid-full glossary-form"
+  onFormSubmit={[Function]}
+>
+  <FieldSet
+    className="glossary-fieldset"
+    legend="Enter a keyword to search"
+    legendSrOnly={true}
+  >
+    <TextInput
+      changeText={[Function]}
+      id="glossary-search"
+      label="Enter a keyword to search"
+      labelMessage=""
+      labelSrOnly={true}
+      placeholder="Search for terms"
+      value="test"
+    />
+  </FieldSet>
+</Form>
+`;

--- a/src/Components/Glossary/GlossarySearch/index.js
+++ b/src/Components/Glossary/GlossarySearch/index.js
@@ -1,0 +1,1 @@
+export { default } from './GlossarySearch';

--- a/src/Components/Glossary/__snapshots__/Glossary.test.jsx.snap
+++ b/src/Components/Glossary/__snapshots__/Glossary.test.jsx.snap
@@ -11,7 +11,7 @@ exports[`GlossaryComponent matches snapshot 1`] = `
     id="glossary"
   >
     <button
-      className="js-glossary-close"
+      className="glossary-close"
       onClick={[Function]}
       title="Close glossary"
     >
@@ -108,7 +108,7 @@ exports[`GlossaryComponent matches snapshot when visible is false 1`] = `
     id="glossary"
   >
     <button
-      className="js-glossary-close"
+      className="glossary-close"
       onClick={[Function]}
       title="Close glossary"
     >

--- a/src/Components/Glossary/__snapshots__/Glossary.test.jsx.snap
+++ b/src/Components/Glossary/__snapshots__/Glossary.test.jsx.snap
@@ -1,0 +1,195 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GlossaryComponent matches snapshot 1`] = `
+<div
+  className="tm-glossary"
+>
+  <div
+    aria-describedby="glossary-title"
+    aria-hidden={false}
+    className="glossary glossary-visible"
+    id="glossary"
+  >
+    <button
+      className="js-glossary-close"
+      onClick={[Function]}
+      title="Close glossary"
+    >
+      <FontAwesome
+        name="times"
+      />
+      <span
+        className="usa-sr-only"
+      >
+        Close Glossary
+      </span>
+    </button>
+    <div
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
+    >
+      <h2
+        id="glossary-title"
+      >
+        Glossary
+      </h2>
+      <div>
+        <GlossarySearch
+          changeText={[Function]}
+          searchTextValue=""
+        />
+        <div
+          className="glossary-content"
+        >
+          <GlossaryComponent
+            glossaryItems={
+              Array [
+                Object {
+                  "definition": "The employee responsible for filling the position.",
+                  "id": 2,
+                  "title": "Assignment Officer (AO)",
+                },
+                Object {
+                  "definition": "An employee who is applying for a position.",
+                  "id": 3,
+                  "title": "Bidder",
+                },
+                Object {
+                  "definition": "A secure text-based message sent from one State department location to another.",
+                  "id": 4,
+                  "title": "Cable",
+                },
+                Object {
+                  "definition": "The organization sponsoring a position. Most bureaus oversee regional areas, such as Western Europe. Others, such as the Bureau of Consular Affairs, oversee functional groups. If referring to a regional bureau, include the acronym -- State Department employees often use acronyms to refer to regional bureaus. In UI copy, put the acronym before the full name, eg: (WHA) Bureau of Western Hemispheric Affairs.",
+                  "id": 5,
+                  "title": "Bureau",
+                },
+                Object {
+                  "definition": "An employee responsible for helping others find and successfully bid for appropriate positions for their career goals.",
+                  "id": 6,
+                  "title": "Career development officer (CDO)",
+                },
+                Object {
+                  "definition": "A chosen professional competency.",
+                  "id": 7,
+                  "title": "Career Track",
+                },
+                Object {
+                  "definition": "A cone is a colloquial synonym for a generalist or specialist functional field. Bids can be \\"in cone\\" (for a position whose skill code belongs to the bidders' specialization) or \\"out of cone.\\" Each cone contains multiple skill codes.",
+                  "id": 8,
+                  "title": "Cone",
+                },
+                Object {
+                  "definition": "A salary increase to reimburse employees for prices at a foreign post that are higher than same costs in Washington, DC. The specific value of the allowance changes based on local prices. COLA is a colloquial shorthand for what is officially known as post allowance.",
+                  "id": 9,
+                  "title": "Cost of living allowance (COLA)",
+                },
+              ]
+            }
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`GlossaryComponent matches snapshot when visible is false 1`] = `
+<div
+  className="tm-glossary"
+>
+  <div
+    aria-describedby="glossary-title"
+    aria-hidden={true}
+    className="glossary glossary-hidden"
+    id="glossary"
+  >
+    <button
+      className="js-glossary-close"
+      onClick={[Function]}
+      title="Close glossary"
+    >
+      <FontAwesome
+        name="times"
+      />
+      <span
+        className="usa-sr-only"
+      >
+        Close Glossary
+      </span>
+    </button>
+    <div
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
+    >
+      <h2
+        id="glossary-title"
+      >
+        Glossary
+      </h2>
+      <div>
+        <GlossarySearch
+          changeText={[Function]}
+          searchTextValue=""
+        />
+        <div
+          className="glossary-content"
+        >
+          <GlossaryComponent
+            glossaryItems={
+              Array [
+                Object {
+                  "definition": "The employee responsible for filling the position.",
+                  "id": 2,
+                  "title": "Assignment Officer (AO)",
+                },
+                Object {
+                  "definition": "An employee who is applying for a position.",
+                  "id": 3,
+                  "title": "Bidder",
+                },
+                Object {
+                  "definition": "A secure text-based message sent from one State department location to another.",
+                  "id": 4,
+                  "title": "Cable",
+                },
+                Object {
+                  "definition": "The organization sponsoring a position. Most bureaus oversee regional areas, such as Western Europe. Others, such as the Bureau of Consular Affairs, oversee functional groups. If referring to a regional bureau, include the acronym -- State Department employees often use acronyms to refer to regional bureaus. In UI copy, put the acronym before the full name, eg: (WHA) Bureau of Western Hemispheric Affairs.",
+                  "id": 5,
+                  "title": "Bureau",
+                },
+                Object {
+                  "definition": "An employee responsible for helping others find and successfully bid for appropriate positions for their career goals.",
+                  "id": 6,
+                  "title": "Career development officer (CDO)",
+                },
+                Object {
+                  "definition": "A chosen professional competency.",
+                  "id": 7,
+                  "title": "Career Track",
+                },
+                Object {
+                  "definition": "A cone is a colloquial synonym for a generalist or specialist functional field. Bids can be \\"in cone\\" (for a position whose skill code belongs to the bidders' specialization) or \\"out of cone.\\" Each cone contains multiple skill codes.",
+                  "id": 8,
+                  "title": "Cone",
+                },
+                Object {
+                  "definition": "A salary increase to reimburse employees for prices at a foreign post that are higher than same costs in Washington, DC. The specific value of the allowance changes based on local prices. COLA is a colloquial shorthand for what is officially known as post allowance.",
+                  "id": 9,
+                  "title": "Cost of living allowance (COLA)",
+                },
+              ]
+            }
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/Components/Glossary/index.js
+++ b/src/Components/Glossary/index.js
@@ -1,0 +1,1 @@
+export { default } from './Glossary';

--- a/src/Components/Header/DesktopNav/DesktopNav.jsx
+++ b/src/Components/Header/DesktopNav/DesktopNav.jsx
@@ -4,6 +4,7 @@ import FontAwesome from 'react-fontawesome';
 import { USER_PROFILE } from '../../../Constants/PropTypes';
 import Inbox from '../Inbox';
 import Notifications from '../Notifications';
+import GlossaryIcon from '../GlossaryIcon';
 import NavLink from '../NavLink';
 import AccountDropdown from '../../AccountDropdown/AccountDropdown';
 
@@ -66,6 +67,7 @@ userProfile, logout, toggleSearchVisibility }) => (
               <span>
                 <Inbox />
                 <Notifications />
+                <GlossaryIcon />
               </span>
           }
         </div>

--- a/src/Components/Header/DesktopNav/__snapshots__/DesktopNav.test.jsx.snap
+++ b/src/Components/Header/DesktopNav/__snapshots__/DesktopNav.test.jsx.snap
@@ -124,6 +124,7 @@ exports[`DesktopNav matches snapshot when logged in 1`] = `
             number={0}
           />
           <Connect(withRouter(Notifications)) />
+          <Connect(GlossaryIcon) />
         </span>
       </div>
     </div>

--- a/src/Components/Header/GlossaryIcon/GlossaryIcon.jsx
+++ b/src/Components/Header/GlossaryIcon/GlossaryIcon.jsx
@@ -1,0 +1,42 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { toggleGlossary } from '../../../actions/showGlossary';
+import Icon from './Icon';
+import { EMPTY_FUNCTION } from '../../../Constants/PropTypes';
+
+class GlossaryIcon extends Component {
+  constructor(props) {
+    super(props);
+    this.toggleVisibility = this.toggleVisibility.bind(this);
+  }
+  toggleVisibility() {
+    const { toggleGlossaryVisibility, shouldShowGlossary } = this.props;
+    toggleGlossaryVisibility(!shouldShowGlossary);
+  }
+  render() {
+    return (
+      <Icon onClick={this.toggleVisibility} />
+    );
+  }
+}
+
+GlossaryIcon.propTypes = {
+  toggleGlossaryVisibility: PropTypes.func.isRequired,
+  shouldShowGlossary: PropTypes.bool.isRequired,
+};
+
+GlossaryIcon.defaultProps = {
+  toggleGlossaryVisibility: EMPTY_FUNCTION,
+  shouldShowGlossary: false,
+};
+
+const mapStateToProps = state => ({
+  shouldShowGlossary: state.shouldShowGlossary,
+});
+
+export const mapDispatchToProps = dispatch => ({
+  toggleGlossaryVisibility: shouldShow => dispatch(toggleGlossary(shouldShow)),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(GlossaryIcon);

--- a/src/Components/Header/GlossaryIcon/GlossaryIcon.test.jsx
+++ b/src/Components/Header/GlossaryIcon/GlossaryIcon.test.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import sinon from 'sinon';
+import TestUtils from 'react-dom/test-utils';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import createHistory from 'history/createBrowserHistory';
+import { shallow } from 'enzyme';
+import toJSON from 'enzyme-to-json';
+import { testDispatchFunctions } from '../../../testUtilities/testUtilities';
+import GlossaryIcon, { mapDispatchToProps } from './GlossaryIcon';
+
+const middlewares = [thunk];
+const mockStore = configureStore(middlewares);
+const history = createHistory();
+
+describe('GlossaryIconComponent', () => {
+  it('is defined', () => {
+    const wrapper = TestUtils.renderIntoDocument(<Provider store={mockStore({})}><MemoryRouter>
+      <GlossaryIcon history={history} />
+    </MemoryRouter></Provider>);
+    expect(wrapper).toBeDefined();
+  });
+
+  it('can toggle visibility', () => {
+    const spy = sinon.spy();
+    const wrapper = shallow(
+      <GlossaryIcon.WrappedComponent toggleGlossaryVisibility={spy} />,
+    );
+    wrapper.instance().toggleVisibility();
+    sinon.assert.calledOnce(spy);
+  });
+
+  it('matches snapshot', () => {
+    const wrapper = shallow(
+      <GlossaryIcon.WrappedComponent />,
+    );
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+});
+
+describe('mapDispatchToProps', () => {
+  const config = {
+    toggleGlossaryVisibility: [true],
+  };
+  testDispatchFunctions(mapDispatchToProps, config);
+});

--- a/src/Components/Header/GlossaryIcon/Icon/Icon.jsx
+++ b/src/Components/Header/GlossaryIcon/Icon/Icon.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import FontAwesome from 'react-fontawesome';
+import { EMPTY_FUNCTION } from '../../../../Constants/PropTypes';
+import InteractiveElement from '../../../InteractiveElement';
+
+const Icon = ({ onClick }) => (
+  <InteractiveElement
+    className="icon-alert-container glossary-icon"
+    type="div"
+    title="View the glossary"
+    onClick={onClick}
+  >
+    <FontAwesome name="book" />
+  </InteractiveElement>
+);
+
+Icon.propTypes = {
+  onClick: PropTypes.func.isRequired,
+};
+
+Icon.defaultProps = {
+  onClick: EMPTY_FUNCTION,
+};
+
+export default Icon;

--- a/src/Components/Header/GlossaryIcon/Icon/Icon.test.jsx
+++ b/src/Components/Header/GlossaryIcon/Icon/Icon.test.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import toJSON from 'enzyme-to-json';
+import Icon from './Icon';
+
+describe('IconComponent', () => {
+  it('is defined', () => {
+    const wrapper = shallow(
+      <Icon onClick={() => {}} />,
+    );
+    expect(wrapper).toBeDefined();
+  });
+
+  it('matches snapshot', () => {
+    const wrapper = shallow(
+      <Icon onClick={() => {}} />,
+    );
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/Components/Header/GlossaryIcon/Icon/__snapshots__/Icon.test.jsx.snap
+++ b/src/Components/Header/GlossaryIcon/Icon/__snapshots__/Icon.test.jsx.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`IconComponent matches snapshot 1`] = `
+<InteractiveElement
+  className="icon-alert-container glossary-icon"
+  onClick={[Function]}
+  title="View the glossary"
+  type="div"
+>
+  <FontAwesome
+    name="book"
+  />
+</InteractiveElement>
+`;

--- a/src/Components/Header/GlossaryIcon/Icon/index.js
+++ b/src/Components/Header/GlossaryIcon/Icon/index.js
@@ -1,0 +1,1 @@
+export { default } from './Icon';

--- a/src/Components/Header/GlossaryIcon/__snapshots__/GlossaryIcon.test.jsx.snap
+++ b/src/Components/Header/GlossaryIcon/__snapshots__/GlossaryIcon.test.jsx.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GlossaryIconComponent matches snapshot 1`] = `
+<Icon
+  onClick={[Function]}
+/>
+`;

--- a/src/Components/Header/GlossaryIcon/index.js
+++ b/src/Components/Header/GlossaryIcon/index.js
@@ -1,0 +1,1 @@
+export { default } from './GlossaryIcon';

--- a/src/Components/SaveNewSearchDialog/__snapshots__/SaveNewSearchDialog.test.jsx.snap
+++ b/src/Components/SaveNewSearchDialog/__snapshots__/SaveNewSearchDialog.test.jsx.snap
@@ -16,6 +16,7 @@ exports[`SaveNewSearchDialogComponent matches snapshot 1`] = `
       label="Name:"
       labelMessage=""
       labelSrOnly={false}
+      placeholder=""
       value={null}
     />
   </FieldSet>

--- a/src/Components/SearchFilters/LanguageFilter/__snapshots__/LanguageFilter.test.jsx.snap
+++ b/src/Components/SearchFilters/LanguageFilter/__snapshots__/LanguageFilter.test.jsx.snap
@@ -8,6 +8,7 @@ exports[`LanguageFilterComponent matches snapshot 1`] = `
     id="language-language-section"
     setAccordion={[Function]}
     title="language"
+    useIdClass={true}
   >
     <SelectForm
       defaultSort=""

--- a/src/Components/SearchFilters/MultiSelectFilterContainer/__snapshots__/MultiSelectFilterContainer.test.jsx.snap
+++ b/src/Components/SearchFilters/MultiSelectFilterContainer/__snapshots__/MultiSelectFilterContainer.test.jsx.snap
@@ -8,6 +8,7 @@ exports[`MultiSelectFilterContainerComponent matches snapshot 1`] = `
     id="checkbox-title"
     setAccordion={[Function]}
     title="title"
+    useIdClass={true}
   />
 </Accordion>
 `;

--- a/src/Components/TextInput/TextInput.jsx
+++ b/src/Components/TextInput/TextInput.jsx
@@ -15,7 +15,7 @@ class TextInput extends Component {
     this.setState({ input }, this.props.changeText(e.target.value));
   }
   render() {
-    const { id, labelSrOnly, type, label, labelMessage } = this.props;
+    const { id, labelSrOnly, type, label, labelMessage, placeholder } = this.props;
     const { input } = this.state;
     let labelClass;
     // set the input class based on "type" prop
@@ -57,6 +57,7 @@ class TextInput extends Component {
           value={input.value}
           onChange={this.changeText}
           className={inputClass}
+          placeholder={placeholder}
         />
         {message}
       </div>
@@ -72,6 +73,7 @@ TextInput.propTypes = {
   label: PropTypes.string,
   labelMessage: PropTypes.string,
   value: PropTypes.string,
+  placeholder: PropTypes.string,
 };
 
 TextInput.defaultProps = {
@@ -80,6 +82,7 @@ TextInput.defaultProps = {
   label: '',
   labelMessage: '',
   value: null,
+  placeholder: '',
 };
 
 export default TextInput;

--- a/src/Components/TextInput/__snapshots__/TextInput.test.jsx.snap
+++ b/src/Components/TextInput/__snapshots__/TextInput.test.jsx.snap
@@ -13,6 +13,7 @@ exports[`TextInputComponent matches snapshot 1`] = `
     id="1"
     name="input-type-text"
     onChange={[Function]}
+    placeholder=""
     type="text"
     value=""
   />

--- a/src/Constants/PropTypes.js
+++ b/src/Constants/PropTypes.js
@@ -408,3 +408,12 @@ export const PROFILE_MENU_SECTION_EXPANDED = PropTypes.shape({
   title: PropTypes.string,
   display: PropTypes.bool,
 });
+
+export const GLOSSARY_OBJECT = PropTypes.shape({
+  id: PropTypes.number,
+  title: PropTypes.string,
+  definition: PropTypes.string,
+  link: PropTypes.string,
+});
+
+export const GLOSSARY_ARRAY = PropTypes.arrayOf(GLOSSARY_OBJECT);

--- a/src/Containers/Glossary/Glossary.jsx
+++ b/src/Containers/Glossary/Glossary.jsx
@@ -1,0 +1,66 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { toggleGlossary } from '../../actions/showGlossary';
+import { glossaryFetchData } from '../../actions/glossary';
+import { EMPTY_FUNCTION } from '../../Constants/PropTypes';
+import Glossary from '../../Components/Glossary';
+
+class GlossaryContainer extends Component {
+
+  constructor(props) {
+    super(props);
+    this.toggleVisibility = this.toggleVisibility.bind(this);
+  }
+
+  componentWillMount() {
+    this.props.fetchGlossary();
+  }
+
+  toggleVisibility() {
+    const { shouldShowGlossary, toggleGlossaryVisibility } = this.props;
+    toggleGlossaryVisibility(!shouldShowGlossary);
+  }
+
+  render() {
+    const { shouldShowGlossary, glossaryItems, glossaryIsLoading } = this.props;
+    return (
+      <Glossary
+        glossaryItems={glossaryItems}
+        glossaryIsLoading={glossaryIsLoading}
+        visible={shouldShowGlossary}
+        toggleVisibility={this.toggleVisibility}
+      />
+    );
+  }
+}
+
+GlossaryContainer.propTypes = {
+  shouldShowGlossary: PropTypes.bool.isRequired,
+  toggleGlossaryVisibility: PropTypes.func.isRequired,
+  fetchGlossary: PropTypes.func.isRequired,
+  glossaryItems: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+  glossaryIsLoading: PropTypes.bool.isRequired,
+};
+
+GlossaryContainer.defaultProps = {
+  shouldShowGlossary: false,
+  toggleGlossaryVisibility: EMPTY_FUNCTION,
+  fetchGlossary: EMPTY_FUNCTION,
+  glossaryItems: [],
+  glossaryIsLoading: false,
+};
+
+const mapStateToProps = state => ({
+  shouldShowGlossary: state.shouldShowGlossary,
+  glossaryItems: state.glossary,
+  glossaryHasErrored: state.glossaryHasErrored,
+  glossaryIsLoading: state.glossaryIsLoading,
+});
+
+export const mapDispatchToProps = dispatch => ({
+  toggleGlossaryVisibility: shouldDisplay => dispatch(toggleGlossary(shouldDisplay)),
+  fetchGlossary: () => dispatch(glossaryFetchData()),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(GlossaryContainer);

--- a/src/Containers/Glossary/Glossary.test.jsx
+++ b/src/Containers/Glossary/Glossary.test.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import sinon from 'sinon';
+import { shallow } from 'enzyme';
+import TestUtils from 'react-dom/test-utils';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { testDispatchFunctions } from '../../testUtilities/testUtilities';
+import Glossary, { mapDispatchToProps } from './Glossary';
+
+const middlewares = [thunk];
+const mockStore = configureStore(middlewares);
+
+describe('Glossary', () => {
+  it('is defined', () => {
+    const wrapper = TestUtils.renderIntoDocument(<Provider store={mockStore({})}><MemoryRouter>
+      <Glossary />
+    </MemoryRouter></Provider>);
+    expect(wrapper).toBeDefined();
+  });
+
+  it('can call the toggleVisibility function', () => {
+    const spy = sinon.spy();
+    const wrapper = shallow(
+      <Glossary.WrappedComponent
+        toggleGlossaryVisibility={spy}
+      />,
+    );
+    wrapper.instance().toggleVisibility();
+    sinon.assert.calledOnce(spy);
+  });
+});
+
+describe('mapDispatchToProps', () => {
+  const config = {
+    toggleGlossaryVisibility: [true],
+  };
+  testDispatchFunctions(mapDispatchToProps, config);
+});

--- a/src/Containers/Glossary/index.js
+++ b/src/Containers/Glossary/index.js
@@ -1,0 +1,1 @@
+export { default } from './Glossary';

--- a/src/Containers/Main/Main.jsx
+++ b/src/Containers/Main/Main.jsx
@@ -16,6 +16,7 @@ import rootReducer from '../../reducers';
 import Routes from '../../Containers/Routes/Routes';
 import Header from '../../Components/Header/Header';
 import Footer from '../../Components/Footer/Footer';
+import Glossary from '../../Containers/Glossary';
 
 import checkIndexAuthorization from '../../lib/check-auth';
 
@@ -52,6 +53,7 @@ const Main = props => (
           <Routes {...props} isAuthorized={isAuthorized} />
         </main>
         <Footer />
+        <Glossary />
       </div>
     </ConnectedRouter>
   </Provider>

--- a/src/__mocks__/glossaryItems.js
+++ b/src/__mocks__/glossaryItems.js
@@ -1,0 +1,12 @@
+const glossaryItems = [
+  { id: 2, title: 'Assignment Officer (AO)', definition: 'The employee responsible for filling the position.' },
+  { id: 3, title: 'Bidder', definition: 'An employee who is applying for a position.' },
+  { id: 4, title: 'Cable', definition: 'A secure text-based message sent from one State department location to another.' },
+  { id: 5, title: 'Bureau', definition: 'The organization sponsoring a position. Most bureaus oversee regional areas, such as Western Europe. Others, such as the Bureau of Consular Affairs, oversee functional groups. If referring to a regional bureau, include the acronym -- State Department employees often use acronyms to refer to regional bureaus. In UI copy, put the acronym before the full name, eg: (WHA) Bureau of Western Hemispheric Affairs.' },
+  { id: 6, title: 'Career development officer (CDO)', definition: 'An employee responsible for helping others find and successfully bid for appropriate positions for their career goals.' },
+  { id: 7, title: 'Career Track', definition: 'A chosen professional competency.' },
+  { id: 8, title: 'Cone', definition: 'A cone is a colloquial synonym for a generalist or specialist functional field. Bids can be "in cone" (for a position whose skill code belongs to the bidders\' specialization) or "out of cone." Each cone contains multiple skill codes.' },
+  { id: 9, title: 'Cost of living allowance (COLA)', definition: 'A salary increase to reimburse employees for prices at a foreign post that are higher than same costs in Washington, DC. The specific value of the allowance changes based on local prices. COLA is a colloquial shorthand for what is officially known as post allowance.' },
+];
+
+export default glossaryItems;

--- a/src/actions/glossary.js
+++ b/src/actions/glossary.js
@@ -1,0 +1,49 @@
+// import axios from 'axios';
+// import { fetchUserToken } from '../utilities';
+// import api from '../api';
+
+// TODO - use real data from API
+
+export function glossaryHasErrored(bool) {
+  return {
+    type: 'GLOSSARY_HAS_ERRORED',
+    hasErrored: bool,
+  };
+}
+export function glossaryIsLoading(bool) {
+  return {
+    type: 'GLOSSARY_IS_LOADING',
+    isLoading: bool,
+  };
+}
+export function glossaryFetchDataSuccess(glossary) {
+  return {
+    type: 'GLOSSARY_FETCH_DATA_SUCCESS',
+    glossary,
+  };
+}
+
+// subset of terms from github
+const items = [
+  { id: 2, title: 'Assignment Officer (AO)', definition: 'The employee responsible for filling the position.' },
+  { id: 3, title: 'Bidder', definition: 'An employee who is applying for a position.' },
+  { id: 4, title: 'Cable', definition: 'A secure text-based message sent from one State department location to another.' },
+  { id: 5, title: 'Bureau', definition: 'The organization sponsoring a position. Most bureaus oversee regional areas, such as Western Europe. Others, such as the Bureau of Consular Affairs, oversee functional groups. If referring to a regional bureau, include the acronym -- State Department employees often use acronyms to refer to regional bureaus. In UI copy, put the acronym before the full name, eg: (WHA) Bureau of Western Hemispheric Affairs.' },
+  { id: 6, title: 'Career development officer (CDO)', definition: 'An employee responsible for helping others find and successfully bid for appropriate positions for their career goals.' },
+  { id: 7, title: 'Career Track', definition: 'A chosen professional competency.' },
+  { id: 8, title: 'Cone', definition: 'A cone is a colloquial synonym for a generalist or specialist functional field. Bids can be "in cone" (for a position whose skill code belongs to the bidders\' specialization) or "out of cone." Each cone contains multiple skill codes.' },
+  { id: 9, title: 'Cost of living allowance (COLA)', definition: 'A salary increase to reimburse employees for prices at a foreign post that are higher than same costs in Washington, DC. The specific value of the allowance changes based on local prices. COLA is a colloquial shorthand for what is officially known as post allowance.' },
+];
+
+// fake async until API endpoint is created
+export function glossaryFetchData() {
+  return (dispatch) => {
+    dispatch(glossaryIsLoading(true));
+    dispatch(glossaryHasErrored(false));
+    setTimeout(() => {
+      dispatch(glossaryFetchDataSuccess(items));
+      dispatch(glossaryIsLoading(false));
+      dispatch(glossaryHasErrored(false));
+    }, 400);
+  };
+}

--- a/src/actions/glossary.test.js
+++ b/src/actions/glossary.test.js
@@ -1,0 +1,20 @@
+import { setupAsyncMocks } from '../testUtilities/testUtilities';
+import * as actions from './glossary';
+
+const { mockStore } = setupAsyncMocks();
+
+describe('async actions', () => {
+  it('can fetch the glossary', (done) => {
+    const store = mockStore({ glossary: [] });
+
+    store.dispatch(actions.glossaryFetchData());
+    store.dispatch(actions.glossaryIsLoading());
+
+    const f = () => {
+      setTimeout(() => {
+        done();
+      }, 600);
+    };
+    f();
+  });
+});

--- a/src/actions/showGlossary.js
+++ b/src/actions/showGlossary.js
@@ -1,0 +1,12 @@
+export function shouldShowGlossary(shouldShow) {
+  return {
+    type: 'SHOULD_SHOW_GLOSSARY',
+    shouldShow,
+  };
+}
+
+export function toggleGlossary(show = true) {
+  return (dispatch) => {
+    dispatch(shouldShowGlossary(show));
+  };
+}

--- a/src/actions/showGlossary.test.jsx
+++ b/src/actions/showGlossary.test.jsx
@@ -1,0 +1,11 @@
+import { setupAsyncMocks } from '../testUtilities/testUtilities';
+import * as actions from './showGlossary';
+
+const { mockStore } = setupAsyncMocks();
+
+describe('showGlossary actions', () => {
+  it('can call the toggleGlossary function', () => {
+    const store = mockStore({ shouldShowGlossary: false });
+    store.dispatch(actions.toggleGlossary(true));
+  });
+});

--- a/src/actions/showSearchBar.test.jsx
+++ b/src/actions/showSearchBar.test.jsx
@@ -1,7 +1,11 @@
+import { setupAsyncMocks } from '../testUtilities/testUtilities';
 import * as actions from './showSearchBar';
+
+const { mockStore } = setupAsyncMocks();
 
 describe('showSearchBar actions', () => {
   it('can call the toggleSearchBar function', () => {
-    expect(actions.toggleSearchBar()).toBeDefined();
+    const store = mockStore({ shouldShowSearchBar: false });
+    store.dispatch(actions.toggleSearchBar(true));
   });
 });

--- a/src/reducers/glossary/glossary.js
+++ b/src/reducers/glossary/glossary.js
@@ -1,0 +1,24 @@
+export function glossaryHasErrored(state = false, action) {
+  switch (action.type) {
+    case 'GLOSSARY_HAS_ERRORED':
+      return action.hasErrored;
+    default:
+      return state;
+  }
+}
+export function glossaryIsLoading(state = false, action) {
+  switch (action.type) {
+    case 'GLOSSARY_IS_LOADING':
+      return action.isLoading;
+    default:
+      return state;
+  }
+}
+export function glossary(state = [], action) {
+  switch (action.type) {
+    case 'GLOSSARY_FETCH_DATA_SUCCESS':
+      return action.glossary;
+    default:
+      return state;
+  }
+}

--- a/src/reducers/glossary/glossary.test.js
+++ b/src/reducers/glossary/glossary.test.js
@@ -1,0 +1,15 @@
+import * as reducers from './glossary';
+
+describe('reducers', () => {
+  it('can set reducer GLOSSARY_HAS_ERRORED', () => {
+    expect(reducers.glossaryHasErrored(false, { type: 'GLOSSARY_HAS_ERRORED', hasErrored: true })).toBe(true);
+  });
+
+  it('can set reducer GLOSSARY_IS_LOADING', () => {
+    expect(reducers.glossaryIsLoading(false, { type: 'GLOSSARY_IS_LOADING', isLoading: true })).toBe(true);
+  });
+
+  it('can set reducer GLOSSARY_FETCH_DATA_SUCCESS', () => {
+    expect(reducers.glossary([], { type: 'GLOSSARY_FETCH_DATA_SUCCESS', glossary: [1] }).length).toBe(1);
+  });
+});

--- a/src/reducers/glossary/index.js
+++ b/src/reducers/glossary/index.js
@@ -1,0 +1,3 @@
+import { glossary, glossaryHasErrored, glossaryIsLoading } from './glossary';
+
+export default { glossary, glossaryHasErrored, glossaryIsLoading };

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -25,6 +25,8 @@ import routerLocations from './routerLocations';
 import selectedAccordion from './selectedAccordion';
 import shouldShowStaticContent from './showStaticContent';
 import profileMenu from './profileMenu';
+import showGlossary from './showGlossary';
+import glossary from './glossary';
 
 
 export default combineReducers({
@@ -50,6 +52,8 @@ export default combineReducers({
   ...shouldShowStaticContent,
   ...shouldShowSearchBar,
   ...profileMenu,
+  ...showGlossary,
+  ...glossary,
   router: routerReducer,
   form,
   client,

--- a/src/reducers/showGlossary/index.js
+++ b/src/reducers/showGlossary/index.js
@@ -1,0 +1,3 @@
+import shouldShowGlossary from './showGlossary';
+
+export default { shouldShowGlossary };

--- a/src/reducers/showGlossary/showGlossary.js
+++ b/src/reducers/showGlossary/showGlossary.js
@@ -1,0 +1,11 @@
+export default function shouldShowGlossary(state = false, action) {
+  switch (action.type) {
+    case 'SHOULD_SHOW_GLOSSARY':
+      return action.shouldShow;
+    // close Glossary on route change
+    case '@@router/LOCATION_CHANGE':
+      return false;
+    default:
+      return state;
+  }
+}

--- a/src/reducers/showGlossary/showGlossary.test.js
+++ b/src/reducers/showGlossary/showGlossary.test.js
@@ -1,0 +1,7 @@
+import shouldShowGlossary from './showGlossary';
+
+describe('showGlossary reducers', () => {
+  it('can set reducer SHOULD_SHOW_GLOSSARY', () => {
+    expect(shouldShowGlossary(false, { type: 'SHOULD_SHOW_GLOSSARY', shouldShow: true })).toBe(true);
+  });
+});

--- a/src/sass/_glossary.scss
+++ b/src/sass/_glossary.scss
@@ -1,0 +1,91 @@
+// scss-lint:disable QualifyingElement
+// scss-lint:disable ImportantRule
+
+.tm-glossary {
+  * {
+    box-sizing: border-box;
+  }
+
+  body {
+    font-family: sans-serif;
+  }
+
+  $foreground-color: $color-black;
+
+  .glossary {
+    background: $tm-white-smoke;
+    border-left: 1px solid $tm-navy-dark;
+    bottom: 0;
+    overflow-y: scroll;
+    padding: 5rem 3rem;
+    position: fixed;
+    right: 0;
+    top: 0;
+    transition: right .2s;
+    width: 30rem;
+
+    .glossary-hidden {
+      display: none !important;
+    }
+  }
+
+  .glossary-hidden {
+    right: -30rem;
+  }
+
+  ul {
+    padding: 0;
+  }
+
+  li {
+    list-style-type: none;
+  }
+
+  button {
+    appearance: none;
+    padding: .5rem;
+    text-align: left;
+  }
+
+  .glossary-content {
+    padding: 4rem 0;
+  }
+
+  .js-accordion button {
+    width: 100%;
+  }
+
+  .js-glossary-close {
+    background-color: transparent;
+    border: 0;
+    color: $foreground-color;
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
+
+  .usa-accordion {
+    color: $foreground-color;
+
+    li {
+      background-color: transparent;
+    }
+
+    .usa-accordion-button {
+      background-color: transparent;
+      border: 0;
+      border-bottom: 1px solid $foreground-color;
+      color: $foreground-color;
+    }
+
+    .accordion-item-title {
+      padding-right: 25%;
+    }
+
+    .usa-accordion-content {
+      background-color: transparent;
+      font-size: .8em;
+      padding: 1rem;
+    }
+  }
+}

--- a/src/sass/_glossary.scss
+++ b/src/sass/_glossary.scss
@@ -51,11 +51,7 @@
     padding: 4rem 0;
   }
 
-  .js-accordion button {
-    width: 100%;
-  }
-
-  .js-glossary-close {
+  .glossary-close {
     background-color: transparent;
     border: 0;
     color: $foreground-color;

--- a/src/sass/_iconAlert.scss
+++ b/src/sass/_iconAlert.scss
@@ -31,3 +31,7 @@
     color: $color-gray-lighter;
   }
 }
+
+.glossary-icon {
+  cursor: pointer;
+}

--- a/src/sass/_spinner.scss
+++ b/src/sass/_spinner.scss
@@ -47,3 +47,9 @@ $tm-spinner-filled-ratio: 1.15;
   float: left;
   margin: 2px 6px 0 0;
 }
+
+.tm-spinner-glossary {
+  left: 30%;
+  position: absolute;
+  top: 100px;
+}

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -55,4 +55,5 @@
 @import 'status';
 @import 'organizationStamp';
 @import 'alerts';
+@import 'glossary';
 @import 'overrides';

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -197,3 +197,27 @@ export const getTimeDistanceInWords = (dateToCompare, date = new Date(), options
 // Prefix asset paths with the PUBLIC_URL
 export const getAssetPath = strAssetPath =>
   `${process.env.PUBLIC_URL}${strAssetPath}`;
+
+// Filter by objects that contain a specified prop(s) that match a string.
+// Check if any of "array"'s objects' "props" contain "keyword"
+export const filterByProps = (keyword, props = [], array = []) => {
+  // keyword should have length
+  if (keyword.length) {
+    // filter the array and return its value
+    return array.filter((data) => {
+      let doesMatch;
+      // iterate through props and see if keyword is found in their values
+      props.forEach((prop) => {
+        // if so, doesMatch = true
+        if (data[prop].toLowerCase().indexOf(keyword.toLowerCase()) !== -1) {
+          doesMatch = true;
+        }
+      });
+      // if keyWord was found in atleast one of the props, doesMatch should be true
+      return doesMatch;
+    },
+    );
+  }
+  // if keyword length === 0, return the unfiltered array
+  return array;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -185,6 +185,10 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+aria-accordion@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/aria-accordion/-/aria-accordion-1.0.0.tgz#2dcb25ba86c97ac20d258c3fcdc710863f9ea2a2"
+
 aria-query@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-0.7.0.tgz#4af10a1e61573ddea0cf3b99b51c52c05b424d24"
@@ -3243,6 +3247,14 @@ globule@^1.0.0:
     lodash "~4.17.4"
     minimatch "~3.0.2"
 
+glossary-panel@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/glossary-panel/-/glossary-panel-1.0.0.tgz#b474a5309c7241c2d2daec13b44e05dc70edb1fb"
+  dependencies:
+    aria-accordion "1.0.0"
+    list.js "1.3.0"
+    underscore "^1.8.3"
+
 gonzales-pe-sl@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/gonzales-pe-sl/-/gonzales-pe-sl-4.2.3.tgz#6a868bc380645f141feeb042c6f97fcc71b59fe6"
@@ -4472,6 +4484,10 @@ lexical-scope@^1.2.0:
   resolved "https://registry.yarnpkg.com/lexical-scope/-/lexical-scope-1.2.0.tgz#fcea5edc704a4b3a8796cdca419c3a0afaf22df4"
   dependencies:
     astw "^2.0.0"
+
+list.js@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/list.js/-/list.js-1.3.0.tgz#6c9f9c106a6a9e2681bf41823ee4fc1067a1645c"
 
 load-json-file@^1.0.0:
   version "1.1.0"
@@ -7500,6 +7516,10 @@ uid-number@^0.0.6:
 umd@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/umd/-/umd-3.0.1.tgz#8ae556e11011f63c2596708a8837259f01b3d60e"
+
+underscore@^1.8.3:
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
 
 union-class-names@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -185,10 +185,6 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-aria-accordion@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/aria-accordion/-/aria-accordion-1.0.0.tgz#2dcb25ba86c97ac20d258c3fcdc710863f9ea2a2"
-
 aria-query@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-0.7.0.tgz#4af10a1e61573ddea0cf3b99b51c52c05b424d24"
@@ -3247,14 +3243,6 @@ globule@^1.0.0:
     lodash "~4.17.4"
     minimatch "~3.0.2"
 
-glossary-panel@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/glossary-panel/-/glossary-panel-1.0.0.tgz#b474a5309c7241c2d2daec13b44e05dc70edb1fb"
-  dependencies:
-    aria-accordion "1.0.0"
-    list.js "1.3.0"
-    underscore "^1.8.3"
-
 gonzales-pe-sl@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/gonzales-pe-sl/-/gonzales-pe-sl-4.2.3.tgz#6a868bc380645f141feeb042c6f97fcc71b59fe6"
@@ -4484,10 +4472,6 @@ lexical-scope@^1.2.0:
   resolved "https://registry.yarnpkg.com/lexical-scope/-/lexical-scope-1.2.0.tgz#fcea5edc704a4b3a8796cdca419c3a0afaf22df4"
   dependencies:
     astw "^2.0.0"
-
-list.js@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/list.js/-/list.js-1.3.0.tgz#6c9f9c106a6a9e2681bf41823ee4fc1067a1645c"
 
 load-json-file@^1.0.0:
   version "1.1.0"
@@ -7516,10 +7500,6 @@ uid-number@^0.0.6:
 umd@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/umd/-/umd-3.0.1.tgz#8ae556e11011f63c2596708a8837259f01b3d60e"
-
-underscore@^1.8.3:
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
 
 union-class-names@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
First stab at the Glossary. @krisdelacruz is creating wireframes, so I will update once I have those.

Uses a static list of glossary terms from https://github.com/18F/State-TalentMAP/wiki/Content-styleguide but ideally we load these onto the API. I've created async actions to mimic a delayed retrieval a glossary array.

Then we have two primary connected components. One is a Glossary Button in the Header which hooks into a toggle action. The other is the Glossary itself, which is displayed conditionally based on the value the toggle action changes. It makes use of our `Accordion` component to list terms.

There's also a search bar in the Glossary, which runs on the client and filters based on values of certain properties of the glossary objects.

Used https://www.fec.gov/data/ as a starting point.

In action:
![jan-04-2018 18-07-03](https://user-images.githubusercontent.com/11576347/34588298-341a29f6-f17a-11e7-84c1-ac8c9f7953a5.gif)
