### PR TITLE
Add AuthorizedWrapper to conditionally render the Glossary component

### DIFF
--- a/src/Containers/AuthorizedWrapper/AuthorizedWrapper.jsx
+++ b/src/Containers/AuthorizedWrapper/AuthorizedWrapper.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const AuthorizedWrapper = ({ isAuthorized, children }) => {
+  const hasAuthorization = isAuthorized();
+  return (
+    <div className="authorized-wrapper">
+      { hasAuthorization && children }
+    </div>
+  );
+};
+
+AuthorizedWrapper.propTypes = {
+  isAuthorized: PropTypes.func.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+export default AuthorizedWrapper;

--- a/src/Containers/AuthorizedWrapper/AuthorizedWrapper.test.jsx
+++ b/src/Containers/AuthorizedWrapper/AuthorizedWrapper.test.jsx
@@ -1,0 +1,61 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import toJSON from 'enzyme-to-json';
+import AuthorizedWrapper from './AuthorizedWrapper';
+
+describe('AuthorizedWrapper', () => {
+  const props = {
+    isAuthorized: () => {},
+    children: <span>test</span>,
+  };
+  it('is defined', () => {
+    const wrapper = shallow(
+      <AuthorizedWrapper
+        {...props}
+      />,
+    );
+    expect(wrapper).toBeDefined();
+  });
+
+  it('it does not render children if isAuthorized returns false', () => {
+    const wrapper = shallow(
+      <AuthorizedWrapper
+        {...props}
+        isAuthorized={() => false}
+      />,
+    );
+    expect(wrapper).toBeDefined();
+    expect(wrapper.find('span').exists()).toBe(false);
+  });
+
+  it('it renders children if isAuthorized returns true', () => {
+    const wrapper = shallow(
+      <AuthorizedWrapper
+        {...props}
+        isAuthorized={() => true}
+      />,
+    );
+    expect(wrapper).toBeDefined();
+    expect(wrapper.find('span').exists()).toBe(true);
+  });
+
+  it('matches snapshot when isAuthorized returns true', () => {
+    const wrapper = shallow(
+      <AuthorizedWrapper
+        {...props}
+        isAuthorized={() => true}
+      />,
+    );
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+
+  it('matches snapshot when isAuthorized returns false', () => {
+    const wrapper = shallow(
+      <AuthorizedWrapper
+        {...props}
+        isAuthorized={() => false}
+      />,
+    );
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/Containers/AuthorizedWrapper/__snapshots__/AuthorizedWrapper.test.jsx.snap
+++ b/src/Containers/AuthorizedWrapper/__snapshots__/AuthorizedWrapper.test.jsx.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AuthorizedWrapper matches snapshot when isAuthorized returns false 1`] = `
+<div
+  className="authorized-wrapper"
+/>
+`;
+
+exports[`AuthorizedWrapper matches snapshot when isAuthorized returns true 1`] = `
+<div
+  className="authorized-wrapper"
+>
+  <span>
+    test
+  </span>
+</div>
+`;

--- a/src/Containers/AuthorizedWrapper/index.js
+++ b/src/Containers/AuthorizedWrapper/index.js
@@ -1,0 +1,1 @@
+export { default } from './AuthorizedWrapper';

--- a/src/Containers/Main/Main.jsx
+++ b/src/Containers/Main/Main.jsx
@@ -17,6 +17,7 @@ import Routes from '../../Containers/Routes/Routes';
 import Header from '../../Components/Header/Header';
 import Footer from '../../Components/Footer/Footer';
 import Glossary from '../../Containers/Glossary';
+import AuthorizedWrapper from '../../Containers/AuthorizedWrapper';
 
 import checkIndexAuthorization from '../../lib/check-auth';
 
@@ -53,7 +54,9 @@ const Main = props => (
           <Routes {...props} isAuthorized={isAuthorized} />
         </main>
         <Footer />
-        <Glossary />
+        <AuthorizedWrapper {...props} isAuthorized={isAuthorized}>
+          <Glossary />
+        </AuthorizedWrapper>
       </div>
     </ConnectedRouter>
   </Provider>


### PR DESCRIPTION
Closes #1254 by making use of an `AuthorizedWrapper` to conditionally render a component, the Glossary in this case, based on the result of `isAuthorized()`. We could apply this wrapper to other components throughout the application as well.