### PR TITLE
Add dynamic asset path to .scss files

### DIFF
--- a/src/sass/_accordion.scss
+++ b/src/sass/_accordion.scss
@@ -5,10 +5,10 @@
   }
 
   .usa-accordion-button[aria-expanded=false] {
-    background-image: url('/assets/img/plus-white.svg');
+    background-image: url('#{$asset-path}/assets/img/plus-white.svg');
   }
 
   .usa-accordion-button[aria-expanded=true] {
-    background-image: url('/assets/img/minus-white.svg');
+    background-image: url('#{$asset-path}/assets/img/minus-white.svg');
   }
 }

--- a/src/sass/sass-vars/variables.js
+++ b/src/sass/sass-vars/variables.js
@@ -1,5 +1,5 @@
-// Our responsive breakpoint variables
 module.exports = {
+  // Our responsive breakpoint variables
   screenSmMinNum: 600,
   get 'screen-sm-min'() { return `${this.screenSmMinNum}px`; },
 
@@ -17,4 +17,8 @@ module.exports = {
 
   get screenMdMaxNum() { return this.screenLgMinNum - 1; },
   get 'screen-md-max'() { return `${this.screenMdMaxNum}px`; },
+
+  // Set our asset path. This is similar to getAssetPath in utilities, but
+  // we wrap the environment variable in quotes so it can be used in .scss files.
+  'asset-path': process.env.PUBLIC_URL ? `"${process.env.PUBLIC_URL}"` : '""',
 };


### PR DESCRIPTION
Resolves issues with asset paths in scss files not resolving when deployed server-side.