### PR TITLE
Override placeholder color for accessibility

### DIFF
--- a/src/sass/_select.scss
+++ b/src/sass/_select.scss
@@ -1,0 +1,7 @@
+// scss-lint:disable SelectorFormat
+
+.Select-placeholder,
+.Select--single > .Select-control .Select-value {
+  // override for accessibility
+  color: $color-gray;
+}

--- a/src/sass/_select.scss
+++ b/src/sass/_select.scss
@@ -1,3 +1,4 @@
+// Overrides styles for the react-select module
 // scss-lint:disable SelectorFormat
 
 .Select-placeholder,

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -61,4 +61,5 @@
 @import 'alerts';
 @import 'glossary';
 @import 'bidStats';
+@import 'select';
 @import 'overrides';


### PR DESCRIPTION
Default gray placeholder text for the Multi-select fails accessibility tests. This changes the text to a darker gray.