### PR TITLE
New search header

### DIFF
--- a/src/Components/BidTracker/BidTrackerCard/__snapshots__/BidTrackerCard.test.jsx.snap
+++ b/src/Components/BidTracker/BidTrackerCard/__snapshots__/BidTrackerCard.test.jsx.snap
@@ -191,6 +191,7 @@ exports[`BidTrackerCardComponent matches snapshot 1`] = `
                 "representation": "[00180000] OMS (DCM) (Addis Ababa, Ethiopia)",
               },
             ],
+            "grade": "03",
             "id": 1,
             "is_cdo": false,
             "skills": Array [

--- a/src/Components/BidTracker/BidTrackerCardContainer/__snapshots__/BidTrackerCardContainer.test.jsx.snap
+++ b/src/Components/BidTracker/BidTrackerCardContainer/__snapshots__/BidTrackerCardContainer.test.jsx.snap
@@ -75,6 +75,7 @@ exports[`BidTrackerCardContainerComponent matches snapshot when priorityExists i
             "representation": "[00180000] OMS (DCM) (Addis Ababa, Ethiopia)",
           },
         ],
+        "grade": "03",
         "id": 1,
         "is_cdo": false,
         "skills": Array [

--- a/src/Components/BidTracker/BidTrackerCardList/__snapshots__/BidTrackerCardList.test.jsx.snap
+++ b/src/Components/BidTracker/BidTrackerCardList/__snapshots__/BidTrackerCardList.test.jsx.snap
@@ -77,6 +77,7 @@ exports[`BidTrackerCardListComponent matches snapshot 1`] = `
             "representation": "[00180000] OMS (DCM) (Addis Ababa, Ethiopia)",
           },
         ],
+        "grade": "03",
         "id": 1,
         "is_cdo": false,
         "skills": Array [
@@ -175,6 +176,7 @@ exports[`BidTrackerCardListComponent matches snapshot 1`] = `
             "representation": "[00180000] OMS (DCM) (Addis Ababa, Ethiopia)",
           },
         ],
+        "grade": "03",
         "id": 1,
         "is_cdo": false,
         "skills": Array [
@@ -273,6 +275,7 @@ exports[`BidTrackerCardListComponent matches snapshot 1`] = `
             "representation": "[00180000] OMS (DCM) (Addis Ababa, Ethiopia)",
           },
         ],
+        "grade": "03",
         "id": 1,
         "is_cdo": false,
         "skills": Array [

--- a/src/Components/BidTracker/__snapshots__/BidTracker.test.jsx.snap
+++ b/src/Components/BidTracker/__snapshots__/BidTracker.test.jsx.snap
@@ -244,6 +244,7 @@ exports[`BidTrackerComponent matches snapshot 1`] = `
                 "representation": "[00180000] OMS (DCM) (Addis Ababa, Ethiopia)",
               },
             ],
+            "grade": "03",
             "id": 1,
             "is_cdo": false,
             "skills": Array [

--- a/src/Components/BidderPortfolio/BidControls/__snapshots__/BidControls.test.jsx.snap
+++ b/src/Components/BidderPortfolio/BidControls/__snapshots__/BidControls.test.jsx.snap
@@ -20,7 +20,9 @@ exports[`BidControlsComponent matches snapshot when isLoading is false 1`] = `
     >
       <SelectForm
         defaultSort=""
+        emptyOptionText="- Select -"
         id="porfolio-sort"
+        includeFirstEmptyOption={false}
         label="Sort by:"
         languages={Array []}
         onSelectOption={[Function]}
@@ -70,7 +72,9 @@ exports[`BidControlsComponent matches snapshot when isLoading is true 1`] = `
     >
       <SelectForm
         defaultSort=""
+        emptyOptionText="- Select -"
         id="porfolio-sort"
+        includeFirstEmptyOption={false}
         label="Sort by:"
         languages={Array []}
         onSelectOption={[Function]}

--- a/src/Components/BidderPortfolio/BidderPortfolioCard/__snapshots__/BidderPortfolioCard.test.jsx.snap
+++ b/src/Components/BidderPortfolio/BidderPortfolioCard/__snapshots__/BidderPortfolioCard.test.jsx.snap
@@ -30,6 +30,7 @@ exports[`BidderPortfolioCardComponent matches snapshot 1`] = `
             "representation": "[00180000] OMS (DCM) (Addis Ababa, Ethiopia)",
           },
         ],
+        "grade": "03",
         "id": 1,
         "is_cdo": false,
         "skills": Array [
@@ -79,6 +80,7 @@ exports[`BidderPortfolioCardComponent matches snapshot 1`] = `
             "representation": "[00180000] OMS (DCM) (Addis Ababa, Ethiopia)",
           },
         ],
+        "grade": "03",
         "id": 1,
         "is_cdo": false,
         "skills": Array [

--- a/src/Components/BidderPortfolio/BidderPortfolioGridItem/__snapshots__/BidderPortfolioGridItem.test.jsx.snap
+++ b/src/Components/BidderPortfolio/BidderPortfolioGridItem/__snapshots__/BidderPortfolioGridItem.test.jsx.snap
@@ -53,6 +53,7 @@ exports[`BidderPortfolioGridItemComponent matches snapshot 1`] = `
                   "representation": "[00180000] OMS (DCM) (Addis Ababa, Ethiopia)",
                 },
               ],
+              "grade": "03",
               "id": 1,
               "is_cdo": false,
               "skills": Array [
@@ -108,6 +109,7 @@ exports[`BidderPortfolioGridItemComponent matches snapshot 1`] = `
                 "representation": "[00180000] OMS (DCM) (Addis Ababa, Ethiopia)",
               },
             ],
+            "grade": "03",
             "id": 1,
             "is_cdo": false,
             "skills": Array [

--- a/src/Components/BidderPortfolio/BidderPortfolioSearch/__snapshots__/BidderPortfolioSearch.test.jsx.snap
+++ b/src/Components/BidderPortfolio/BidderPortfolioSearch/__snapshots__/BidderPortfolioSearch.test.jsx.snap
@@ -9,8 +9,8 @@ exports[`BidderPortfolioSearchComponent matches snapshot 1`] = `
   >
     <ResultsSearchHeader
       defaultKeyword=""
-      defaultLocation=""
       labelSrOnly={true}
+      onFilterChange={[Function]}
       onUpdate={[Function]}
       placeholder="Search Bidder Last Name, Skill Code..."
     />

--- a/src/Components/Footer/Footer.jsx
+++ b/src/Components/Footer/Footer.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { getAssetPath } from '../../utilities';
 import logo from '../../assets/logos/png/horizontal_color.png';
-import pkg from '../../../package.json';
 
 const dosFooterLogo = getAssetPath('/assets/img/rsz_dos-seal.png');
 const tmFooterLogo = getAssetPath('/assets/logos/png/horizontal_color_thin.png');
@@ -58,7 +57,7 @@ const Footer = () => (
             To share your feedback with us, open an issue or pull request on our <a href="https://github.com/18F/State-TalentMAP">Github Repository</a>
           </div>
           <div className="tm-footer-body-contact-item">
-            This project is a beta for Department of State | v{pkg.version}
+            This project is a beta for Department of State
           </div>
         </div>
       </div>

--- a/src/Components/Footer/__snapshots__/Footer.test.jsx.snap
+++ b/src/Components/Footer/__snapshots__/Footer.test.jsx.snap
@@ -115,8 +115,7 @@ exports[`Footer Component matches snapshot 1`] = `
         <div
           className="tm-footer-body-contact-item"
         >
-          This project is a beta for Department of State | v
-          0.1.0
+          This project is a beta for Department of State
         </div>
       </div>
     </div>

--- a/src/Components/Header/DesktopNav/__snapshots__/DesktopNav.test.jsx.snap
+++ b/src/Components/Header/DesktopNav/__snapshots__/DesktopNav.test.jsx.snap
@@ -103,6 +103,7 @@ exports[`DesktopNav matches snapshot when logged in 1`] = `
                   "representation": "[00180000] OMS (DCM) (Addis Ababa, Ethiopia)",
                 },
               ],
+              "grade": "03",
               "id": 1,
               "is_cdo": false,
               "skills": Array [

--- a/src/Components/Header/Header.jsx
+++ b/src/Components/Header/Header.jsx
@@ -13,7 +13,7 @@ import { USER_PROFILE, EMPTY_FUNCTION, ROUTER_LOCATION_OBJECT } from '../../Cons
 import GovBanner from './GovBanner/GovBanner';
 import ResultsMultiSearchHeaderContainer from '../ResultsMultiSearchHeader/ResultsMultiSearchContainer';
 import ResultsSearchHeader from '../ResultsSearchHeader';
-import { isCurrentPathIn } from '../ProfileMenu/navigation';
+import { isCurrentPath, isCurrentPathIn } from '../ProfileMenu/navigation';
 import { searchBarRoutes, searchBarRoutesForce, searchBarRoutesForceHidden } from './searchRoutes';
 import MobileNav from './MobileNav';
 import DesktopNav from './DesktopNav';
@@ -41,6 +41,10 @@ export class Header extends Component {
   onFilterChange(q) {
     const { searchbarFilters, setSearchFilters } = this.props;
     setSearchFilters({ ...searchbarFilters, ...q });
+  }
+
+  isOnResultsPage() {
+    return isCurrentPath('/results', this.props.location.pathname);
   }
 
   matchCurrentPath(historyObject) {
@@ -104,14 +108,18 @@ export class Header extends Component {
       signedInAs = userFirstName;
     }
 
+    // Apply a custom class if we're on the results page.
+    const isOnResultsPage = this.isOnResultsPage();
+    const resultsPageClass = isOnResultsPage ? 'is-on-results-page' : '';
+
     const isOnHasOwnSearchRoute = this.isOnHasOwnSearchRoute();
     const isOnForceHideSearchRoute = this.isOnForceHideSearchRoute();
     const showResultsSearchHeader =
       shouldShowSearchBar && !isOnHasOwnSearchRoute && !isOnForceHideSearchRoute;
-    const searchBarVisibilityClass = shouldShowSearchBar ? 'search-bar-visible' : 'search-bar-hidden';
+    const searchBarVisibilityClass = showResultsSearchHeader ? 'search-bar-visible' : 'search-bar-hidden';
 
     return (
-      <div className={searchBarVisibilityClass}>
+      <div className={`${searchBarVisibilityClass} ${resultsPageClass}`}>
         <header className="usa-header usa-header-extended tm-header" role="banner">
           <ToggleContent />
           <GovBanner />

--- a/src/Components/Header/Header.jsx
+++ b/src/Components/Header/Header.jsx
@@ -6,10 +6,12 @@ import { withRouter } from 'react-router';
 import { push } from 'react-router-redux';
 import ToggleContent from '../StaticDevContent/ToggleContent';
 import { userProfileFetchData } from '../../actions/userProfile';
+import { setSelectedSearchbarFilters } from '../../actions/selectedSearchbarFilters';
 import { logoutRequest } from '../../login/actions';
 import { toggleSearchBar } from '../../actions/showSearchBar';
 import { USER_PROFILE, EMPTY_FUNCTION, ROUTER_LOCATION_OBJECT } from '../../Constants/PropTypes';
 import GovBanner from './GovBanner/GovBanner';
+import ResultsMultiSearchHeaderContainer from '../ResultsMultiSearchHeader/ResultsMultiSearchContainer';
 import ResultsSearchHeader from '../ResultsSearchHeader';
 import { isCurrentPathIn } from '../ProfileMenu/navigation';
 import { searchBarRoutes, searchBarRoutesForce, searchBarRoutesForceHidden } from './searchRoutes';
@@ -25,6 +27,7 @@ export class Header extends Component {
     this.submitSearch = this.submitSearch.bind(this);
     this.isOnHasOwnSearchRoute = this.isOnHasOwnSearchRoute.bind(this);
     this.isOnForceHideSearchRoute = this.isOnForceHideSearchRoute.bind(this);
+    this.onFilterChange = this.onFilterChange.bind(this);
   }
 
   componentWillMount() {
@@ -33,6 +36,11 @@ export class Header extends Component {
     }
     this.matchCurrentPath(this.props.location);
     this.checkPath();
+  }
+
+  onFilterChange(q) {
+    const { searchbarFilters, setSearchFilters } = this.props;
+    setSearchFilters({ ...searchbarFilters, ...q });
   }
 
   matchCurrentPath(historyObject) {
@@ -83,7 +91,7 @@ export class Header extends Component {
       client: {
         token,
       },
-      shouldShowSearchBar, logout, userProfile,
+      shouldShowSearchBar, logout, userProfile, searchbarFilters,
     } = this.props;
 
     const logo = getAssetPath('/assets/logos/png/horizontal_color_thin.png');
@@ -133,10 +141,19 @@ export class Header extends Component {
         </header>
         {
           showResultsSearchHeader &&
-          <div className="results results-search-bar-homepage">
-            <ResultsSearchHeader
-              onUpdate={this.submitSearch}
-            />
+          <div className="results results-search-bar-header">
+            <MediaQuery widthType="min" breakpoint="screenMdMin">
+              <ResultsMultiSearchHeaderContainer
+                onUpdate={this.submitSearch}
+              />
+            </MediaQuery>
+            <MediaQuery widthType="max" breakpoint="screenSmMax">
+              <ResultsSearchHeader
+                onUpdate={this.submitSearch}
+                onFilterChange={this.onFilterChange}
+                defaultKeyword={searchbarFilters.q}
+              />
+            </MediaQuery>
           </div>
         }
       </div>
@@ -161,12 +178,16 @@ Header.propTypes = {
   toggleSearchBarVisibility: PropTypes.func.isRequired,
   shouldShowSearchBar: PropTypes.bool.isRequired,
   history: PropTypes.shape({}).isRequired,
+  searchbarFilters: PropTypes.shape({}),
+  setSearchFilters: PropTypes.func.isRequired,
 };
 
 Header.defaultProps = {
   client: null,
   userProfile: {},
   logout: EMPTY_FUNCTION,
+  searchbarFilters: {},
+  setSearchFilters: EMPTY_FUNCTION,
 };
 
 const mapStateToProps = state => ({
@@ -174,6 +195,7 @@ const mapStateToProps = state => ({
   client: state.client,
   userProfile: state.userProfile,
   shouldShowSearchBar: state.shouldShowSearchBar,
+  searchbarFilters: state.selectedSearchbarFilters,
 });
 
 export const mapDispatchToProps = dispatch => ({
@@ -181,6 +203,7 @@ export const mapDispatchToProps = dispatch => ({
   logout: () => dispatch(logoutRequest()),
   onNavigateTo: dest => dispatch(push(dest)),
   toggleSearchBarVisibility: bool => dispatch(toggleSearchBar(bool)),
+  setSearchFilters: query => dispatch(setSelectedSearchbarFilters(query)),
 });
 
 const connected = connect(mapStateToProps, mapDispatchToProps)(withRouter(Header));

--- a/src/Components/Header/Header.test.jsx
+++ b/src/Components/Header/Header.test.jsx
@@ -74,6 +74,26 @@ describe('Header', () => {
     sinon.assert.calledOnce(spy);
   });
 
+  it('can call the onFilterChange function', () => {
+    const spy = sinon.spy();
+    const header = shallow(
+      <Header
+        client={client}
+        login={loginObject}
+        fetchData={() => {}}
+        isAuthorized={() => true}
+        onNavigateTo={() => {}}
+        location={location}
+        toggleSearchBarVisibility={() => {}}
+        shouldShowSearchBar
+        history={history}
+        setSearchFilters={spy}
+      />,
+    );
+    header.instance().onFilterChange({ q: 'search' });
+    sinon.assert.calledOnce(spy);
+  });
+
   it('refreshes data on history change', () => {
     const wrapper = shallow(
       <Header
@@ -134,6 +154,7 @@ describe('mapDispatchToProps', () => {
     fetchData: ['?q'],
     onNavigateTo: ['/profile'],
     toggleSearchBarVisibility: [true],
+    setSearchFilters: [{}],
   };
   testDispatchFunctions(mapDispatchToProps, config);
 });

--- a/src/Components/Header/MobileNav/MobileNav.jsx
+++ b/src/Components/Header/MobileNav/MobileNav.jsx
@@ -31,7 +31,7 @@ const MobileNav = ({ user, logout, showLogin }) => (
           <span className="usa-unstyled-list mobile-nav-only">
             <hr />
             <li>
-              <Link to="/profile">Profile</Link>
+              <Link to="/profile/dashboard/">Profile</Link>
             </li>
             <li>
               {

--- a/src/Components/Header/MobileNav/__snapshots__/MobileNav.test.jsx.snap
+++ b/src/Components/Header/MobileNav/__snapshots__/MobileNav.test.jsx.snap
@@ -69,7 +69,7 @@ exports[`MobileNav matches snapshot when showLogin is false 1`] = `
           <li>
             <Link
               replace={false}
-              to="/profile"
+              to="/profile/dashboard/"
             >
               Profile
             </Link>
@@ -160,7 +160,7 @@ exports[`MobileNav matches snapshot when showLogin is true 1`] = `
           <li>
             <Link
               replace={false}
-              to="/profile"
+              to="/profile/dashboard/"
             >
               Profile
             </Link>

--- a/src/Components/Header/__snapshots__/Header.test.jsx.snap
+++ b/src/Components/Header/__snapshots__/Header.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Header matches snapshot when logged in 1`] = `
 <div
-  className="search-bar-visible"
+  className="search-bar-hidden is-on-results-page"
 >
   <header
     className="usa-header usa-header-extended tm-header"
@@ -74,7 +74,7 @@ exports[`Header matches snapshot when logged in 1`] = `
 
 exports[`Header matches snapshot when logged out 1`] = `
 <div
-  className="search-bar-visible"
+  className="search-bar-hidden is-on-results-page"
 >
   <header
     className="usa-header usa-header-extended tm-header"

--- a/src/Components/HomePageFiltersSection/HomePageFiltersContainer/HomePageFilters/__snapshots__/HomePageFilters.test.jsx.snap
+++ b/src/Components/HomePageFiltersSection/HomePageFiltersContainer/HomePageFilters/__snapshots__/HomePageFilters.test.jsx.snap
@@ -23,6 +23,8 @@ exports[`HomePageFiltersComponent matches snapshot 1`] = `
           ]
         }
         isLoading={false}
+        label="Terms"
+        labelSrOnly={false}
         onFilterSelect={[Function]}
         userSkills={Array []}
       />

--- a/src/Components/HomePageFiltersSection/HomePageFiltersContainer/__snapshots__/HomePageFiltersContainer.test.jsx.snap
+++ b/src/Components/HomePageFiltersSection/HomePageFiltersContainer/__snapshots__/HomePageFiltersContainer.test.jsx.snap
@@ -26,6 +26,28 @@ exports[`HomePageFiltersContainerComponent matches snapshot 1`] = `
           "description": "skill",
         },
       },
+      Object {
+        "data": Array [
+          Object {
+            "code": "2",
+            "custom_description": "2",
+          },
+        ],
+        "item": Object {
+          "description": "grade",
+        },
+      },
+      Object {
+        "data": Array [
+          Object {
+            "code": "bur",
+            "custom_description": "bureau",
+          },
+        ],
+        "item": Object {
+          "description": "region",
+        },
+      },
     ]
   }
   isLoading={false}

--- a/src/Components/HomePageFiltersSection/SkillCodeFilter/SkillCodeFilter.jsx
+++ b/src/Components/HomePageFiltersSection/SkillCodeFilter/SkillCodeFilter.jsx
@@ -42,21 +42,26 @@ class SkillCodeFilter extends Component {
   }
 
   render() {
-    const { filters, isLoading } = this.props;
+    const { filters, isLoading, label, labelSrOnly } = this.props;
     const { selectedOptions } = this.state;
     const options = wrapFilters(filters);
     const sortedOptions = options.sort(propSort('custom_description'));
+    const labelClass = labelSrOnly ? 'usa-sr-only' : '';
     return (
-      <Select
-        multi
-        value={selectedOptions.value}
-        searchable={false}
-        options={sortedOptions}
-        onChange={this.handleChange}
-        closeOnSelect={false}
-        placeholder="Select one or multiple Skill Codes"
-        isLoading={isLoading}
-      />
+      <div>
+        <label htmlFor="skill-multi-select" className={labelClass}>{label}</label>
+        <Select
+          id="skill-multi-select"
+          multi
+          value={selectedOptions.value}
+          searchable={false}
+          options={sortedOptions}
+          onChange={this.handleChange}
+          closeOnSelect={false}
+          placeholder="Select Skill Codes"
+          isLoading={isLoading}
+        />
+      </div>
     );
   }
 }
@@ -66,11 +71,15 @@ SkillCodeFilter.propTypes = {
   onFilterSelect: PropTypes.func.isRequired,
   isLoading: PropTypes.bool,
   userSkills: USER_SKILL_CODE_ARRAY,
+  label: PropTypes.string,
+  labelSrOnly: PropTypes.bool,
 };
 
 SkillCodeFilter.defaultProps = {
   isLoading: false,
   userSkills: [],
+  label: 'Terms',
+  labelSrOnly: false,
 };
 
 export default SkillCodeFilter;

--- a/src/Components/HomePageFiltersSection/SkillCodeFilter/__snapshots__/SkillCodeFilter.test.jsx.snap
+++ b/src/Components/HomePageFiltersSection/SkillCodeFilter/__snapshots__/SkillCodeFilter.test.jsx.snap
@@ -1,61 +1,70 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SkillCodeFilterComponent matches snapshot 1`] = `
-<Select
-  arrowRenderer={[Function]}
-  autosize={true}
-  backspaceRemoves={true}
-  backspaceToRemoveMessage="Press backspace to remove {label}"
-  clearAllText="Clear all"
-  clearRenderer={[Function]}
-  clearValueText="Clear value"
-  clearable={true}
-  closeOnSelect={false}
-  deleteRemoves={true}
-  delimiter=","
-  disabled={false}
-  escapeClearsValue={true}
-  filterOptions={[Function]}
-  ignoreAccents={true}
-  ignoreCase={true}
-  inputProps={Object {}}
-  isLoading={false}
-  joinValues={false}
-  labelKey="label"
-  matchPos="any"
-  matchProp="any"
-  menuBuffer={0}
-  menuRenderer={[Function]}
-  multi={true}
-  noResultsText="No results found"
-  onBlurResetsInput={true}
-  onChange={[Function]}
-  onCloseResetsInput={true}
-  onSelectResetsInput={true}
-  openOnClick={true}
-  optionComponent={[Function]}
-  options={
-    Array [
-      Object {
-        "code": "1",
-        "custom_description": "1",
-        "label": "1",
-        "value": "1",
-      },
-    ]
-  }
-  pageSize={5}
-  placeholder="Select one or multiple Skill Codes"
-  removeSelected={true}
-  required={false}
-  rtl={false}
-  scrollMenuIntoView={true}
-  searchable={false}
-  simpleValue={false}
-  tabSelectsValue={true}
-  trimFilter={true}
-  value={Array []}
-  valueComponent={[Function]}
-  valueKey="value"
-/>
+<div>
+  <label
+    className=""
+    htmlFor="skill-multi-select"
+  >
+    Terms
+  </label>
+  <Select
+    arrowRenderer={[Function]}
+    autosize={true}
+    backspaceRemoves={true}
+    backspaceToRemoveMessage="Press backspace to remove {label}"
+    clearAllText="Clear all"
+    clearRenderer={[Function]}
+    clearValueText="Clear value"
+    clearable={true}
+    closeOnSelect={false}
+    deleteRemoves={true}
+    delimiter=","
+    disabled={false}
+    escapeClearsValue={true}
+    filterOptions={[Function]}
+    id="skill-multi-select"
+    ignoreAccents={true}
+    ignoreCase={true}
+    inputProps={Object {}}
+    isLoading={false}
+    joinValues={false}
+    labelKey="label"
+    matchPos="any"
+    matchProp="any"
+    menuBuffer={0}
+    menuRenderer={[Function]}
+    multi={true}
+    noResultsText="No results found"
+    onBlurResetsInput={true}
+    onChange={[Function]}
+    onCloseResetsInput={true}
+    onSelectResetsInput={true}
+    openOnClick={true}
+    optionComponent={[Function]}
+    options={
+      Array [
+        Object {
+          "code": "1",
+          "custom_description": "1",
+          "label": "1",
+          "value": "1",
+        },
+      ]
+    }
+    pageSize={5}
+    placeholder="Select Skill Codes"
+    removeSelected={true}
+    required={false}
+    rtl={false}
+    scrollMenuIntoView={true}
+    searchable={false}
+    simpleValue={false}
+    tabSelectsValue={true}
+    trimFilter={true}
+    value={Array []}
+    valueComponent={[Function]}
+    valueKey="value"
+  />
+</div>
 `;

--- a/src/Components/HomePageFiltersSection/__snapshots__/HomePageFiltersSection.test.jsx.snap
+++ b/src/Components/HomePageFiltersSection/__snapshots__/HomePageFiltersSection.test.jsx.snap
@@ -32,6 +32,28 @@ exports[`HomePageFiltersSectionComponent matches snapshot 1`] = `
               "description": "skill",
             },
           },
+          Object {
+            "data": Array [
+              Object {
+                "code": "2",
+                "custom_description": "2",
+              },
+            ],
+            "item": Object {
+              "description": "grade",
+            },
+          },
+          Object {
+            "data": Array [
+              Object {
+                "code": "bur",
+                "custom_description": "bureau",
+              },
+            ],
+            "item": Object {
+              "description": "region",
+            },
+          },
         ]
       }
       isLoading={false}

--- a/src/Components/ProfileDashboard/UserProfile/__snapshots__/UserProfile.test.jsx.snap
+++ b/src/Components/ProfileDashboard/UserProfile/__snapshots__/UserProfile.test.jsx.snap
@@ -30,6 +30,7 @@ exports[`UserProfileComponent matches snapshot 1`] = `
             "representation": "[00180000] OMS (DCM) (Addis Ababa, Ethiopia)",
           },
         ],
+        "grade": "03",
         "id": 1,
         "is_cdo": false,
         "skills": Array [
@@ -80,6 +81,7 @@ exports[`UserProfileComponent matches snapshot 1`] = `
             "representation": "[00180000] OMS (DCM) (Addis Ababa, Ethiopia)",
           },
         ],
+        "grade": "03",
         "id": 1,
         "is_cdo": false,
         "skills": Array [

--- a/src/Components/ProfileDashboard/__snapshots__/ProfileDashboard.test.jsx.snap
+++ b/src/Components/ProfileDashboard/__snapshots__/ProfileDashboard.test.jsx.snap
@@ -50,6 +50,7 @@ exports[`ProfileDashboardComponent matches snapshot when loaded 1`] = `
                     "representation": "[00180000] OMS (DCM) (Addis Ababa, Ethiopia)",
                   },
                 ],
+                "grade": "03",
                 "id": 1,
                 "is_cdo": false,
                 "skills": Array [

--- a/src/Components/ResultsControls/__snapshots__/ResultsControls.test.jsx.snap
+++ b/src/Components/ResultsControls/__snapshots__/ResultsControls.test.jsx.snap
@@ -21,7 +21,9 @@ exports[`ResultsControlsComponent matches snapshot 1`] = `
     >
       <SelectForm
         defaultSort=""
+        emptyOptionText="- Select -"
         id="sort"
+        includeFirstEmptyOption={false}
         label="Sort by:"
         languages={Array []}
         onSelectOption={[Function]}
@@ -40,7 +42,9 @@ exports[`ResultsControlsComponent matches snapshot 1`] = `
     >
       <SelectForm
         defaultSort={10}
+        emptyOptionText="- Select -"
         id="pageSize"
+        includeFirstEmptyOption={false}
         label="Results:"
         languages={Array []}
         onSelectOption={[Function]}

--- a/src/Components/ResultsMultiSearchHeader/ResultsMultiSearchContainer/ResultsMultiSearchContainer.jsx
+++ b/src/Components/ResultsMultiSearchHeader/ResultsMultiSearchContainer/ResultsMultiSearchContainer.jsx
@@ -1,0 +1,122 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { push } from 'react-router-redux';
+import queryString from 'query-string';
+import PropTypes from 'prop-types';
+import { setSelectedSearchbarFilters } from '../../../actions/selectedSearchbarFilters';
+import { FILTERS_PARENT, USER_PROFILE, EMPTY_FUNCTION } from '../../../Constants/PropTypes';
+import { filtersFetchData } from '../../../actions/filters/filters';
+import ResultsMultiSearchHeader from '../ResultsMultiSearchHeader';
+
+class ResultsMultiSearchHeaderContainer extends Component {
+  constructor(props) {
+    super(props);
+    this.onSubmit = this.onSubmit.bind(this);
+    this.onFilterChange = this.onFilterChange.bind(this);
+    this.state = {
+      query: {
+        q: '',
+      },
+    };
+  }
+
+  componentWillMount() {
+    const { fetchFilters, filters } = this.props;
+    // Have the filters already been fetched?
+    // if so, we'll pass back the saved filters
+    // as a param, which tells our filters action
+    // to not perform AJAX, and simply compare
+    // the query params against the filters
+    if (filters.hasFetched) {
+      fetchFilters(filters, {}, filters);
+    } else { // if not, we'll perform AJAX
+      fetchFilters(filters, {});
+    }
+  }
+
+  onFilterChange(q) {
+    const { searchbarFilters, setSearchFilters } = this.props;
+    setSearchFilters({ ...searchbarFilters, ...q });
+  }
+
+  onSubmit(q) {
+    const query = q;
+    const stringifiedFilterValues = {};
+    // Form query object by iterating through keys.
+    Object.keys(query).forEach((key) => {
+      // Is there a value for the key?
+      if (query[key] && query[key].length) {
+        // If it's an array, split it. Else, simply return the string.
+        const isArray = Array.isArray(query[key]);
+        if (isArray) {
+          stringifiedFilterValues[key] = query[key].join();
+        } else {
+          stringifiedFilterValues[key] = query[key];
+        }
+      }
+      // If there's no value for a key, delete it from the object.
+      if (!stringifiedFilterValues[key] || !stringifiedFilterValues[key].length) {
+        delete stringifiedFilterValues[key];
+      }
+    });
+    // Stringify the object
+    const qString = queryString.stringify(stringifiedFilterValues);
+    // Navigate to results with the formed query.
+    this.props.onNavigateTo(`/results?${qString}`);
+  }
+
+  render() {
+    const { filters, userProfile, userProfileIsLoading, filtersIsLoading,
+      searchbarFilters } = this.props;
+    return (
+      <ResultsMultiSearchHeader
+        filters={filters.filters}
+        filtersIsLoading={filtersIsLoading}
+        userProfile={userProfile}
+        userProfileIsLoading={userProfileIsLoading}
+        onSubmit={this.onSubmit}
+        onFilterChange={this.onFilterChange}
+        defaultFilters={searchbarFilters}
+      />
+    );
+  }
+}
+
+ResultsMultiSearchHeaderContainer.propTypes = {
+  filters: FILTERS_PARENT,
+  filtersIsLoading: PropTypes.bool,
+  fetchFilters: PropTypes.func.isRequired,
+  userProfile: USER_PROFILE.isRequired,
+  userProfileIsLoading: PropTypes.bool,
+  onNavigateTo: PropTypes.func.isRequired,
+  setSearchFilters: PropTypes.func.isRequired,
+  searchbarFilters: PropTypes.shape({}),
+};
+
+ResultsMultiSearchHeaderContainer.defaultProps = {
+  filters: { filters: [] },
+  filtersIsLoading: false,
+  userProfile: {},
+  userProfileIsLoading: false,
+  setSearchFilters: EMPTY_FUNCTION,
+  searchbarFilters: {},
+};
+
+const mapStateToProps = state => ({
+  filters: state.filters,
+  filtersHasErrored: state.filtersHasErrored,
+  filtersIsLoading: state.filtersIsLoading,
+  selectedAccordion: state.selectedAccordion,
+  userProfile: state.userProfile,
+  userProfileIsLoading: state.userProfileIsLoading,
+  searchbarFilters: state.selectedSearchbarFilters,
+});
+
+export const mapDispatchToProps = dispatch => ({
+  fetchFilters: (items, queryParams, savedFilters) =>
+    dispatch(filtersFetchData(items, queryParams, savedFilters)),
+  onNavigateTo: dest => dispatch(push(dest)),
+  setSearchFilters: query => dispatch(setSelectedSearchbarFilters(query)),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(ResultsMultiSearchHeaderContainer);

--- a/src/Components/ResultsMultiSearchHeader/ResultsMultiSearchContainer/ResultsMultiSearchContainer.test.jsx
+++ b/src/Components/ResultsMultiSearchHeader/ResultsMultiSearchContainer/ResultsMultiSearchContainer.test.jsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import sinon from 'sinon';
+import { shallow } from 'enzyme';
+import TestUtils from 'react-dom/test-utils';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { testDispatchFunctions } from '../../../testUtilities/testUtilities';
+import ResultsMultiSearchContainer, { mapDispatchToProps } from './ResultsMultiSearchContainer';
+import filters from '../../../__mocks__/filtersArray';
+import { bidderUserObject } from '../../../__mocks__/userObject';
+
+const middlewares = [thunk];
+const mockStore = configureStore(middlewares);
+
+describe('ResultsMultiSearchContainer', () => {
+  const props = {
+    filters: { filters },
+    userProfile: bidderUserObject,
+    fetchFilters: () => {},
+    onNavigateTo: () => {},
+  };
+
+  it('is defined', () => {
+    const wrapper = TestUtils.renderIntoDocument(
+      <Provider {...props} store={mockStore({})}><MemoryRouter>
+        <ResultsMultiSearchContainer />
+      </MemoryRouter></Provider>);
+    expect(wrapper).toBeDefined();
+  });
+
+  it('can call the onFilterChange function', () => {
+    const spy = sinon.spy();
+    const wrapper = shallow(
+      <ResultsMultiSearchContainer.WrappedComponent
+        {...props}
+        setSearchFilters={spy}
+      />,
+    );
+    wrapper.instance().onFilterChange({});
+    sinon.assert.calledOnce(spy);
+  });
+
+  it('can form a query with the onSubmit function', () => {
+    const url = { value: '' };
+    function navigateTo(value) { url.value = value; }
+    const wrapper = shallow(
+      <ResultsMultiSearchContainer.WrappedComponent
+        {...props}
+        onNavigateTo={navigateTo}
+      />,
+    );
+    wrapper.instance().onSubmit({ q: 'german', otherFilters: ['1', '2'], emptyFilters: [] });
+    expect(url.value).toBe('/results?otherFilters=1%2C2&q=german');
+  });
+
+  it('can perform actions upon componentWillMount', () => {
+    const fetchFiltersSpy = sinon.spy();
+    const wrapper = shallow(<ResultsMultiSearchContainer.WrappedComponent
+      {...props}
+      fetchFilters={fetchFiltersSpy}
+      filters={{ ...props.filters, hasFetched: true }}
+    />);
+    wrapper.update();
+    // define the instance
+    sinon.assert.calledOnce(fetchFiltersSpy);
+  });
+});
+
+describe('mapDispatchToProps', () => {
+  const config = {
+    fetchFilters: [{}],
+    onNavigateTo: ['/test'],
+    setSearchFilters: [{}],
+  };
+  testDispatchFunctions(mapDispatchToProps, config);
+});

--- a/src/Components/ResultsMultiSearchHeader/ResultsMultiSearchContainer/index.js
+++ b/src/Components/ResultsMultiSearchHeader/ResultsMultiSearchContainer/index.js
@@ -1,0 +1,1 @@
+export { default } from './ResultsMultiSearchContainer';

--- a/src/Components/ResultsMultiSearchHeader/ResultsMultiSearchHeader.jsx
+++ b/src/Components/ResultsMultiSearchHeader/ResultsMultiSearchHeader.jsx
@@ -81,7 +81,7 @@ class ResultsMultiSearchHeader extends Component {
       this.setState({ defaultGrade, gradeWasUpdated: true });
     }
 
-    // set grade to correct state
+    // set bureau to correct state
     if (!bureauWasUpdated && defaultBureau) {
       this.setState({ defaultBureau, bureauWasUpdated: true });
     }

--- a/src/Components/ResultsMultiSearchHeader/ResultsMultiSearchHeader.jsx
+++ b/src/Components/ResultsMultiSearchHeader/ResultsMultiSearchHeader.jsx
@@ -1,0 +1,231 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import FontAwesome from 'react-fontawesome';
+import { FILTER_ITEMS_ARRAY, USER_PROFILE, EMPTY_FUNCTION } from '../../Constants/PropTypes';
+import SearchBar from '../SearchBar/SearchBar';
+import SkillCodeFilter from '../HomePageFiltersSection/SkillCodeFilter';
+import SelectForm from '../SelectForm';
+
+class ResultsMultiSearchHeader extends Component {
+  constructor(props) {
+    super(props);
+    this.onChangeText = this.onChangeText.bind(this);
+    this.submitSearch = this.submitSearch.bind(this);
+    this.onChangeGrade = this.onChangeGrade.bind(this);
+    this.onChangeBureau = this.onChangeBureau.bind(this);
+    this.onChangeSkills = this.onChangeSkills.bind(this);
+    this.filterChange = this.filterChange.bind(this);
+    this.state = {
+      q: this.props.defaultFilters.q || '',
+      skill__code__in: [],
+      bureau__code__in: null,
+      grade__code__in: null,
+      defaultGrade: null,
+      defaultBureau: null,
+      defaultQuery: '',
+      skillsWasUpdated: false,
+      gradeWasUpdated: false,
+      qWasUpdated: false,
+      bureauWasUpdated: false,
+    };
+  }
+
+  componentWillReceiveProps(props) {
+    this.setupDefaultValues(props);
+  }
+
+  onChangeSkills(e) {
+    this.setState({ skill__code__in: e, skillsWasUpdated: true }, this.filterChange);
+  }
+
+  onChangeBureau(e) {
+    this.setState({ bureau__code__in: e.target.value }, this.filterChange);
+  }
+
+  onChangeGrade(e) {
+    this.setState({ grade__code__in: e.target.value }, this.filterChange);
+  }
+
+  onChangeText(e) {
+    this.setState({ q: e.target.value, qWasUpdated: true }, this.filterChange);
+  }
+
+  // Setup default values only once so that we can mount the component while waiting
+  // for async actions to complete. We'll also save state in redux so that the component can be
+  // unmounted and remounted and maintain state. This is useful for responsively rendering this
+  // component while maintaining the selected filters. We also have to balance that
+  // with loading the user's defaults, but only on the initial page load.
+  setupDefaultValues(props) {
+    const { skillsWasUpdated, gradeWasUpdated, qWasUpdated, bureauWasUpdated } = this.state;
+    const { userProfile, defaultFilters } = props;
+
+    // set default values for our filters
+    const defaultGrade = defaultFilters.grade__code__in || userProfile.grade;
+    const defaultBureau = defaultFilters.bureau__code__in || userProfile.bureau;
+    const defaultQuery = defaultFilters.q;
+    const defaultSkills = defaultFilters.skill__code__in || userProfile.skills;
+
+    // set keyword to correct state
+    if (!qWasUpdated && defaultQuery) {
+      this.setState({
+        q: defaultQuery, qWasUpdated: true,
+      });
+    }
+
+    // set grade to correct state
+    if (!gradeWasUpdated && userProfile.grade) {
+      this.setState({
+        defaultGrade, gradeWasUpdated: true,
+      });
+    }
+
+    // set grade to correct state
+    if (!bureauWasUpdated && defaultBureau) {
+      this.setState({
+        defaultBureau, bureauWasUpdated: true,
+      });
+    }
+
+    // set skills to correct state
+    if (!skillsWasUpdated && (userProfile.skills || defaultFilters.skill__code__in)) {
+      const mappedDefaultSkills = defaultSkills.length ?
+        // map the skills as either a string or an object property 'code'
+        defaultSkills.slice().map(s => ({ code: s.code || s })) : [];
+      this.setState({
+        skill__code__in: mappedDefaultSkills,
+      });
+    }
+  }
+
+  formatQuery() {
+    const { q, skill__code__in, bureau__code__in, grade__code__in } = this.state;
+    const skills = skill__code__in.slice().map(s => s.code);
+    const query = { q, skill__code__in: skills, bureau__code__in, grade__code__in };
+    return query;
+  }
+
+  // return all the filters upon submission
+  submitSearch(e) {
+    // resolves “Form submission canceled because the form is not connected” warning
+    e.preventDefault();
+    const query = this.formatQuery();
+    this.props.onSubmit(query);
+  }
+
+  // return all the filters as an object whenever any change is made
+  filterChange() {
+    const query = this.formatQuery();
+    this.props.onFilterChange(query);
+  }
+
+  render() {
+    const { placeholder, filters, userProfile, filtersIsLoading } = this.props;
+    const { q, defaultGrade, defaultBureau, skill__code__in } = this.state;
+
+    // format skill codes
+    const skillCodes = (filters || []).find(f => f.item && f.item.description === 'skill');
+    const skillCodesData = skillCodes ? skillCodes.data : [];
+
+    // format grades
+    const grades = (filters || []).find(f => f.item && f.item.description === 'grade');
+    const mappedGrades = grades && grades.data ?
+      grades.data.slice().map(g => ({ ...g, value: g.code, text: g.code })) : [];
+
+    // format bureaus
+    const bureaus = (filters || []).find(f => f.item && f.item.description === 'region');
+    const mappedBureaus = bureaus && bureaus.data ?
+      bureaus.data.slice().map(g => ({ ...g, value: g.code, text: g.short_description })) : [];
+
+    // set the default skills
+    // eslint-disable-next-line camelcase
+    const defaultSkills = skill__code__in || userProfile.skills || [];
+    return (
+      <div className="results-search-bar padded-main-content results-multi-search">
+        <div className="usa-grid-full results-search-bar-container">
+          <form className="usa-grid-full" onSubmit={this.submitSearch} >
+            <fieldset className="usa-width-one-whole">
+              <div className="usa-grid-full">
+                <div className="usa-grid-full">
+                  <div className="usa-width-five-twelfths search-results-inputs search-keyword">
+                    <legend className="usa-grid-full">Find your next position</legend>
+                    <SearchBar
+                      id="search-keyword-field"
+                      label="Keywords"
+                      type="medium"
+                      submitText="Search"
+                      labelSrOnly
+                      noForm
+                      noButton
+                      placeholder={placeholder}
+                      onChangeText={this.onChangeText}
+                      defaultValue={q}
+                    />
+                    <div className="search-sub-text">Example: Mexico City Mexico, Political Affairs (5505), Russian 3/3...</div>
+                  </div>
+                  <div className="usa-width-one-fourth search-results-inputs search-keyword">
+                    <SkillCodeFilter
+                      label="Skill Code"
+                      isLoading={filtersIsLoading}
+                      filters={skillCodesData}
+                      onFilterSelect={this.onChangeSkills}
+                      userSkills={defaultSkills}
+                    />
+                  </div>
+                  <div className="usa-width-one-twelfth search-results-inputs search-keyword">
+                    <SelectForm
+                      id="grade-searchbar-filter"
+                      label="Grade"
+                      options={mappedGrades}
+                      defaultSort={defaultGrade}
+                      includeFirstEmptyOption
+                      onSelectOption={this.onChangeGrade}
+                      emptyOptionText=""
+                    />
+                  </div>
+                  <div className="usa-width-one-sixth search-results-inputs search-keyword">
+                    <SelectForm
+                      id="bureau-searchbar-filter"
+                      label="Bureau"
+                      options={mappedBureaus}
+                      defaultSort={defaultBureau}
+                      includeFirstEmptyOption
+                      onSelectOption={this.onChangeBureau}
+                    />
+                  </div>
+                  <div className="usa-width-one-twelfth search-submit-button">
+                    <button className="usa-button" type="submit">
+                      <FontAwesome name="search" className="label-icon" />
+                      Search
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </fieldset>
+          </form>
+        </div>
+      </div>
+    );
+  }
+}
+
+ResultsMultiSearchHeader.propTypes = {
+  onSubmit: PropTypes.func.isRequired,
+  defaultFilters: PropTypes.shape({
+    q: PropTypes.string,
+  }),
+  placeholder: PropTypes.string,
+  filters: FILTER_ITEMS_ARRAY.isRequired,
+  filtersIsLoading: PropTypes.bool,
+  userProfile: USER_PROFILE.isRequired,
+  onFilterChange: PropTypes.func,
+};
+
+ResultsMultiSearchHeader.defaultProps = {
+  defaultFilters: {},
+  filtersIsLoading: false,
+  placeholder: 'Location, Skill Code, Grade, Language, Position Number',
+  userProfile: {},
+  onFilterChange: EMPTY_FUNCTION,
+};
+
+export default ResultsMultiSearchHeader;

--- a/src/Components/ResultsMultiSearchHeader/ResultsMultiSearchHeader.test.jsx
+++ b/src/Components/ResultsMultiSearchHeader/ResultsMultiSearchHeader.test.jsx
@@ -1,0 +1,90 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import sinon from 'sinon';
+import toJSON from 'enzyme-to-json';
+import ResultsMultiSearchHeader from './ResultsMultiSearchHeader';
+
+describe('ResultsMultiSearchHeaderComponent', () => {
+  let wrapper = null;
+
+  const defaultKeyword = 'keyword';
+  const defaultLocation = 'a location';
+
+  it('is defined', () => {
+    wrapper = shallow(<ResultsMultiSearchHeader
+      onUpdate={() => {}}
+    />);
+    expect(wrapper).toBeDefined();
+  });
+
+  it('can receive props', () => {
+    wrapper = shallow(<ResultsMultiSearchHeader
+      onUpdate={() => {}}
+      defaultKeyword={defaultKeyword}
+      defaultLocation={defaultLocation}
+    />);
+    expect(wrapper.instance().props.defaultKeyword).toBe(defaultKeyword);
+  });
+
+  it('can call the onUpdate function', () => {
+    const spy = sinon.spy();
+    wrapper = shallow(<ResultsMultiSearchHeader
+      onUpdate={spy}
+      defaultKeyword={defaultKeyword}
+      defaultLocation={defaultLocation}
+    />);
+    wrapper.instance().props.onUpdate();
+    expect(spy.calledOnce).toBe(true);
+  });
+
+  it('can call the changeText function', () => {
+    wrapper = shallow(<ResultsMultiSearchHeader
+      onUpdate={() => {}}
+      defaultKeyword={defaultKeyword}
+      defaultLocation={defaultLocation}
+    />);
+    wrapper.instance().changeText('q', { target: { value: defaultKeyword } });
+    expect(wrapper.instance().state.q.value).toBe(defaultKeyword);
+  });
+
+  it('can call the onChangeQueryText function', () => {
+    wrapper = shallow(<ResultsMultiSearchHeader
+      onUpdate={() => {}}
+      defaultKeyword={defaultKeyword}
+      defaultLocation={defaultLocation}
+    />);
+    wrapper.instance().onChangeQueryText({ target: { value: defaultKeyword } });
+    expect(wrapper.instance().state.q.value).toBe(defaultKeyword);
+  });
+
+  it('can submit a search', () => {
+    const spy = sinon.spy();
+    wrapper = shallow(<ResultsMultiSearchHeader
+      onUpdate={spy}
+      defaultKeyword={defaultKeyword}
+      defaultLocation={defaultLocation}
+    />);
+    wrapper.find('form').simulate('submit', { preventDefault: () => {} });
+    expect(spy.calledOnce).toBe(true);
+  });
+
+  it('can call the submitSearch function', () => {
+    const spy = sinon.spy();
+    wrapper = shallow(<ResultsMultiSearchHeader
+      onUpdate={spy}
+      defaultKeyword={defaultKeyword}
+      defaultLocation={defaultLocation}
+    />);
+    wrapper.instance().submitSearch({ preventDefault: () => {} });
+    expect(spy.calledOnce).toBe(true);
+  });
+
+  it('matches snapshot', () => {
+    wrapper = shallow(<ResultsMultiSearchHeader
+      onUpdate={() => {}}
+      defaultKeyword={defaultKeyword}
+      defaultLocation={defaultLocation}
+    />);
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/Components/ResultsMultiSearchHeader/ResultsMultiSearchHeader.test.jsx
+++ b/src/Components/ResultsMultiSearchHeader/ResultsMultiSearchHeader.test.jsx
@@ -3,87 +3,153 @@ import React from 'react';
 import sinon from 'sinon';
 import toJSON from 'enzyme-to-json';
 import ResultsMultiSearchHeader from './ResultsMultiSearchHeader';
+import filters from '../../__mocks__/filtersArray';
+import { bidderUserObject } from '../../__mocks__/userObject';
 
 describe('ResultsMultiSearchHeaderComponent', () => {
   let wrapper = null;
 
-  const defaultKeyword = 'keyword';
-  const defaultLocation = 'a location';
+  const props = {
+    filters,
+    userProfile: bidderUserObject,
+    onUpdate: () => {},
+    onSubmit: () => {},
+  };
+
+  // for testing prop updates
+  const updatedProps = {
+    userProfile: bidderUserObject,
+    defaultFilters: {
+      grade__code__in: '03',
+      bureau__code__in: '04',
+      q: 'german',
+      // test that it can accept codes as a string or an object
+      skill__code__in: [{ code: '05' }, '06'],
+    },
+  };
 
   it('is defined', () => {
     wrapper = shallow(<ResultsMultiSearchHeader
-      onUpdate={() => {}}
+      {...props}
     />);
     expect(wrapper).toBeDefined();
   });
 
   it('can receive props', () => {
     wrapper = shallow(<ResultsMultiSearchHeader
-      onUpdate={() => {}}
-      defaultKeyword={defaultKeyword}
-      defaultLocation={defaultLocation}
+      {...props}
     />);
-    expect(wrapper.instance().props.defaultKeyword).toBe(defaultKeyword);
+    expect(wrapper.instance().props.filters).toBe(props.filters);
   });
 
   it('can call the onUpdate function', () => {
     const spy = sinon.spy();
     wrapper = shallow(<ResultsMultiSearchHeader
+      {...props}
       onUpdate={spy}
-      defaultKeyword={defaultKeyword}
-      defaultLocation={defaultLocation}
     />);
     wrapper.instance().props.onUpdate();
     expect(spy.calledOnce).toBe(true);
   });
 
-  it('can call the changeText function', () => {
+  it('can call the onChangeText function', () => {
     wrapper = shallow(<ResultsMultiSearchHeader
-      onUpdate={() => {}}
-      defaultKeyword={defaultKeyword}
-      defaultLocation={defaultLocation}
+      {...props}
     />);
-    wrapper.instance().changeText('q', { target: { value: defaultKeyword } });
-    expect(wrapper.instance().state.q.value).toBe(defaultKeyword);
+    wrapper.instance().onChangeText({ target: { value: 'test' } });
+    expect(wrapper.instance().state.q).toBe('test');
   });
 
-  it('can call the onChangeQueryText function', () => {
+  it('can call the onChangeBureau function', () => {
     wrapper = shallow(<ResultsMultiSearchHeader
-      onUpdate={() => {}}
-      defaultKeyword={defaultKeyword}
-      defaultLocation={defaultLocation}
+      {...props}
     />);
-    wrapper.instance().onChangeQueryText({ target: { value: defaultKeyword } });
-    expect(wrapper.instance().state.q.value).toBe(defaultKeyword);
+    wrapper.instance().onChangeBureau({ target: { value: 'bureau' } });
+    expect(wrapper.instance().state.bureau__code__in).toBe('bureau');
+  });
+
+  it('can call the onChangeGrade function', () => {
+    wrapper = shallow(<ResultsMultiSearchHeader
+      {...props}
+    />);
+    wrapper.instance().onChangeGrade({ target: { value: 'grade' } });
+    expect(wrapper.instance().state.grade__code__in).toBe('grade');
   });
 
   it('can submit a search', () => {
     const spy = sinon.spy();
     wrapper = shallow(<ResultsMultiSearchHeader
-      onUpdate={spy}
-      defaultKeyword={defaultKeyword}
-      defaultLocation={defaultLocation}
+      {...props}
+      onSubmit={spy}
     />);
     wrapper.find('form').simulate('submit', { preventDefault: () => {} });
-    expect(spy.calledOnce).toBe(true);
+    sinon.assert.calledOnce(spy);
+  });
+
+  it('can perform a callback on update', () => {
+    const spy = sinon.spy();
+    wrapper = shallow(<ResultsMultiSearchHeader
+      {...props}
+      onFilterChange={spy}
+    />);
+    wrapper.instance().onChangeSkills([]);
+    sinon.assert.calledOnce(spy);
   });
 
   it('can call the submitSearch function', () => {
     const spy = sinon.spy();
     wrapper = shallow(<ResultsMultiSearchHeader
-      onUpdate={spy}
-      defaultKeyword={defaultKeyword}
-      defaultLocation={defaultLocation}
+      {...props}
+      onSubmit={spy}
     />);
     wrapper.instance().submitSearch({ preventDefault: () => {} });
     expect(spy.calledOnce).toBe(true);
   });
 
+  it('can setup default values when defaultFilters are provided', () => {
+    wrapper = shallow(<ResultsMultiSearchHeader
+      {...props}
+    />);
+    const instance = wrapper.instance();
+    instance.setupDefaultValues(updatedProps);
+    // values from defaultFilters should be used
+    expect(instance.state.defaultGrade).toBe(updatedProps.defaultFilters.grade__code__in);
+    expect(instance.state.defaultBureau).toBe(updatedProps.defaultFilters.bureau__code__in);
+    expect(instance.state.q).toBe(updatedProps.defaultFilters.q);
+  });
+
+  it('can perform actions upon componentWillReceiveProps', () => {
+    wrapper = shallow(<ResultsMultiSearchHeader
+      {...props}
+    />);
+    // define the instance
+    const spy = sinon.spy(wrapper.instance(), 'componentWillReceiveProps');
+    wrapper.update();
+    wrapper.instance().componentWillReceiveProps(updatedProps);
+    sinon.assert.calledOnce(spy);
+  });
+
+  it('can return a formatted queries', () => {
+    wrapper = shallow(<ResultsMultiSearchHeader
+      {...props}
+    />);
+    const query = wrapper.instance().formatQuery();
+    expect(query).toBeDefined();
+  });
+
+  it('can setup default values when no defaultFilters are provided', () => {
+    wrapper = shallow(<ResultsMultiSearchHeader
+      {...props}
+    />);
+    const instance = wrapper.instance();
+    instance.setupDefaultValues(updatedProps);
+    // values from userProfile should be used
+    expect(instance.state.defaultGrade).toBe(updatedProps.userProfile.grade);
+  });
+
   it('matches snapshot', () => {
     wrapper = shallow(<ResultsMultiSearchHeader
-      onUpdate={() => {}}
-      defaultKeyword={defaultKeyword}
-      defaultLocation={defaultLocation}
+      {...props}
     />);
     expect(toJSON(wrapper)).toMatchSnapshot();
   });

--- a/src/Components/ResultsMultiSearchHeader/__snapshots__/ResultsMultiSearchHeader.test.jsx.snap
+++ b/src/Components/ResultsMultiSearchHeader/__snapshots__/ResultsMultiSearchHeader.test.jsx.snap
@@ -1,0 +1,137 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ResultsMultiSearchHeaderComponent matches snapshot 1`] = `
+<div
+  className="results-search-bar padded-main-content results-multi-search"
+>
+  <div
+    className="usa-grid-full results-search-bar-container"
+  >
+    <form
+      className="usa-grid-full"
+      onSubmit={[Function]}
+    >
+      <fieldset
+        className="usa-width-one-whole"
+      >
+        <div
+          className="usa-grid-full"
+        >
+          <div
+            className="usa-grid-full"
+          >
+            <div
+              className="usa-width-five-twelfths search-results-inputs search-keyword"
+            >
+              <legend
+                className="usa-grid-full"
+              >
+                Find your next position
+              </legend>
+              <SearchBar
+                alertText="Disabled"
+                defaultValue=""
+                id="multi-search-keyword-field"
+                label="Keywords"
+                labelSrOnly={true}
+                noButton={true}
+                noForm={true}
+                onChangeText={[Function]}
+                onSubmitSearch={[Function]}
+                placeholder="Location, Skill Code, Grade, Language, Position Number"
+                submitDisabled={false}
+                submitText="Search"
+                type="medium"
+              />
+              <div
+                className="search-sub-text"
+              >
+                Example: Mexico City Mexico, Political Affairs (5505), Russian 3/3...
+              </div>
+            </div>
+            <div
+              className="usa-width-one-fourth search-results-inputs search-keyword"
+            >
+              <SkillCodeFilter
+                filters={
+                  Array [
+                    Object {
+                      "code": "1",
+                      "custom_description": "1",
+                    },
+                  ]
+                }
+                isLoading={false}
+                label="Skill Code"
+                labelSrOnly={false}
+                onFilterSelect={[Function]}
+                userSkills={Array []}
+              />
+            </div>
+            <div
+              className="usa-width-one-twelfth search-results-inputs search-keyword"
+            >
+              <SelectForm
+                defaultSort={null}
+                emptyOptionText=""
+                id="grade-searchbar-filter"
+                includeFirstEmptyOption={true}
+                label="Grade"
+                languages={Array []}
+                onSelectOption={[Function]}
+                options={
+                  Array [
+                    Object {
+                      "code": "2",
+                      "custom_description": "2",
+                      "text": "2",
+                      "value": "2",
+                    },
+                  ]
+                }
+              />
+            </div>
+            <div
+              className="usa-width-one-sixth search-results-inputs search-keyword"
+            >
+              <SelectForm
+                defaultSort={null}
+                emptyOptionText="- Select -"
+                id="bureau-searchbar-filter"
+                includeFirstEmptyOption={true}
+                label="Bureau"
+                languages={Array []}
+                onSelectOption={[Function]}
+                options={
+                  Array [
+                    Object {
+                      "code": "bur",
+                      "custom_description": "bureau",
+                      "text": undefined,
+                      "value": "bur",
+                    },
+                  ]
+                }
+              />
+            </div>
+            <div
+              className="usa-width-one-twelfth search-submit-button"
+            >
+              <button
+                className="usa-button"
+                type="submit"
+              >
+                <FontAwesome
+                  className="label-icon"
+                  name="search"
+                />
+                Search
+              </button>
+            </div>
+          </div>
+        </div>
+      </fieldset>
+    </form>
+  </div>
+</div>
+`;

--- a/src/Components/ResultsMultiSearchHeader/index.js
+++ b/src/Components/ResultsMultiSearchHeader/index.js
@@ -1,0 +1,1 @@
+export { default } from './ResultsMultiSearchHeader';

--- a/src/Components/ResultsSearchHeader/ResultsSearchHeader.jsx
+++ b/src/Components/ResultsSearchHeader/ResultsSearchHeader.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import FontAwesome from 'react-fontawesome';
+import { EMPTY_FUNCTION } from '../../Constants/PropTypes';
 import SearchBar from '../SearchBar/SearchBar';
 
 class ResultsSearchHeader extends Component {
@@ -72,8 +73,9 @@ ResultsSearchHeader.propTypes = {
 };
 
 ResultsSearchHeader.defaultProps = {
+  onUpdate: EMPTY_FUNCTION,
+  onFilterChange: EMPTY_FUNCTION,
   defaultKeyword: '',
-  defaultLocation: '',
   labelSrOnly: false,
   placeholder: 'Location, Skill Code, Grade, Language, Position Number',
 };

--- a/src/Components/ResultsSearchHeader/ResultsSearchHeader.jsx
+++ b/src/Components/ResultsSearchHeader/ResultsSearchHeader.jsx
@@ -23,12 +23,14 @@ class ResultsSearchHeader extends Component {
     this.props.onUpdate({ q: q.value });
   }
   changeText(type, e) {
+    const { q } = this.state;
     this.setState({ [type]: { value: e.target.value } });
+    this.props.onFilterChange({ q: q.value });
   }
   render() {
     const { defaultKeyword, labelSrOnly, placeholder } = this.props;
     return (
-      <div className="results-search-bar padded-main-content">
+      <div className="results-search-bar padded-main-content results-single-search">
         <div className="usa-grid-full results-search-bar-container">
           <form className="usa-grid-full" onSubmit={this.submitSearch} >
             <fieldset className="usa-width-five-sixths">
@@ -66,6 +68,7 @@ ResultsSearchHeader.propTypes = {
   defaultKeyword: PropTypes.string,
   labelSrOnly: PropTypes.bool,
   placeholder: PropTypes.string,
+  onFilterChange: PropTypes.func.isRequired,
 };
 
 ResultsSearchHeader.defaultProps = {

--- a/src/Components/ResultsSearchHeader/ResultsSearchHeader.test.jsx
+++ b/src/Components/ResultsSearchHeader/ResultsSearchHeader.test.jsx
@@ -8,20 +8,31 @@ describe('ResultsSearchHeaderComponent', () => {
   let wrapper = null;
 
   const defaultKeyword = 'keyword';
-  const defaultLocation = 'a location';
+
+  const props = {
+    onUpdate: () => {},
+    defaultKeyword,
+    onFilterChange: () => {},
+  };
 
   it('is defined', () => {
     wrapper = shallow(<ResultsSearchHeader
-      onUpdate={() => {}}
+      {...props}
+    />);
+    expect(wrapper).toBeDefined();
+  });
+
+  it('is defined without a defaultKeyword', () => {
+    wrapper = shallow(<ResultsSearchHeader
+      {...props}
+      defaultKeyword={null}
     />);
     expect(wrapper).toBeDefined();
   });
 
   it('can receive props', () => {
     wrapper = shallow(<ResultsSearchHeader
-      onUpdate={() => {}}
-      defaultKeyword={defaultKeyword}
-      defaultLocation={defaultLocation}
+      {...props}
     />);
     expect(wrapper.instance().props.defaultKeyword).toBe(defaultKeyword);
   });
@@ -29,9 +40,8 @@ describe('ResultsSearchHeaderComponent', () => {
   it('can call the onUpdate function', () => {
     const spy = sinon.spy();
     wrapper = shallow(<ResultsSearchHeader
+      {...props}
       onUpdate={spy}
-      defaultKeyword={defaultKeyword}
-      defaultLocation={defaultLocation}
     />);
     wrapper.instance().props.onUpdate();
     expect(spy.calledOnce).toBe(true);
@@ -39,9 +49,8 @@ describe('ResultsSearchHeaderComponent', () => {
 
   it('can call the changeText function', () => {
     wrapper = shallow(<ResultsSearchHeader
+      {...props}
       onUpdate={() => {}}
-      defaultKeyword={defaultKeyword}
-      defaultLocation={defaultLocation}
     />);
     wrapper.instance().changeText('q', { target: { value: defaultKeyword } });
     expect(wrapper.instance().state.q.value).toBe(defaultKeyword);
@@ -49,9 +58,8 @@ describe('ResultsSearchHeaderComponent', () => {
 
   it('can call the onChangeQueryText function', () => {
     wrapper = shallow(<ResultsSearchHeader
+      {...props}
       onUpdate={() => {}}
-      defaultKeyword={defaultKeyword}
-      defaultLocation={defaultLocation}
     />);
     wrapper.instance().onChangeQueryText({ target: { value: defaultKeyword } });
     expect(wrapper.instance().state.q.value).toBe(defaultKeyword);
@@ -60,9 +68,8 @@ describe('ResultsSearchHeaderComponent', () => {
   it('can submit a search', () => {
     const spy = sinon.spy();
     wrapper = shallow(<ResultsSearchHeader
+      {...props}
       onUpdate={spy}
-      defaultKeyword={defaultKeyword}
-      defaultLocation={defaultLocation}
     />);
     wrapper.find('form').simulate('submit', { preventDefault: () => {} });
     expect(spy.calledOnce).toBe(true);
@@ -71,9 +78,8 @@ describe('ResultsSearchHeaderComponent', () => {
   it('can call the submitSearch function', () => {
     const spy = sinon.spy();
     wrapper = shallow(<ResultsSearchHeader
+      {...props}
       onUpdate={spy}
-      defaultKeyword={defaultKeyword}
-      defaultLocation={defaultLocation}
     />);
     wrapper.instance().submitSearch({ preventDefault: () => {} });
     expect(spy.calledOnce).toBe(true);
@@ -81,9 +87,7 @@ describe('ResultsSearchHeaderComponent', () => {
 
   it('matches snapshot', () => {
     wrapper = shallow(<ResultsSearchHeader
-      onUpdate={() => {}}
-      defaultKeyword={defaultKeyword}
-      defaultLocation={defaultLocation}
+      {...props}
     />);
     expect(toJSON(wrapper)).toMatchSnapshot();
   });

--- a/src/Components/ResultsSearchHeader/__snapshots__/ResultsSearchHeader.test.jsx.snap
+++ b/src/Components/ResultsSearchHeader/__snapshots__/ResultsSearchHeader.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ResultsSearchHeaderComponent matches snapshot 1`] = `
 <div
-  className="results-search-bar padded-main-content"
+  className="results-search-bar padded-main-content results-single-search"
 >
   <div
     className="usa-grid-full results-search-bar-container"

--- a/src/Components/SearchFilters/LanguageFilter/__snapshots__/LanguageFilter.test.jsx.snap
+++ b/src/Components/SearchFilters/LanguageFilter/__snapshots__/LanguageFilter.test.jsx.snap
@@ -15,7 +15,9 @@ exports[`LanguageFilterComponent matches snapshot 1`] = `
   >
     <SelectForm
       defaultSort=""
+      emptyOptionText="- Select -"
       id="speaking-language-dropdown"
+      includeFirstEmptyOption={false}
       label="Speaking"
       languages={Array []}
       onSelectOption={[Function]}
@@ -70,7 +72,9 @@ exports[`LanguageFilterComponent matches snapshot 1`] = `
     />
     <SelectForm
       defaultSort=""
+      emptyOptionText="- Select -"
       id="reading-language-dropdown"
+      includeFirstEmptyOption={false}
       label="Reading"
       languages={Array []}
       onSelectOption={[Function]}

--- a/src/Components/SelectForm/SelectForm.jsx
+++ b/src/Components/SelectForm/SelectForm.jsx
@@ -11,6 +11,10 @@ class SelectForm extends Component {
   }
 
   componentWillReceiveProps(props) {
+    this.setDefaultValue(props);
+  }
+
+  setDefaultValue(props) {
     const { selection } = this.state;
     const { includeFirstEmptyOption, defaultSort } = props;
     if (includeFirstEmptyOption && !selection.length && defaultSort) {

--- a/src/Components/SelectForm/SelectForm.jsx
+++ b/src/Components/SelectForm/SelectForm.jsx
@@ -10,13 +10,21 @@ class SelectForm extends Component {
     };
   }
 
+  componentWillReceiveProps(props) {
+    const { selection } = this.state;
+    const { includeFirstEmptyOption, defaultSort } = props;
+    if (includeFirstEmptyOption && !selection.length && defaultSort) {
+      this.selectOption({ target: { value: defaultSort } });
+    }
+  }
+
   selectOption(e) {
     const selection = e.target.value;
     this.setState({ selection });
     this.props.onSelectOption(e);
   }
   render() {
-    const { id, label, options } = this.props;
+    const { id, label, options, includeFirstEmptyOption, emptyOptionText } = this.props;
     const optionList = options.map(option =>
       (
         <option
@@ -38,6 +46,16 @@ class SelectForm extends Component {
           value={this.state.selection}
         >
           {
+            includeFirstEmptyOption &&
+            <option
+              key="empty-option"
+              disabled="true"
+              value=""
+            >
+              {emptyOptionText}
+            </option>
+          }
+          {
             optionList
           }
         </select>
@@ -52,12 +70,16 @@ SelectForm.propTypes = {
   defaultSort: PropTypes.node,
   options: SORT_BY_ARRAY.isRequired,
   onSelectOption: PropTypes.func.isRequired,
+  includeFirstEmptyOption: PropTypes.bool,
+  emptyOptionText: PropTypes.string,
 };
 
 SelectForm.defaultProps = {
   languages: [],
   defaultSort: '',
   onSelectOption: EMPTY_FUNCTION,
+  includeFirstEmptyOption: false,
+  emptyOptionText: '- Select -',
 };
 
 export default SelectForm;

--- a/src/Components/SelectForm/SelectForm.test.jsx
+++ b/src/Components/SelectForm/SelectForm.test.jsx
@@ -42,6 +42,21 @@ describe('SelectForm', () => {
     expect(wrapper.instance().state.selection).toBe(25);
   });
 
+  it('can perform actions upon componentWillReceiveProps', () => {
+    wrapper = shallow(<SelectForm
+      id={1}
+      label="Some label"
+      defaultSort=""
+      options={POSITION_SEARCH_SORTS.options}
+      onSelectOption={() => {}}
+    />);
+    // define the instance
+    const spy = sinon.spy(wrapper.instance(), 'componentWillReceiveProps');
+    wrapper.update();
+    wrapper.instance().componentWillReceiveProps({ includeFirstEmptyOption: true, defaultSort: '2' });
+    sinon.assert.calledOnce(spy);
+  });
+
   it('can call the selectOption function', () => {
     wrapper = shallow(<SelectForm
       id={1}
@@ -56,6 +71,21 @@ describe('SelectForm', () => {
     const handleSelectSpy = sinon.spy(instance, 'selectOption');
     instance.selectOption({ target: { value: '' } });
     sinon.assert.calledOnce(handleSelectSpy);
+  });
+
+  it('can call the setDefaultValue function', () => {
+    wrapper = shallow(<SelectForm
+      id={1}
+      label="Some label"
+      defaultSort=""
+      options={POSITION_SEARCH_SORTS.options}
+      onSelectOption={() => {}}
+    />);
+    // define the instance
+    const instance = wrapper.instance();
+    const defaultSort = POSITION_SEARCH_SORTS.options[1];
+    instance.setDefaultValue({ includeFirstEmptyOption: true, defaultSort });
+    expect(instance.state.selection).toBe(defaultSort);
   });
 
   it('matches snapshot', () => {

--- a/src/Containers/HomePage/HomePage.jsx
+++ b/src/Containers/HomePage/HomePage.jsx
@@ -5,7 +5,6 @@ import { ENDPOINT_PARAMS } from '../../Constants/EndpointParams';
 import NewPositionsSection from '../../Components/NewPositionsSection';
 import HighlightedPositionsSection from '../../Components/HighlightedPositionsSection';
 import Spinner from '../../Components/Spinner';
-import HomePageFiltersSection from '../../Components/HomePageFiltersSection';
 
 class HomePage extends Component {
   constructor(props) {
@@ -27,6 +26,7 @@ class HomePage extends Component {
   }
 
   render() {
+    /* eslint-disable */
     const { homePagePositions,
       homePagePositionsIsLoading, homePagePositionsHasErrored,
       userProfile, toggleFavorite, toggleBid, bidList,
@@ -34,11 +34,6 @@ class HomePage extends Component {
       userProfileFavoritePositionHasErrored, filters } = this.props;
     return (
       <div className="home content-container">
-        <HomePageFiltersSection
-          filters={filters}
-          isLoading={filtersIsLoading}
-          userSkills={userProfile.skills}
-        />
         <div className="homepage-positions-section-container">
           {
             homePagePositionsIsLoading && !homePagePositionsHasErrored &&

--- a/src/Containers/HomePage/HomePage.jsx
+++ b/src/Containers/HomePage/HomePage.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { HOME_PAGE_POSITIONS, USER_PROFILE, BID_RESULTS, FILTER_ITEMS_ARRAY } from '../../Constants/PropTypes';
+import { HOME_PAGE_POSITIONS, USER_PROFILE, BID_RESULTS } from '../../Constants/PropTypes';
 import { ENDPOINT_PARAMS } from '../../Constants/EndpointParams';
 import NewPositionsSection from '../../Components/NewPositionsSection';
 import HighlightedPositionsSection from '../../Components/HighlightedPositionsSection';
@@ -26,12 +26,11 @@ class HomePage extends Component {
   }
 
   render() {
-    /* eslint-disable */
     const { homePagePositions,
       homePagePositionsIsLoading, homePagePositionsHasErrored,
       userProfile, toggleFavorite, toggleBid, bidList,
-      userProfileFavoritePositionIsLoading, filtersIsLoading,
-      userProfileFavoritePositionHasErrored, filters } = this.props;
+      userProfileFavoritePositionIsLoading,
+      userProfileFavoritePositionHasErrored } = this.props;
     return (
       <div className="home content-container">
         <div className="homepage-positions-section-container">
@@ -80,8 +79,6 @@ HomePage.propTypes = {
   userProfileFavoritePositionHasErrored: PropTypes.bool.isRequired,
   toggleBid: PropTypes.func.isRequired,
   bidList: BID_RESULTS.isRequired,
-  filters: FILTER_ITEMS_ARRAY.isRequired,
-  filtersIsLoading: PropTypes.bool,
 };
 
 HomePage.defaultProps = {

--- a/src/__mocks__/filtersArray.js
+++ b/src/__mocks__/filtersArray.js
@@ -1,5 +1,7 @@
 const filters = [
   { item: { description: 'language' }, data: [{ code: 'a', custom_description: 'letter A' }] },
-  { item: { description: 'skill' }, data: [{ code: '1', custom_description: '1' }] }];
+  { item: { description: 'skill' }, data: [{ code: '1', custom_description: '1' }] },
+  { item: { description: 'grade' }, data: [{ code: '2', custom_description: '2' }] },
+  { item: { description: 'region' }, data: [{ code: 'bur', custom_description: 'bureau' }] }];
 
 export default filters;

--- a/src/__mocks__/userObject.js
+++ b/src/__mocks__/userObject.js
@@ -1,5 +1,6 @@
 export const bidderUserObject = {
   id: 1,
+  grade: '03',
   skills: [
     {
       id: 63,

--- a/src/actions/filters/filters.js
+++ b/src/actions/filters/filters.js
@@ -24,7 +24,7 @@ export function filtersFetchDataSuccess(filters) {
   };
 }
 
-export function filtersFetchData(items, queryParams, savedResponses) {
+export function filtersFetchData(items = { filters: [] }, queryParams = {}, savedResponses) {
   return (dispatch) => {
     dispatch(filtersIsLoading(true));
     dispatch(filtersHasErrored(false));

--- a/src/actions/selectedSearchbarFilters.js
+++ b/src/actions/selectedSearchbarFilters.js
@@ -1,0 +1,12 @@
+export function selectedSearchbarFilters(filters) {
+  return {
+    type: 'SELECTED_SEARCHBAR_FILTERS',
+    filters,
+  };
+}
+
+export function setSelectedSearchbarFilters(filters) {
+  return (dispatch) => {
+    dispatch(selectedSearchbarFilters(filters));
+  };
+}

--- a/src/actions/selectedSearchbarFilters.test.js
+++ b/src/actions/selectedSearchbarFilters.test.js
@@ -1,0 +1,13 @@
+import { setupAsyncMocks } from '../testUtilities/testUtilities';
+import * as actions from './selectedSearchbarFilters';
+
+const { mockStore } = setupAsyncMocks();
+
+const searchBarFilters = {};
+
+describe('selected searchbar filters', () => {
+  it('can fetch selected searchbar filters', () => {
+    const store = mockStore({ filters: searchBarFilters });
+    store.dispatch(actions.setSelectedSearchbarFilters(searchBarFilters));
+  });
+});

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -28,6 +28,7 @@ import profileMenu from './profileMenu';
 import showGlossary from './showGlossary';
 import glossary from './glossary';
 import bidStatistics from './bidStatistics';
+import selectedSearchbarFilters from './selectedSearchbarFilters';
 
 
 export default combineReducers({
@@ -56,6 +57,7 @@ export default combineReducers({
   ...showGlossary,
   ...glossary,
   ...bidStatistics,
+  ...selectedSearchbarFilters,
   router: routerReducer,
   form,
   client,

--- a/src/reducers/selectedSearchbarFilters/index.js
+++ b/src/reducers/selectedSearchbarFilters/index.js
@@ -1,0 +1,3 @@
+import selectedSearchbarFilters from './selectedSearchbarFilters';
+
+export default { selectedSearchbarFilters };

--- a/src/reducers/selectedSearchbarFilters/selectedSearchbarFilters.js
+++ b/src/reducers/selectedSearchbarFilters/selectedSearchbarFilters.js
@@ -1,0 +1,11 @@
+export default function selectedSearchbarFilters(state = {}, action) {
+  switch (action.type) {
+    case 'SELECTED_SEARCHBAR_FILTERS':
+      return action.filters;
+    // reset on route change
+    case '@@router/LOCATION_CHANGE':
+      return {};
+    default:
+      return state;
+  }
+}

--- a/src/reducers/selectedSearchbarFilters/selectedSearchbarFilters.js
+++ b/src/reducers/selectedSearchbarFilters/selectedSearchbarFilters.js
@@ -4,7 +4,7 @@ export default function selectedSearchbarFilters(state = {}, action) {
       return action.filters;
     // reset on route change
     case '@@router/LOCATION_CHANGE':
-      return {};
+      return { q: '' };
     default:
       return state;
   }

--- a/src/reducers/selectedSearchbarFilters/selectedSearchbarFilters.test.js
+++ b/src/reducers/selectedSearchbarFilters/selectedSearchbarFilters.test.js
@@ -1,0 +1,9 @@
+import selectedSearchbarFilters from './selectedSearchbarFilters';
+
+describe('reducers', () => {
+  const searchBarFilters = {};
+
+  it('can set reducer SELECTED_ACCORDION', () => {
+    expect(selectedSearchbarFilters('', { type: 'SELECTED_SEARCHBAR_FILTERS', searchBarFilters })).toBe(searchBarFilters);
+  });
+});

--- a/src/reducers/selectedSearchbarFilters/selectedSearchbarFilters.test.js
+++ b/src/reducers/selectedSearchbarFilters/selectedSearchbarFilters.test.js
@@ -3,7 +3,7 @@ import selectedSearchbarFilters from './selectedSearchbarFilters';
 describe('reducers', () => {
   const searchBarFilters = {};
 
-  it('can set reducer SELECTED_ACCORDION', () => {
-    expect(selectedSearchbarFilters('', { type: 'SELECTED_SEARCHBAR_FILTERS', searchBarFilters })).toBe(searchBarFilters);
+  it('can set reducer SELECTED_SEARCHBAR', () => {
+    expect(selectedSearchbarFilters({}, { type: 'SELECTED_SEARCHBAR_FILTERS', filters: searchBarFilters })).toBe(searchBarFilters);
   });
 });

--- a/src/sass/_bidderPortfolio.scss
+++ b/src/sass/_bidderPortfolio.scss
@@ -48,7 +48,7 @@
   }
 
   .search-submit-button {
-    margin-top: 14px;
+    margin-top: 15px;
   }
 
   .total-results-container {

--- a/src/sass/_header.scss
+++ b/src/sass/_header.scss
@@ -40,6 +40,14 @@
     a {
       display: inline-block;
     }
+
+    @media screen and (max-width: $screen-md-max) {
+      padding-left: 20px;
+    }
+
+    @media screen and (max-width: $screen-sm-min) {
+      padding-left: 0;
+    }
   }
 
   .header-nav-desktop {

--- a/src/sass/_header.scss
+++ b/src/sass/_header.scss
@@ -166,6 +166,12 @@
   }
 }
 
+.search-bar-hidden {
+  .results-search-bar-header {
+    display: none;
+  }
+}
+
 @media screen and (min-width: $screen-md-min) {
   .search-bar-hidden {
     border-bottom: 1px solid $color-gray-light;
@@ -173,5 +179,11 @@
     .usa-nav {
       border-top: 1px solid $color-gray-light;
     }
+  }
+
+  // This is to set correct border color if the toggle-able search bar is hidden
+  // but the user is on the search results page, which has its own search bar.
+  .is-on-results-page {
+    border-bottom-color: $tm-dark-blue;
   }
 }

--- a/src/sass/_home.scss
+++ b/src/sass/_home.scss
@@ -106,7 +106,7 @@
   }
 
   .positions-section-container-right {
-    float: left;
+    float: right;
     text-align: right;
   }
 

--- a/src/sass/_resultsSearchBarContainer.scss
+++ b/src/sass/_resultsSearchBarContainer.scss
@@ -1,3 +1,5 @@
+$input-height: 40px;
+
 .results-search-bar {
   background-color: $tm-dark-blue;
   color: $color-white;
@@ -23,6 +25,10 @@
   }
 
   .label-input-wrapper {
+    input {
+      height: $input-height;
+    }
+
     width: 100%;
   }
 
@@ -33,7 +39,6 @@
   .search-results-inputs {
     float: left;
     padding: 15px 0;
-    width: 100%;
 
     input {
       border-radius: 5px;
@@ -43,7 +48,7 @@
     }
 
     label {
-      margin: 0 0 5px 5px;
+      margin: 0 0 5px;
     }
   }
 
@@ -67,7 +72,6 @@
     label {
       display: block;
       text-align: left;
-      text-transform: uppercase;
     }
   }
 
@@ -77,12 +81,97 @@
   }
 }
 
-.results-search-bar-homepage {
+.results-multi-search {
+  $font-size: 16px;
 
   color: $color-white;
+
+  select {
+    font-size: $font-size;
+    height: $input-height;
+    padding-bottom: 0;
+    padding-top: 0;
+  }
+
+  label,
+  legend {
+    font-size: $font-size;
+    font-weight: normal;
+    margin: 0 0 5px;
+  }
+
+  legend {
+    text-transform: uppercase;
+  }
+
+  .search-sub-text {
+    font-size: .7em;
+    font-style: italic;
+    margin: 5px 0 0 10px;
+    position: absolute;
+    white-space: nowrap;
+  }
+
+  .Select {
+    font-size: $font-size;
+  }
+
+  .Select-control {
+    border-radius: 0;
+    height: $input-height;
+  }
+
+  .Select-multi-value-wrapper {
+    height: $input-height - 4;
+  }
+
+  .Select-placeholder {
+    padding-top: 1px;
+  }
 
   .results-search-bar {
     background-color: $tm-dark-blue;
     height: auto;
+  }
+
+  .search-keyword {
+    position: relative;
+  }
+
+  .search-submit-button {
+    button {
+      margin-top: 5px;
+      min-width: 90px;
+      padding: 12px 10px;
+    }
+  }
+
+  @media screen and (max-width: $screen-md-max) {
+    .usa-width-one-twelfth:nth-child(3n) {
+      margin-right: 4.82916%;
+    }
+  }
+
+  @media screen and (min-width: $screen-lg-min) {
+    .search-results-inputs {
+      margin-right: 2%;
+    }
+  }
+}
+
+.results-single-search {
+
+  padding-bottom: 3px;
+
+  .results-search-bar-container {
+    padding-top: 3px;
+  }
+
+  .search-results-inputs {
+    width: 100%;
+  }
+
+  .usa-button {
+    margin-top: 3px;
   }
 }

--- a/src/sass/_resultsSearchBarContainer.scss
+++ b/src/sass/_resultsSearchBarContainer.scss
@@ -1,3 +1,6 @@
+// Overrides styles for the react-select module
+// scss-lint:disable SelectorFormat
+
 $input-height: 40px;
 
 .results-search-bar {
@@ -25,11 +28,11 @@ $input-height: 40px;
   }
 
   .label-input-wrapper {
+    width: 100%;
+
     input {
       height: $input-height;
     }
-
-    width: 100%;
   }
 
   .label-icon {
@@ -85,6 +88,7 @@ $input-height: 40px;
   $font-size: 16px;
 
   color: $color-white;
+  padding-top: 1px;
 
   select {
     font-size: $font-size;
@@ -122,7 +126,7 @@ $input-height: 40px;
   }
 
   .Select-multi-value-wrapper {
-    height: $input-height - 4;
+    height: $input-height - 5; // offset height to match
   }
 
   .Select-placeholder {
@@ -161,7 +165,7 @@ $input-height: 40px;
 
 .results-single-search {
 
-  padding-bottom: 3px;
+  padding-bottom: 2px;
 
   .results-search-bar-container {
     padding-top: 3px;

--- a/src/sass/_select.scss
+++ b/src/sass/_select.scss
@@ -10,6 +10,7 @@
 .Select--multi {
   .Select-value {
     background-color: $blue-primary;
+    border-radius: 9px;
     color: $color-white;
     font-size: .8em;
     margin-top: 8px;
@@ -28,6 +29,7 @@
   }
 
   .Select-value-icon {
+    border-right: 0;
     float: right;
   }
 

--- a/src/sass/_select.scss
+++ b/src/sass/_select.scss
@@ -6,3 +6,32 @@
   // override for accessibility
   color: $color-gray;
 }
+
+.Select--multi {
+  .Select-value {
+    background-color: $blue-primary;
+    color: $color-white;
+    font-size: .8em;
+    margin-top: 8px;
+    max-width: 220px;
+  }
+
+  .Select-value-label {
+    max-width: 90%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .Select-multi-value-wrapper {
+    overflow: scroll;
+  }
+
+  .Select-value-icon {
+    float: right;
+  }
+
+  .Select-value-icon:hover {
+    color: $color-primary-alt-light;
+  }
+}


### PR DESCRIPTION
Covers #1165, #1166 and #1167 by adding new filters to the home page search bar.

Some notes about behavior:

- MediaQuery is used to render the original search component in condensed views. However, we share state so that the search term is maintained between component mounts.
- The user's skill code and grade are used to pre-populate the filters. The current selections are also saved to a shared state to be maintained between screen width changes. However, on any route change, they are reset to the defaults (an empty search string; user's skills and grade; no bureau selected) 
- Not available on the Results page since it already has a set of filters