### PR TITLE
Account dropdown style updates

### DIFF
--- a/src/Components/AccountDropdown/AccountDropdown.jsx
+++ b/src/Components/AccountDropdown/AccountDropdown.jsx
@@ -23,7 +23,8 @@ export class AccountDropdown extends Component {
   }
 
   render() {
-    const firstName = this.props.userProfile.user ? this.props.userProfile.user.first_name : '...';
+    const { shouldDisplayName, userProfile } = this.props;
+    const firstName = userProfile.user ? userProfile.user.first_name : '...';
     const avatar = getAssetPath('/assets/img/avatar.png');
     return (
       <Dropdown
@@ -37,17 +38,24 @@ export class AccountDropdown extends Component {
             className="account-dropdown--avatar"
             src={avatar}
           />
-          <span className="account-dropdown--name" id="account-username">{firstName}</span>
+          {
+            shouldDisplayName &&
+              <span className="account-dropdown--name" id="account-username">{firstName}</span>
+          }
         </DropdownTrigger>
         <DropdownContent>
           <div className="account-dropdown--identity account-dropdown--segment">
             <div>Signed in as</div>
             <strong>{firstName}</strong>
           </div>
-          <div className="account-dropdown--identity account-dropdown--segment">
+          <div
+            className="account-dropdown--identity account-dropdown--segment account-dropdown-link"
+          >
             <Link to="/profile/dashboard" onClick={this.hideDropdown}>Profile</Link>
           </div>
-          <div className="account-dropdown--identity account-dropdown--segment">
+          <div
+            className="account-dropdown--identity account-dropdown--segment account-dropdown-link"
+          >
             <Link to="/login" onClick={this.logout}>Logout</Link>
           </div>
         </DropdownContent>
@@ -59,11 +67,13 @@ export class AccountDropdown extends Component {
 AccountDropdown.propTypes = {
   logoutRequest: PropTypes.func,
   userProfile: USER_PROFILE,
+  shouldDisplayName: PropTypes.bool,
 };
 
 AccountDropdown.defaultProps = {
   logoutRequest: EMPTY_FUNCTION,
   userProfile: {},
+  shouldDisplayName: false,
 };
 
 export default AccountDropdown;

--- a/src/Components/AccountDropdown/AccountDropdown.test.jsx
+++ b/src/Components/AccountDropdown/AccountDropdown.test.jsx
@@ -51,15 +51,25 @@ describe('AccountDropdown', () => {
     sinon.assert.calledOnce(spy);
   });
 
+  it('does not display the name when shouldDisplayName is false', () => {
+    const accountDropdown = shallow(<AccountDropdown shouldDisplayName={false} />);
+    expect(accountDropdown.find('#account-username').exists()).toBe(false);
+  });
+
   it('matches snapshot', () => {
     const accountDropdown = shallow(<AccountDropdown />);
     expect(toJSON(accountDropdown)).toMatchSnapshot();
   });
 
-  it("can render the logged in user's name", () => {
+  it('matches snapshot when shouldDisplayName is true', () => {
+    const accountDropdown = shallow(<AccountDropdown shouldDisplayName />);
+    expect(toJSON(accountDropdown)).toMatchSnapshot();
+  });
+
+  it("can render the logged in user's name when shouldDisplayName is true", () => {
     const firstName = 'test';
     const accountDropdown = mount(<Provider store={mockStore({})}><MemoryRouter>
-      <AccountDropdown userProfile={{ user: { first_name: firstName } }} />
+      <AccountDropdown shouldDisplayName userProfile={{ user: { first_name: firstName } }} />
     </MemoryRouter></Provider>);
     expect(accountDropdown.find('#account-username').text()).toBe(firstName);
   });

--- a/src/Components/AccountDropdown/__snapshots__/AccountDropdown.test.jsx.snap
+++ b/src/Components/AccountDropdown/__snapshots__/AccountDropdown.test.jsx.snap
@@ -14,6 +14,60 @@ exports[`AccountDropdown matches snapshot 1`] = `
       className="account-dropdown--avatar"
       src="/assets/img/avatar.png"
     />
+  </DropdownTrigger>
+  <DropdownContent
+    className=""
+  >
+    <div
+      className="account-dropdown--identity account-dropdown--segment"
+    >
+      <div>
+        Signed in as
+      </div>
+      <strong>
+        ...
+      </strong>
+    </div>
+    <div
+      className="account-dropdown--identity account-dropdown--segment account-dropdown-link"
+    >
+      <Link
+        onClick={[Function]}
+        replace={false}
+        to="/profile/dashboard"
+      >
+        Profile
+      </Link>
+    </div>
+    <div
+      className="account-dropdown--identity account-dropdown--segment account-dropdown-link"
+    >
+      <Link
+        onClick={[Function]}
+        replace={false}
+        to="/login"
+      >
+        Logout
+      </Link>
+    </div>
+  </DropdownContent>
+</Dropdown>
+`;
+
+exports[`AccountDropdown matches snapshot when shouldDisplayName is true 1`] = `
+<Dropdown
+  className="account-dropdown"
+  removeElement={true}
+>
+  <DropdownTrigger
+    className=""
+    href="/#"
+  >
+    <img
+      alt="avatar"
+      className="account-dropdown--avatar"
+      src="/assets/img/avatar.png"
+    />
     <span
       className="account-dropdown--name"
       id="account-username"
@@ -35,7 +89,7 @@ exports[`AccountDropdown matches snapshot 1`] = `
       </strong>
     </div>
     <div
-      className="account-dropdown--identity account-dropdown--segment"
+      className="account-dropdown--identity account-dropdown--segment account-dropdown-link"
     >
       <Link
         onClick={[Function]}
@@ -46,7 +100,7 @@ exports[`AccountDropdown matches snapshot 1`] = `
       </Link>
     </div>
     <div
-      className="account-dropdown--identity account-dropdown--segment"
+      className="account-dropdown--identity account-dropdown--segment account-dropdown-link"
     >
       <Link
         onClick={[Function]}

--- a/src/Components/Header/DesktopNav/__snapshots__/DesktopNav.test.jsx.snap
+++ b/src/Components/Header/DesktopNav/__snapshots__/DesktopNav.test.jsx.snap
@@ -79,6 +79,7 @@ exports[`DesktopNav matches snapshot when logged in 1`] = `
       >
         <AccountDropdown
           logoutRequest={[Function]}
+          shouldDisplayName={false}
           userProfile={
             Object {
               "bid_statistics": Array [

--- a/src/sass/_dropdown.scss
+++ b/src/sass/_dropdown.scss
@@ -9,7 +9,8 @@
 
 .dropdown__content {
   display: none;
-  min-width: 100px;
+  left: -80px;
+  min-width: 160px;
   position: absolute;
   z-index: $dropdown-content-z;
 }
@@ -25,6 +26,19 @@
   width: 20px;
 }
 
+.account-dropdown-link:hover {
+  background: $blue-primary;
+  color: $color-white;
+  padding: 0;
+
+  a {
+    color: $color-white;
+    display: block;
+    padding: 10px 15px;
+    width: 100%;
+  }
+}
+
 .account-dropdown .dropdown__trigger {
   line-height: 20px;
   padding: 10px 0;
@@ -32,7 +46,7 @@
 
 .account-dropdown .dropdown__trigger::after {
   content: '\25BE';
-  margin: 0 0 0 10px;
+  margin: 0 0 0 5px;
 }
 
 .account-dropdown--avatar,


### PR DESCRIPTION
Some small tweaks to the account dropdown. Adds a prop to hide the name by default. Also adds highlighting of the hovered link. Low priority since this is merging into `sprint-14`.