### PR TITLE
Sprint 12 fixes

### DIFF
--- a/src/Components/BidStatistics/BidStatList/BidStatList.jsx
+++ b/src/Components/BidStatistics/BidStatList/BidStatList.jsx
@@ -4,8 +4,8 @@ import BidStatCard from '../BidStatCard';
 import { numbersToPercentString } from '../../../utilities';
 
 const BidStatList = ({ bidStats }) => {
-  const positionsFilledPercent =
-    numbersToPercentString(bidStats.available_positions, bidStats.total_positions, 3, true);
+  const positionsFilledPercent = numbersToPercentString(
+    bidStats.total_positions - bidStats.available_positions, bidStats.total_positions, 3);
   return (
     <div className="usa-grid-full bid-stat-card-list">
       <BidStatCard title="Positions Available" number={bidStats.available_positions} />

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -259,9 +259,8 @@ export const returnObjectsWherePropMatches = (sourceArray = [], compareArray = [
 
 // Convert a numerator and a denominator to a percentage. Pass "inverse === true" if you want
 // the inverse, i.e. the remainder.
-export const numbersToPercentString = (numerator, denominator, precision = 3, inverse = false) => {
+export const numbersToPercentString = (numerator, denominator, precision = 3) => {
   const formatFraction = fraction => parseFloat(fraction).toPrecision(precision) * 100;
-  let percentage = formatFraction(numerator / denominator);
-  if (inverse) { percentage = formatFraction((denominator - numerator) / denominator); }
+  const percentage = formatFraction(numerator / denominator);
   return `${percentage}%`;
 };

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -195,7 +195,7 @@ export const removeDuplicates = (myArr, prop) => (
 export const getTimeDistanceInWords = (dateToCompare, date = new Date(), options = {}) =>
   `${distanceInWords(dateToCompare, date, options)} ago`;
 
-// Format the date into out preferred format.
+// Format the date into our preferred format.
 // We can take any valid date and convert it into M.D.YYYY format, or any
 // format provided with the dateFormat param.
 export const formatDate = (date, dateFormat = 'M.D.YYYY') => {
@@ -227,7 +227,7 @@ export const filterByProps = (keyword, props = [], array = []) => {
           doesMatch = true;
         }
       });
-      // if keyWord was found in atleast one of the props, doesMatch should be true
+      // if keyword was found in at least one of the props, doesMatch should be true
       return doesMatch;
     },
     );

--- a/src/utilities.test.js
+++ b/src/utilities.test.js
@@ -313,16 +313,11 @@ describe('numbersToPercentString', () => {
     expect(percent).toBe('20%');
   });
 
-  it('can return a percent inverse', () => {
-    const percent = numbersToPercentString(numerator, denominator, precision, true);
-    expect(percent).toBe('80%');
-  });
-
   it('can return a percent with proper precision', () => {
     numerator = 3;
     denominator = 7;
     precision = 4;
-    const percent = numbersToPercentString(numerator, denominator, precision, false);
+    const percent = numbersToPercentString(numerator, denominator, precision);
     expect(percent).toBe('42.86%');
   });
 });


### PR DESCRIPTION
Addresses feedback on https://github.com/18F/State-TalentMAP/pull/1253 regarding typos and the `inverse` param in the `numbersToPercentString` function.