### PR TITLE
Fix formatFraction function

### DIFF
--- a/src/utilities.js
+++ b/src/utilities.js
@@ -262,7 +262,8 @@ export const returnObjectsWherePropMatches = (sourceArray = [], compareArray = [
 // Convert a numerator and a denominator to a percentage. Pass "inverse === true" if you want
 // the inverse, i.e. the remainder.
 export const numbersToPercentString = (numerator, denominator, precision = 3) => {
-  const formatFraction = fraction => parseFloat(fraction).toPrecision(precision) * 100;
+  const formatFraction = fraction =>
+    (parseFloat(fraction) * 100).toString().slice(0, precision + 1);
   const percentage = formatFraction(numerator / denominator);
   return `${percentage}%`;
 };

--- a/src/utilities.test.js
+++ b/src/utilities.test.js
@@ -321,7 +321,7 @@ describe('numbersToPercentString', () => {
     denominator = 7;
     precision = 4;
     const percent = numbersToPercentString(numerator, denominator, precision);
-    expect(percent).toBe('42.86%');
+    expect(percent).toBe('42.85%');
   });
 });
 


### PR DESCRIPTION
The `formatFraction` function was including intermediate zeros because `toPrecision` only counts significant digits. This change performs precision at a string level so that we can return a consistent output.