### PR TITLE
Sprint 14 feedback

### DIFF
--- a/src/Components/GlossaryEditor/GlossaryEditorCardList/GlossaryEditorCardList.jsx
+++ b/src/Components/GlossaryEditor/GlossaryEditorCardList/GlossaryEditorCardList.jsx
@@ -3,22 +3,29 @@ import PropTypes from 'prop-types';
 import { GROUPED_GLOSSARY_ARRAYS_OBJECT, GLOSSARY_ERROR_OBJECT, GLOSSARY_SUCCESS_OBJECT } from '../../../Constants/PropTypes';
 import LetterList from '../LetterList';
 import GroupedCardList from './GroupedCardList';
+import Alert from '../../Alert';
 
 const GlossaryEditorCardList = ({ terms, submitGlossaryTerm, submitGlossaryFirstLetter,
-availableLetters, glossaryPatchHasErrored, glossaryPatchSuccess }) => (
-  <div className="usa-grid-full">
-    <div className="usa-grid-full letter-list-container">
-      <LetterList letters={availableLetters} onClick={submitGlossaryFirstLetter} />
+availableLetters, glossaryPatchHasErrored, glossaryPatchSuccess }) => {
+  const showNoResultsAlerts = !Object.keys(terms).length;
+  return (
+    <div className="usa-grid-full">
+      <div className="usa-grid-full letter-list-container">
+        <LetterList letters={availableLetters} onClick={submitGlossaryFirstLetter} />
+      </div>
+      <GroupedCardList
+        terms={terms}
+        submitGlossaryTerm={submitGlossaryTerm}
+        groups={availableLetters}
+        glossaryPatchHasErrored={glossaryPatchHasErrored}
+        glossaryPatchSuccess={glossaryPatchSuccess}
+      />
+      { showNoResultsAlerts &&
+        <Alert title="No glossary terms within your search criteria." messages={[{ body: 'Try broadening your search or removing filters.' }]} />
+      }
     </div>
-    <GroupedCardList
-      terms={terms}
-      submitGlossaryTerm={submitGlossaryTerm}
-      groups={availableLetters}
-      glossaryPatchHasErrored={glossaryPatchHasErrored}
-      glossaryPatchSuccess={glossaryPatchSuccess}
-    />
-  </div>
-);
+  );
+};
 
 GlossaryEditorCardList.propTypes = {
   terms: GROUPED_GLOSSARY_ARRAYS_OBJECT.isRequired,

--- a/src/Components/GlossaryEditor/GlossaryEditorCardList/GlossaryEditorCardList.test.jsx
+++ b/src/Components/GlossaryEditor/GlossaryEditorCardList/GlossaryEditorCardList.test.jsx
@@ -18,9 +18,25 @@ describe('GlossaryEditorCardListComponent', () => {
     expect(wrapper).toBeDefined();
   });
 
+  it('displays an alert if there are no terms', () => {
+    const wrapper = shallow(<GlossaryEditorCardList
+      {...props}
+      terms={{}}
+    />);
+    expect(wrapper.find('Alert').exists()).toBe(true);
+  });
+
   it('matches snapshot', () => {
     const wrapper = shallow(<GlossaryEditorCardList
       {...props}
+    />);
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+
+  it('matches snapshot when there are no terms', () => {
+    const wrapper = shallow(<GlossaryEditorCardList
+      {...props}
+      terms={{}}
     />);
     expect(toJSON(wrapper)).toMatchSnapshot();
   });

--- a/src/Components/GlossaryEditor/GlossaryEditorCardList/__snapshots__/GlossaryEditorCardList.test.jsx.snap
+++ b/src/Components/GlossaryEditor/GlossaryEditorCardList/__snapshots__/GlossaryEditorCardList.test.jsx.snap
@@ -76,3 +76,46 @@ exports[`GlossaryEditorCardListComponent matches snapshot 1`] = `
   />
 </div>
 `;
+
+exports[`GlossaryEditorCardListComponent matches snapshot when there are no terms 1`] = `
+<div
+  className="usa-grid-full"
+>
+  <div
+    className="usa-grid-full letter-list-container"
+  >
+    <LetterList
+      letters={
+        Array [
+          "A",
+          "B",
+        ]
+      }
+      onClick={[Function]}
+    />
+  </div>
+  <GroupedCardList
+    glossaryPatchHasErrored={Object {}}
+    glossaryPatchSuccess={Object {}}
+    groups={
+      Array [
+        "A",
+        "B",
+      ]
+    }
+    submitGlossaryTerm={[Function]}
+    terms={Object {}}
+  />
+  <Alert
+    messages={
+      Array [
+        Object {
+          "body": "Try broadening your search or removing filters.",
+        },
+      ]
+    }
+    title="No glossary terms within your search criteria."
+    type="info"
+  />
+</div>
+`;

--- a/src/Components/TextEditor/TextEditor/TextEditor.jsx
+++ b/src/Components/TextEditor/TextEditor/TextEditor.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import Editor, { createEditorStateWithText } from 'draft-js-plugins-editor';
 import TextEditorSubmit from '../../TextEditorSubmit';
 import { EMPTY_FUNCTION } from '../../../Constants/PropTypes';
-// import InteractiveElement from '../../InteractiveElement';
 
 export default class TextEditor extends Component {
   constructor(props) {

--- a/src/Components/TextEditor/index.js
+++ b/src/Components/TextEditor/index.js
@@ -1,1 +1,2 @@
+// export the loadable component by default
 export { default } from './TextEditorLoadable';

--- a/src/Containers/GlossaryEditor/GlossaryEditor.jsx
+++ b/src/Containers/GlossaryEditor/GlossaryEditor.jsx
@@ -20,7 +20,6 @@ class GlossaryEditorContainer extends Component {
 
   submitGlossaryTerm(term) {
     const { submitGlossaryTerm } = this.props;
-    // TODO - create action and integrate with API once its implemented
     submitGlossaryTerm(term);
   }
 

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -260,8 +260,7 @@ export const wrapForMultiSelect = (options, valueProp, labelProp) => options.sli
 export const returnObjectsWherePropMatches = (sourceArray = [], compareArray = [], propToCheck) =>
   sourceArray.filter(o1 => compareArray.some(o2 => o1[propToCheck] === o2[propToCheck]));
 
-// Convert a numerator and a denominator to a percentage. Pass "inverse === true" if you want
-// the inverse, i.e. the remainder.
+// Convert a numerator and a denominator to a percentage.
 export const numbersToPercentString = (numerator, denominator, precision = 3) => {
   const formatFraction = fraction =>
     (parseFloat(fraction) * 100).toString().slice(0, precision + 1);


### PR DESCRIPTION
Updates from sprint-14 feedback. Removes some unneeded comments, adds a "no results" alert to the glossary editor, and adds a note about the default export from `TextEditor`.