### PR TITLE
Draft bid submission and deletion from Bid Tracker

### DIFF
--- a/src/Components/BidTracker/BidHelpers.js
+++ b/src/Components/BidTracker/BidHelpers.js
@@ -28,7 +28,7 @@ import {
 
 // determine whether to show an alert on the bid tracker based on the status
 export function shouldShowAlert(bid) {
-  const alertStatusArray = [HAND_SHAKE_OFFERED_PROP, APPROVED_PROP, CLOSED_PROP,
+  const alertStatusArray = [DRAFT_PROP, HAND_SHAKE_OFFERED_PROP, APPROVED_PROP, CLOSED_PROP,
     HAND_SHAKE_DECLINED_PROP, DECLINED_PROP];
 
   // status is in the array OR paneling is today

--- a/src/Components/BidTracker/BidTracker.jsx
+++ b/src/Components/BidTracker/BidTracker.jsx
@@ -6,7 +6,7 @@ import Spinner from '../Spinner';
 import NotificationsSection from './NotificationsSection';
 import ContactCDOButton from './ContactCDOButton';
 
-const BidTracker = ({ bidList, bidListIsLoading, acceptBid, declineBid,
+const BidTracker = ({ bidList, bidListIsLoading, acceptBid, declineBid, submitBid, deleteBid,
 notifications, notificationsIsLoading, markBidTrackerNotification, userProfile,
 userProfileIsLoading }) => {
   const isLoading = bidListIsLoading || userProfileIsLoading;
@@ -41,6 +41,8 @@ userProfileIsLoading }) => {
                 bids={bidList.results}
                 acceptBid={acceptBid}
                 declineBid={declineBid}
+                submitBid={submitBid}
+                deleteBid={deleteBid}
                 userProfile={userProfile}
               />
             </div>
@@ -55,6 +57,8 @@ BidTracker.propTypes = {
   bidListIsLoading: PropTypes.bool.isRequired,
   acceptBid: PropTypes.func.isRequired,
   declineBid: PropTypes.func.isRequired,
+  submitBid: PropTypes.func.isRequired,
+  deleteBid: PropTypes.func.isRequired,
   notifications: NOTIFICATION_LIST.isRequired,
   notificationsIsLoading: PropTypes.bool.isRequired,
   markBidTrackerNotification: PropTypes.func.isRequired,

--- a/src/Components/BidTracker/BidTracker.test.jsx
+++ b/src/Components/BidTracker/BidTracker.test.jsx
@@ -12,6 +12,8 @@ describe('BidTrackerComponent', () => {
     bidListIsLoading: false,
     acceptBid: () => {},
     declineBid: () => {},
+    submitBid: () => {},
+    deleteBid: () => {},
     notifications: notificationsObject,
     notificationsIsLoading: false,
     markBidTrackerNotification: () => {},

--- a/src/Components/BidTracker/BidTrackerCard/BidTrackerCard.jsx
+++ b/src/Components/BidTracker/BidTrackerCard/BidTrackerCard.jsx
@@ -13,7 +13,7 @@ import {
   IN_PANEL_PROP,
 } from '../../../Constants/BidData';
 
-const BidTrackerCard = ({ bid, acceptBid, declineBid, userProfile }) => {
+const BidTrackerCard = ({ bid, acceptBid, declineBid, submitBid, deleteBid, userProfile }) => {
   // determine whether we render an alert on top of the card
   const showAlert = shouldShowAlert(bid);
   // determine whether we should show the contacts section based on the status
@@ -31,6 +31,8 @@ const BidTrackerCard = ({ bid, acceptBid, declineBid, userProfile }) => {
                 bid={bid}
                 acceptBid={acceptBid}
                 declineBid={declineBid}
+                submitBid={submitBid}
+                deleteBid={deleteBid}
               />
           }
         </div>
@@ -55,6 +57,8 @@ BidTrackerCard.propTypes = {
   bid: BID_OBJECT.isRequired,
   acceptBid: PropTypes.func.isRequired,
   declineBid: PropTypes.func.isRequired,
+  submitBid: PropTypes.func.isRequired,
+  deleteBid: PropTypes.func.isRequired,
   userProfile: USER_PROFILE.isRequired,
 };
 

--- a/src/Components/BidTracker/BidTrackerCard/BidTrackerCard.test.jsx
+++ b/src/Components/BidTracker/BidTrackerCard/BidTrackerCard.test.jsx
@@ -12,6 +12,8 @@ describe('BidTrackerCardComponent', () => {
     bid,
     acceptBid: () => {},
     declineBid: () => {},
+    submitBid: () => {},
+    deleteBid: () => {},
     userProfile: bidderUserObject,
   };
 

--- a/src/Components/BidTracker/BidTrackerCard/__snapshots__/BidTrackerCard.test.jsx.snap
+++ b/src/Components/BidTracker/BidTrackerCard/__snapshots__/BidTrackerCard.test.jsx.snap
@@ -145,6 +145,8 @@ exports[`BidTrackerCardComponent matches snapshot 1`] = `
           }
         }
         declineBid={[Function]}
+        deleteBid={[Function]}
+        submitBid={[Function]}
       />
     </div>
   </div>

--- a/src/Components/BidTracker/BidTrackerCardContainer/BidTrackerCardContainer.jsx
+++ b/src/Components/BidTracker/BidTrackerCardContainer/BidTrackerCardContainer.jsx
@@ -10,13 +10,16 @@ import IsOnStandby from '../PriorityCards/IsOnStandby';
 // If a priority bid exists, then we check whether this individual bid is the priority bid.
 // If it is, we'll wrap the card in the IsPriority component, and if not, we'll pass the bid
 // object to the IsOnStandby component.
-const BidTrackerCardContainer = ({ bid, acceptBid, declineBid, priorityExists, userProfile }) => {
+const BidTrackerCardContainer = ({ bid, acceptBid, declineBid, priorityExists, userProfile,
+submitBid, deleteBid }) => {
   const card = (
     <BidTrackerCard
       bid={bid}
       acceptBid={acceptBid}
       declineBid={declineBid}
       userProfile={userProfile}
+      submitBid={submitBid}
+      deleteBid={deleteBid}
     />
   );
 
@@ -54,6 +57,8 @@ BidTrackerCardContainer.propTypes = {
   bid: BID_OBJECT.isRequired,
   acceptBid: PropTypes.func.isRequired,
   declineBid: PropTypes.func.isRequired,
+  submitBid: PropTypes.func.isRequired,
+  deleteBid: PropTypes.func.isRequired,
   priorityExists: PropTypes.bool,
   userProfile: USER_PROFILE.isRequired,
 };

--- a/src/Components/BidTracker/BidTrackerCardContainer/BidTrackerCardContainer.test.jsx
+++ b/src/Components/BidTracker/BidTrackerCardContainer/BidTrackerCardContainer.test.jsx
@@ -12,6 +12,8 @@ describe('BidTrackerCardContainerComponent', () => {
     bid,
     acceptBid: () => {},
     declineBid: () => {},
+    submitBid: () => {},
+    deleteBid: () => {},
     isPriority: false,
     userProfile: bidderUserObject,
   };

--- a/src/Components/BidTracker/BidTrackerCardContainer/__snapshots__/BidTrackerCardContainer.test.jsx.snap
+++ b/src/Components/BidTracker/BidTrackerCardContainer/__snapshots__/BidTrackerCardContainer.test.jsx.snap
@@ -50,6 +50,8 @@ exports[`BidTrackerCardContainerComponent matches snapshot when priorityExists i
       }
     }
     declineBid={[Function]}
+    deleteBid={[Function]}
+    submitBid={[Function]}
     userProfile={
       Object {
         "bid_statistics": Array [

--- a/src/Components/BidTracker/BidTrackerCardList/BidTrackerCardList.jsx
+++ b/src/Components/BidTracker/BidTrackerCardList/BidTrackerCardList.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { BID_RESULTS, USER_PROFILE } from '../../../Constants/PropTypes';
 import BidTrackerCardContainer from '../BidTrackerCardContainer';
 
-const BidTrackerCardList = ({ bids, acceptBid, declineBid, userProfile }) => {
+const BidTrackerCardList = ({ bids, acceptBid, declineBid, submitBid, deleteBid, userProfile }) => {
   // Push the priority bid to the top. There should only be one priority bid.
   // We do this sorting client-side to maintain any sorts the user might select,
   // while ensuring the priority bid is stickied to the top.
@@ -23,6 +23,8 @@ const BidTrackerCardList = ({ bids, acceptBid, declineBid, userProfile }) => {
             bid={bid}
             acceptBid={acceptBid}
             declineBid={declineBid}
+            submitBid={submitBid}
+            deleteBid={deleteBid}
             userProfile={userProfile}
             priorityExists={doesPriorityExist}
           />
@@ -36,6 +38,8 @@ BidTrackerCardList.propTypes = {
   bids: BID_RESULTS.isRequired,
   acceptBid: PropTypes.func.isRequired,
   declineBid: PropTypes.func.isRequired,
+  submitBid: PropTypes.func.isRequired,
+  deleteBid: PropTypes.func.isRequired,
   userProfile: USER_PROFILE.isRequired,
 };
 

--- a/src/Components/BidTracker/BidTrackerCardList/BidTrackerCardList.test.jsx
+++ b/src/Components/BidTracker/BidTrackerCardList/BidTrackerCardList.test.jsx
@@ -12,6 +12,8 @@ describe('BidTrackerCardListComponent', () => {
     bids,
     acceptBid: () => {},
     declineBid: () => {},
+    submitBid: () => {},
+    deleteBid: () => {},
     userProfile: bidderUserObject,
   };
 

--- a/src/Components/BidTracker/BidTrackerCardList/__snapshots__/BidTrackerCardList.test.jsx.snap
+++ b/src/Components/BidTracker/BidTrackerCardList/__snapshots__/BidTrackerCardList.test.jsx.snap
@@ -50,8 +50,10 @@ exports[`BidTrackerCardListComponent matches snapshot 1`] = `
       }
     }
     declineBid={[Function]}
+    deleteBid={[Function]}
     isPriority={false}
     priorityExists={true}
+    submitBid={[Function]}
     userProfile={
       Object {
         "bid_statistics": Array [
@@ -135,8 +137,10 @@ exports[`BidTrackerCardListComponent matches snapshot 1`] = `
       }
     }
     declineBid={[Function]}
+    deleteBid={[Function]}
     isPriority={false}
     priorityExists={true}
+    submitBid={[Function]}
     userProfile={
       Object {
         "bid_statistics": Array [
@@ -220,8 +224,10 @@ exports[`BidTrackerCardListComponent matches snapshot 1`] = `
       }
     }
     declineBid={[Function]}
+    deleteBid={[Function]}
     isPriority={false}
     priorityExists={true}
+    submitBid={[Function]}
     userProfile={
       Object {
         "bid_statistics": Array [

--- a/src/Components/BidTracker/OverlayAlert/DraftAlert/DraftAlert.jsx
+++ b/src/Components/BidTracker/OverlayAlert/DraftAlert/DraftAlert.jsx
@@ -1,0 +1,83 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import FontAwesome from 'react-fontawesome';
+import { BID_OBJECT } from '../../../../Constants/PropTypes';
+import InteractiveElement from '../../../InteractiveElement';
+import { NO_POST, NO_SKILL, NO_GRADE } from '../../../../Constants/SystemMessages';
+
+class DraftAlert extends Component {
+  constructor(props) {
+    super(props);
+    this.onSubmitBid = this.onSubmitBid.bind(this);
+    this.onDeleteBid = this.onDeleteBid.bind(this);
+  }
+  onSubmitBid() {
+    const { submitBid, id } = this.props;
+    submitBid(id);
+  }
+  onDeleteBid() {
+    const { deleteBid, bid } = this.props;
+    deleteBid(bid.position.id);
+  }
+  render() {
+    const { bid } = this.props;
+    const position = bid.position;
+    const positionTitle = position.title;
+    const post = position && position.post && position.post.location ?
+      position.post.location : NO_POST;
+    const skillCode = position && position.post ? position.post.location : NO_SKILL;
+    const grade = position && position.grade ? position.grade : NO_GRADE;
+    return (
+      <div className="bid-tracker-alert-container bid-tracker-alert-container--draft">
+        <div className="usa-grid-full">
+          <div className="usa-width-one-half draft-submission-container">
+            <div className="sub-submission-text">
+              Would you like to submit your bid?
+            </div>
+            <div className="usa-grid-full draft-submission-buttons-container">
+              <button
+                className="tm-button-transparent tm-button-submit-bid"
+                onClick={this.onSubmitBid}
+              >
+                <FontAwesome name="paper-plane-o" /> Submit Bid
+              </button>
+              <InteractiveElement
+                className="remove-bid-link"
+                role="link"
+                onClick={this.onDeleteBid}
+              >
+                Remove Bid
+              </InteractiveElement>
+            </div>
+          </div>
+          <div className="usa-width-one-half draft-position-details">
+            <div>
+              {positionTitle}
+            </div>
+            <div>
+              <span className="title">Post: </span>
+              {post}
+            </div>
+            <div>
+              <span className="title">Skill Code: </span>
+              {skillCode}
+            </div>
+            <div>
+              <span className="title">Grade: </span>
+              {grade}
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+DraftAlert.propTypes = {
+  id: PropTypes.number.isRequired,
+  bid: BID_OBJECT.isRequired,
+  submitBid: PropTypes.func.isRequired,
+  deleteBid: PropTypes.func.isRequired,
+};
+
+export default DraftAlert;

--- a/src/Components/BidTracker/OverlayAlert/DraftAlert/DraftAlert.test.jsx
+++ b/src/Components/BidTracker/OverlayAlert/DraftAlert/DraftAlert.test.jsx
@@ -1,0 +1,47 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import sinon from 'sinon';
+import toJSON from 'enzyme-to-json';
+import DraftAlert from './DraftAlert';
+import bidListObject from '../../../../__mocks__/bidListObject';
+
+describe('DraftAlertComponent', () => {
+  const props = {
+    id: 1,
+    bid: bidListObject.results[0],
+    submitBid: () => {},
+    deleteBid: () => {},
+  };
+
+  it('is defined', () => {
+    const wrapper = shallow(
+      <DraftAlert {...props} />,
+    );
+    expect(wrapper).toBeDefined();
+  });
+
+  it('can submit a bid', () => {
+    const submitSpy = sinon.spy();
+    const wrapper = shallow(
+      <DraftAlert {...props} submitBid={submitSpy} />,
+    );
+    wrapper.find('.tm-button-submit-bid').simulate('click');
+    sinon.assert.calledOnce(submitSpy);
+  });
+
+  it('can delete a bid', () => {
+    const deleteSpy = sinon.spy();
+    const wrapper = shallow(
+      <DraftAlert {...props} deleteBid={deleteSpy} />,
+    );
+    wrapper.find('.remove-bid-link').simulate('click');
+    sinon.assert.calledOnce(deleteSpy);
+  });
+
+  it('matches snapshot', () => {
+    const wrapper = shallow(
+      <DraftAlert {...props} />,
+    );
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/Components/BidTracker/OverlayAlert/DraftAlert/__snapshots__/DraftAlert.test.jsx.snap
+++ b/src/Components/BidTracker/OverlayAlert/DraftAlert/__snapshots__/DraftAlert.test.jsx.snap
@@ -1,0 +1,73 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DraftAlertComponent matches snapshot 1`] = `
+<div
+  className="bid-tracker-alert-container bid-tracker-alert-container--draft"
+>
+  <div
+    className="usa-grid-full"
+  >
+    <div
+      className="usa-width-one-half draft-submission-container"
+    >
+      <div
+        className="sub-submission-text"
+      >
+        Would you like to submit your bid?
+      </div>
+      <div
+        className="usa-grid-full draft-submission-buttons-container"
+      >
+        <button
+          className="tm-button-transparent tm-button-submit-bid"
+          onClick={[Function]}
+        >
+          <FontAwesome
+            name="paper-plane-o"
+          />
+           Submit Bid
+        </button>
+        <InteractiveElement
+          className="remove-bid-link"
+          onClick={[Function]}
+          role="link"
+          type="div"
+        >
+          Remove Bid
+        </InteractiveElement>
+      </div>
+    </div>
+    <div
+      className="usa-width-one-half draft-position-details"
+    >
+      <div>
+        POLITICAL/ECONOMIC OFFICER
+      </div>
+      <div>
+        <span
+          className="title"
+        >
+          Post: 
+        </span>
+        Curacao
+      </div>
+      <div>
+        <span
+          className="title"
+        >
+          Skill Code: 
+        </span>
+        Curacao
+      </div>
+      <div>
+        <span
+          className="title"
+        >
+          Grade: 
+        </span>
+        03
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/Components/BidTracker/OverlayAlert/DraftAlert/index.js
+++ b/src/Components/BidTracker/OverlayAlert/DraftAlert/index.js
@@ -1,0 +1,1 @@
+export { default } from './DraftAlert';

--- a/src/Components/BidTracker/OverlayAlert/HandshakeOfferedAlert/HandshakeOfferedAlert.jsx
+++ b/src/Components/BidTracker/OverlayAlert/HandshakeOfferedAlert/HandshakeOfferedAlert.jsx
@@ -21,11 +21,13 @@ class HandshakeOfferedAlert extends Component {
     return (
       <div className="bid-tracker-alert-container bid-tracker-alert-container--handshake-offered">
         <div className="top-text">{`${userName}, you've been offered a handshake`}</div>
-        <div>
+        <div className="usa-grid-full">
           <button className="tm-button-transparent" onClick={this.onAcceptBid}>
             <FontAwesome name="check-o" /> Accept Handshake
           </button>
-          <button className="unstyled-button" onClick={this.onDeclineBid}>Decline Handshake</button>
+          <button className="tm-button-transparent tm-button-no-box" onClick={this.onDeclineBid}>
+            Decline Handshake
+          </button>
         </div>
         <div className="sub-text">24 hours to accept the handshake</div>
       </div>

--- a/src/Components/BidTracker/OverlayAlert/HandshakeOfferedAlert/__snapshots__/HandshakeOfferedAlert.test.jsx.snap
+++ b/src/Components/BidTracker/OverlayAlert/HandshakeOfferedAlert/__snapshots__/HandshakeOfferedAlert.test.jsx.snap
@@ -9,7 +9,9 @@ exports[`HandshakeOfferedAlertComponent matches snapshot 1`] = `
   >
     test, you've been offered a handshake
   </div>
-  <div>
+  <div
+    className="usa-grid-full"
+  >
     <button
       className="tm-button-transparent"
       onClick={[Function]}
@@ -20,7 +22,7 @@ exports[`HandshakeOfferedAlertComponent matches snapshot 1`] = `
        Accept Handshake
     </button>
     <button
-      className="unstyled-button"
+      className="tm-button-transparent tm-button-no-box"
       onClick={[Function]}
     >
       Decline Handshake

--- a/src/Components/BidTracker/OverlayAlert/OverlayAlert.jsx
+++ b/src/Components/BidTracker/OverlayAlert/OverlayAlert.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { BID_OBJECT } from '../../../Constants/PropTypes';
-import { APPROVED_PROP, CLOSED_PROP, HAND_SHAKE_OFFERED_PROP,
+import { APPROVED_PROP, CLOSED_PROP, HAND_SHAKE_OFFERED_PROP, DRAFT_PROP,
   HAND_SHAKE_DECLINED_PROP, IN_PANEL_PROP, DECLINED_PROP, PANEL_RESCHEDULED_PROP } from '../../../Constants/BidData';
 import ApprovedAlert from './ApprovedAlert';
 import HandshakeOfferedAlert from './HandshakeOfferedAlert';
@@ -10,12 +10,14 @@ import HandshakeDeclinedAlert from './HandshakeDeclinedAlert';
 import DeclinedAlert from './DeclinedAlert';
 import ClosedAlert from './ClosedAlert';
 import PanelRescheduledAlert from './PanelRescheduledAlert';
+import DraftAlert from './DraftAlert';
 
 // Alert rendering based on status is handled here.
-const OverlayAlert = ({ bid, acceptBid, declineBid }) => {
+const OverlayAlert = ({ bid, acceptBid, declineBid, submitBid, deleteBid }) => {
   const CLASS_PENDING = 'bid-tracker-overlay-alert--pending';
   const CLASS_SUCCESS = 'bid-tracker-overlay-alert--success';
   const CLASS_CLOSED = 'bid-tracker-overlay-alert--closed';
+  const CLASS_DRAFT = 'bid-tracker-overlay-alert--draft';
 
   const BID_TITLE = `${bid.position.title} (${bid.position.position_number})`;
 
@@ -58,6 +60,16 @@ const OverlayAlert = ({ bid, acceptBid, declineBid }) => {
       overlayClass = CLASS_PENDING;
       overlayContent = <PanelRescheduledAlert date={bid.scheduled_panel_date} />;
       break;
+    case DRAFT_PROP:
+      overlayClass = CLASS_DRAFT;
+      overlayContent = (
+        <DraftAlert
+          id={bid.id}
+          bid={bid}
+          submitBid={submitBid}
+          deleteBid={deleteBid}
+        />);
+      break;
     default:
       break;
   }
@@ -76,6 +88,8 @@ OverlayAlert.propTypes = {
   bid: BID_OBJECT.isRequired,
   acceptBid: PropTypes.func.isRequired,
   declineBid: PropTypes.func.isRequired,
+  submitBid: PropTypes.func.isRequired,
+  deleteBid: PropTypes.func.isRequired,
 };
 
 export default OverlayAlert;

--- a/src/Components/BidTracker/OverlayAlert/OverlayAlert.test.jsx
+++ b/src/Components/BidTracker/OverlayAlert/OverlayAlert.test.jsx
@@ -11,6 +11,8 @@ describe('OverlayAlertComponent', () => {
     bid: bidListObject.results[0],
     acceptBid: () => {},
     declineBid: () => {},
+    submitBid: () => {},
+    deleteBid: () => {},
   };
 
   // All possible props, plus  fake prop to test the default case of the switch

--- a/src/Components/BidTracker/__snapshots__/BidTracker.test.jsx.snap
+++ b/src/Components/BidTracker/__snapshots__/BidTracker.test.jsx.snap
@@ -219,6 +219,8 @@ exports[`BidTrackerComponent matches snapshot 1`] = `
           ]
         }
         declineBid={[Function]}
+        deleteBid={[Function]}
+        submitBid={[Function]}
         userProfile={
           Object {
             "bid_statistics": Array [

--- a/src/Components/InteractiveElement/InteractiveElement.jsx
+++ b/src/Components/InteractiveElement/InteractiveElement.jsx
@@ -20,12 +20,15 @@ const InteractiveElement = ({ children, type, ...rest }) => {
     onKeyDown: onClick ? (e) => { if (ifEnter(e)) { onClick(); } } : EMPTY_FUNCTION,
     ...rest,
   };
+
+  const CLASS_NAME = 'interactive-element';
   return (
   // At the time of writing, CodeClimate's version of eslint-a11y-plugin
   // did not take role="button" into account with the following error:
   // eslint-disable-next-line jsx-a11y/no-static-element-interactions
   type === 'div' ?
     <div
+      className={CLASS_NAME}
       {...defaultProps}
       {...props}
     >
@@ -33,6 +36,7 @@ const InteractiveElement = ({ children, type, ...rest }) => {
     </div> :
     // eslint-disable-next-line jsx-a11y/no-static-element-interactions
     <span
+      className={CLASS_NAME}
       {...defaultProps}
       {...props}
     >

--- a/src/Components/InteractiveElement/__snapshots__/InteractiveElement.test.jsx.snap
+++ b/src/Components/InteractiveElement/__snapshots__/InteractiveElement.test.jsx.snap
@@ -2,6 +2,7 @@
 
 exports[`InteractiveElementComponent matches snapshot 1`] = `
 <span
+  className="interactive-element"
   onKeyDown={[Function]}
   role="button"
   tabIndex="0"
@@ -13,6 +14,7 @@ exports[`InteractiveElementComponent matches snapshot 1`] = `
 
 exports[`InteractiveElementComponent matches snapshot when type is "div" 1`] = `
 <div
+  className="interactive-element"
   onKeyDown={[Function]}
   role="button"
   tabIndex="0"

--- a/src/Containers/BidTracker/BidTracker.jsx
+++ b/src/Containers/BidTracker/BidTracker.jsx
@@ -25,7 +25,7 @@ class BidTrackerContainer extends Component {
   }
 
   render() {
-    const { bidList, toggleBid,
+    const { bidList, toggleBid, deleteBid,
       bidListHasErrored, bidListIsLoading, bidListToggleHasErrored,
       bidListToggleIsLoading, bidListToggleSuccess, submitBidPosition,
       submitBidHasErrored, submitBidIsLoading, submitBidSuccess,
@@ -43,6 +43,7 @@ class BidTrackerContainer extends Component {
         bidListToggleHasErrored={bidListToggleHasErrored}
         bidListToggleIsLoading={bidListToggleIsLoading}
         bidListToggleSuccess={bidListToggleSuccess}
+        deleteBid={deleteBid}
         submitBid={submitBidPosition}
         submitBidHasErrored={submitBidHasErrored}
         submitBidIsLoading={submitBidIsLoading}
@@ -72,6 +73,7 @@ BidTrackerContainer.propTypes = {
   bidListRouteChangeResetState: PropTypes.func.isRequired,
   fetchBidList: PropTypes.func,
   toggleBid: PropTypes.func,
+  deleteBid: PropTypes.func,
   bidListHasErrored: PropTypes.bool,
   bidListIsLoading: PropTypes.bool,
   bidList: BID_LIST,
@@ -104,6 +106,7 @@ BidTrackerContainer.propTypes = {
 BidTrackerContainer.defaultProps = {
   fetchBidList: EMPTY_FUNCTION,
   toggleBid: EMPTY_FUNCTION,
+  deleteBid: EMPTY_FUNCTION,
   bidList: { results: [] },
   bidListHasErrored: false,
   bidListIsLoading: false,
@@ -169,6 +172,7 @@ export const mapDispatchToProps = dispatch => ({
   submitBidPosition: id => dispatch(submitBid(id)),
   acceptBidPosition: id => dispatch(acceptBid(id)),
   declineBidPosition: id => dispatch(declineBid(id)),
+  deleteBid: id => dispatch(toggleBidPosition(id, true)),
   // Here, we only want the newest bidding-related notification.
   // We'll perform a client-side check to see if it's unread, as that's would be the only
   // case that we'd display this notification.

--- a/src/Containers/BidTracker/BidTracker.test.jsx
+++ b/src/Containers/BidTracker/BidTracker.test.jsx
@@ -41,6 +41,7 @@ describe('mapDispatchToProps', () => {
     submitBidPosition: [1],
     acceptBidPosition: [1],
     declineBidPosition: [1],
+    deleteBid: [1],
   };
   testDispatchFunctions(mapDispatchToProps, config);
 });

--- a/src/sass/_bidTracker.scss
+++ b/src/sass/_bidTracker.scss
@@ -1,5 +1,6 @@
 // set a min-width for the bid tracker card, since it is not optimized for mobile
 $card-width: 775px;
+$draft-icon-offset: 120px;
 
 .bid-tracker-page {
   padding: 20px;
@@ -46,6 +47,7 @@ $card-width: 775px;
 
 .bid-tracker-container {
   margin-bottom: 30px;
+  overflow: hidden;
   position: relative;
 }
 
@@ -77,6 +79,7 @@ $card-width: 775px;
   }
 }
 
+.bid-tracker-overlay-alert--draft,
 .bid-tracker-overlay-alert--success {
   background: $color-green-dark;
 }
@@ -87,6 +90,28 @@ $card-width: 775px;
 
 .bid-tracker-overlay-alert--closed {
   background: $color-gray;
+}
+
+.bid-tracker-overlay-alert--draft {
+  margin-left: $draft-icon-offset;
+
+  .bid-tracker-overlay-alert-content-container {
+    padding-right: $draft-icon-offset;
+    width: 95%;
+  }
+}
+
+.bid-tracker-overlay-alert--draft::after {
+  border-bottom: 10px solid transparent;
+  border-left: 10px solid $color-white;
+  border-top: 10px solid transparent;
+  clear: both;
+  content: '';
+  height: 0;
+  left: 0;
+  position: absolute;
+  top: 43px;
+  width: 0;
 }
 
 .bid-tracker {
@@ -152,6 +177,7 @@ $card-width: 775px;
   }
 
   .bid-tracker-bid-steps-container {
+    // overflow-y: hidden;
     padding-bottom: 25px;
     padding-right: 10%;
     padding-top: 40px;
@@ -427,6 +453,7 @@ $card-width: 775px;
 
   .sub-text {
     font-size: 13px;
+    margin-top: 5px;
   }
 
   .top-text {
@@ -455,6 +482,53 @@ $card-width: 775px;
 
   button {
     margin-right: 30px;
+  }
+}
+
+.bid-tracker-alert-container--draft {
+  top: 35px;
+
+  .remove-bid-link {
+    cursor: pointer;
+    float: left;
+    margin-right: 10px;
+    margin-top: 7px;
+    text-decoration: underline;
+  }
+
+  .title {
+    font-weight: bold;
+  }
+
+  .draft-submission-container {
+    border-right: 1px solid $color-white;
+  }
+
+  .draft-submission-buttons-container {
+    max-width: 350px;
+  }
+
+  .draft-position-details {
+    padding-left: 5%;
+    text-align: left;
+  }
+
+  .sub-submission-text {
+    margin-bottom: 15px;
+    margin-right: 14%;
+  }
+
+  .tm-button-submit-bid {
+    float: left;
+    margin-right: 30px;
+    padding-left: 10%;
+    padding-right: 10%;
+
+    .fa {
+      font-size: 1em;
+      margin-bottom: 0;
+      margin-right: 5px;
+    }
   }
 }
 

--- a/src/sass/_buttons.scss
+++ b/src/sass/_buttons.scss
@@ -146,3 +146,7 @@
   border-radius: 3px;
   padding: 9px 12px;
 }
+
+.tm-button-no-box {
+  box-shadow: 0 0 0 2px transparent inset;
+}

--- a/src/sass/_interactiveElement.scss
+++ b/src/sass/_interactiveElement.scss
@@ -1,0 +1,3 @@
+.interactive-element {
+  cursor: pointer;
+}

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -31,6 +31,7 @@
 // Components
 @import 'containers';
 @import 'autosuggest';
+@import 'interactiveElement';
 @import 'bidCount';
 @import 'condensedCard';
 @import 'bidListButton';


### PR DESCRIPTION
Adds an Overlay alert to the Bid Tracker for draft bids where you have the option to submit or delete the bid, as well as see basic information about the position.

I wasn't able to find the exact issue number associated with this task, but I'll add it as soon as I find it.