### PR TITLE
Resolve setState warnings with Glossary

### DIFF
--- a/src/Containers/AuthorizedWrapper/AuthorizedWrapper.jsx
+++ b/src/Containers/AuthorizedWrapper/AuthorizedWrapper.jsx
@@ -1,14 +1,32 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-const AuthorizedWrapper = ({ isAuthorized, children }) => {
-  const hasAuthorization = isAuthorized();
-  return (
-    <div className="authorized-wrapper">
-      { hasAuthorization && children }
-    </div>
-  );
-};
+class AuthorizedWrapper extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isAuthorized: { value: false },
+    };
+  }
+  componentWillMount() {
+    this.setAuthorization();
+  }
+  componentWillReceiveProps() {
+    this.setAuthorization();
+  }
+  setAuthorization() {
+    const isAuthorized = { value: this.props.isAuthorized() };
+    this.setState({ isAuthorized });
+  }
+  render() {
+    const { isAuthorized } = this.state;
+    return (
+      <div className="authorized-wrapper">
+        { isAuthorized.value && this.props.children }
+      </div>
+    );
+  }
+}
 
 AuthorizedWrapper.propTypes = {
   isAuthorized: PropTypes.func.isRequired,


### PR DESCRIPTION
We were receiving `setState` warnings by evaluating `isAuthorized()` within the render of the `AuthorizedWrapper`, so this abstracts that function out into `ComponentWillMount` and `ComponentWillReceiveProps` to resolve those errors.