### PR TITLE
Integrate glossary action with /glossary endpoint

### DIFF
--- a/src/Constants/PropTypes.js
+++ b/src/Constants/PropTypes.js
@@ -419,3 +419,8 @@ export const GLOSSARY_OBJECT = PropTypes.shape({
 });
 
 export const GLOSSARY_ARRAY = PropTypes.arrayOf(GLOSSARY_OBJECT);
+
+export const GLOSSARY_LIST = PropTypes.shape({
+  ...PAGINATION_PROPS,
+  results: GLOSSARY_ARRAY,
+});

--- a/src/Containers/Glossary/Glossary.jsx
+++ b/src/Containers/Glossary/Glossary.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { toggleGlossary } from '../../actions/showGlossary';
 import { glossaryFetchData } from '../../actions/glossary';
-import { EMPTY_FUNCTION, GLOSSARY_ARRAY } from '../../Constants/PropTypes';
+import { EMPTY_FUNCTION, GLOSSARY_LIST } from '../../Constants/PropTypes';
 import Glossary from '../../Components/Glossary';
 
 class GlossaryContainer extends Component {
@@ -26,7 +26,7 @@ class GlossaryContainer extends Component {
     const { shouldShowGlossary, glossaryItems, glossaryIsLoading } = this.props;
     return (
       <Glossary
-        glossaryItems={glossaryItems}
+        glossaryItems={glossaryItems.results}
         glossaryIsLoading={glossaryIsLoading}
         visible={shouldShowGlossary}
         toggleVisibility={this.toggleVisibility}
@@ -39,7 +39,7 @@ GlossaryContainer.propTypes = {
   shouldShowGlossary: PropTypes.bool.isRequired,
   toggleGlossaryVisibility: PropTypes.func.isRequired,
   fetchGlossary: PropTypes.func.isRequired,
-  glossaryItems: GLOSSARY_ARRAY.isRequired,
+  glossaryItems: GLOSSARY_LIST.isRequired,
   glossaryIsLoading: PropTypes.bool.isRequired,
 };
 
@@ -47,7 +47,7 @@ GlossaryContainer.defaultProps = {
   shouldShowGlossary: false,
   toggleGlossaryVisibility: EMPTY_FUNCTION,
   fetchGlossary: EMPTY_FUNCTION,
-  glossaryItems: [],
+  glossaryItems: { results: [] },
   glossaryIsLoading: false,
 };
 

--- a/src/actions/glossary.js
+++ b/src/actions/glossary.js
@@ -1,8 +1,6 @@
-// import axios from 'axios';
-// import { fetchUserToken } from '../utilities';
-// import api from '../api';
-
-// TODO - use real data from API
+import axios from 'axios';
+import { fetchUserToken } from '../utilities';
+import api from '../api';
 
 export function glossaryHasErrored(bool) {
   return {
@@ -23,27 +21,19 @@ export function glossaryFetchDataSuccess(glossary) {
   };
 }
 
-// subset of terms from github
-const items = [
-  { id: 2, title: 'Assignment Officer (AO)', definition: 'The employee responsible for filling the position.' },
-  { id: 3, title: 'Bidder', definition: 'An employee who is applying for a position.' },
-  { id: 4, title: 'Cable', definition: 'A secure text-based message sent from one State department location to another.' },
-  { id: 5, title: 'Bureau', definition: 'The organization sponsoring a position. Most bureaus oversee regional areas, such as Western Europe. Others, such as the Bureau of Consular Affairs, oversee functional groups. If referring to a regional bureau, include the acronym -- State Department employees often use acronyms to refer to regional bureaus. In UI copy, put the acronym before the full name, eg: (WHA) Bureau of Western Hemispheric Affairs.' },
-  { id: 6, title: 'Career development officer (CDO)', definition: 'An employee responsible for helping others find and successfully bid for appropriate positions for their career goals.' },
-  { id: 7, title: 'Career Track', definition: 'A chosen professional competency.' },
-  { id: 8, title: 'Cone', definition: 'A cone is a colloquial synonym for a generalist or specialist functional field. Bids can be "in cone" (for a position whose skill code belongs to the bidders\' specialization) or "out of cone." Each cone contains multiple skill codes.' },
-  { id: 9, title: 'Cost of living allowance (COLA)', definition: 'A salary increase to reimburse employees for prices at a foreign post that are higher than same costs in Washington, DC. The specific value of the allowance changes based on local prices. COLA is a colloquial shorthand for what is officially known as post allowance.' },
-];
-
-// fake async until API endpoint is created
 export function glossaryFetchData() {
   return (dispatch) => {
     dispatch(glossaryIsLoading(true));
     dispatch(glossaryHasErrored(false));
-    setTimeout(() => {
-      dispatch(glossaryFetchDataSuccess(items));
-      dispatch(glossaryIsLoading(false));
-      dispatch(glossaryHasErrored(false));
-    }, 400);
+    axios.get(`${api}/glossary/`, { headers: { Authorization: fetchUserToken() } })
+        .then(({ data }) => {
+          dispatch(glossaryFetchDataSuccess(data));
+          dispatch(glossaryIsLoading(false));
+          dispatch(glossaryHasErrored(false));
+        })
+        .catch(() => {
+          dispatch(glossaryIsLoading(false));
+          dispatch(glossaryHasErrored(true));
+        });
   };
 }

--- a/src/actions/glossary.test.js
+++ b/src/actions/glossary.test.js
@@ -1,19 +1,41 @@
 import { setupAsyncMocks } from '../testUtilities/testUtilities';
 import * as actions from './glossary';
 
-const { mockStore } = setupAsyncMocks();
+const { mockStore, mockAdapter } = setupAsyncMocks();
 
 describe('async actions', () => {
-  it('can fetch the glossary', (done) => {
-    const store = mockStore({ glossary: [] });
+  beforeEach(() => {
+    const glossary = {
+      results: [
+        {
+          id: 7,
+          title: 'COLA',
+          definition: 'Cost of Living Adjustment',
+          link: 'google.com',
+        },
+        {
+          id: 8,
+          title: 'D',
+          definition: 'd',
+          link: 'google.com',
+        },
+      ],
+    };
 
-    store.dispatch(actions.glossaryFetchData());
-    store.dispatch(actions.glossaryIsLoading());
+    mockAdapter.onGet('http://localhost:8000/api/v1/glossary/').reply(200,
+      glossary,
+    );
+  });
+
+  it('can fetch the glossary', (done) => {
+    const store = mockStore({ glossary: {} });
 
     const f = () => {
       setTimeout(() => {
+        store.dispatch(actions.glossaryFetchData());
+        store.dispatch(actions.glossaryIsLoading());
         done();
-      }, 600);
+      }, 0);
     };
     f();
   });

--- a/src/reducers/glossary/glossary.js
+++ b/src/reducers/glossary/glossary.js
@@ -14,7 +14,7 @@ export function glossaryIsLoading(state = false, action) {
       return state;
   }
 }
-export function glossary(state = [], action) {
+export function glossary(state = { results: [] }, action) {
   switch (action.type) {
     case 'GLOSSARY_FETCH_DATA_SUCCESS':
       return action.glossary;


### PR DESCRIPTION
Removes static glossary array and integrates action with the `/glossary` endpoint.

Relies on https://github.com/18F/State-TalentMAP-API/pull/297