### PR TITLE
Fix tests and rendering of homepage card section titles

### DIFF
--- a/src/Components/HomePagePositions/HomePagePositions.jsx
+++ b/src/Components/HomePagePositions/HomePagePositions.jsx
@@ -21,13 +21,14 @@ const HomePagePositions = ({ homePagePositions, homePagePositionsIsLoading,
   }
 
   let positionsInSkillTitle = 'Positions in Skill';
-  if (homePagePositions.isSkillCode && homePagePositions.isSkillCode.length) {
-    positionsInSkillTitle = `Positions in ${homePagePositions.isSkillCode[0].skill}`;
+  if (homePagePositions.userSkillCodePositions && homePagePositions.userSkillCodePositions.length) {
+    positionsInSkillTitle = `Positions in ${homePagePositions.userSkillCodePositions[0].skill}`;
   }
 
   let gradeTitle = 'Recently Posted Positions in Grade';
-  if (homePagePositions.isGradeAndRecent && homePagePositions.isGradeAndRecent.length) {
-    gradeTitle = `${gradeTitle} ${homePagePositions.isGradeAndRecent[0].grade}`;
+  if (homePagePositions.userGradeRecentPositions
+  && homePagePositions.userGradeRecentPositions.length) {
+    gradeTitle = `${gradeTitle} ${homePagePositions.userGradeRecentPositions[0].grade}`;
   }
 
   // set view more link for service needs

--- a/src/Components/HomePagePositions/HomePagePositions.jsx
+++ b/src/Components/HomePagePositions/HomePagePositions.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { HOME_PAGE_POSITIONS, USER_PROFILE, BID_RESULTS } from '../../Constants/PropTypes';
+import { HOME_PAGE_POSITIONS, USER_PROFILE, BID_RESULTS,
+USER_SKILL_CODE_POSITIONS, USER_GRADE_RECENT_POSITIONS, SERVICE_NEED_POSITIONS } from '../../Constants/PropTypes';
 import HomePagePositionsSection from '../HomePagePositionsSection';
 
 const HomePagePositions = ({ homePagePositions, homePagePositionsIsLoading,
@@ -21,15 +22,18 @@ const HomePagePositions = ({ homePagePositions, homePagePositionsIsLoading,
   }
 
   let positionsInSkillTitle = 'Positions in Skill';
-  if (homePagePositions.userSkillCodePositions && homePagePositions.userSkillCodePositions.length) {
-    positionsInSkillTitle = `Positions in ${homePagePositions.userSkillCodePositions[0].skill}`;
+  const userSkillCodePositions = homePagePositions[USER_SKILL_CODE_POSITIONS];
+  if (userSkillCodePositions && userSkillCodePositions.length) {
+    positionsInSkillTitle = `Positions in ${homePagePositions[USER_SKILL_CODE_POSITIONS][0].skill}`;
   }
 
   let gradeTitle = 'Recently Posted Positions in Grade';
-  if (homePagePositions.userGradeRecentPositions
-  && homePagePositions.userGradeRecentPositions.length) {
+  const userGradeRecentPositions = homePagePositions[USER_GRADE_RECENT_POSITIONS];
+  if (userGradeRecentPositions && userGradeRecentPositions.length) {
     gradeTitle = `${gradeTitle} ${homePagePositions.userGradeRecentPositions[0].grade}`;
   }
+
+  const serviceNeedPositions = homePagePositions[SERVICE_NEED_POSITIONS];
 
   // set view more link for service needs
   const serviceNeedsLink = '/results?post__has_service_needs_differential=true';
@@ -47,7 +51,7 @@ const HomePagePositions = ({ homePagePositions, homePagePositionsIsLoading,
           toggleFavorite={toggleFavorite}
           userProfileFavoritePositionIsLoading={userProfileFavoritePositionIsLoading}
           userProfileFavoritePositionHasErrored={userProfileFavoritePositionHasErrored}
-          positions={homePagePositions.serviceNeedPositions}
+          positions={serviceNeedPositions}
           isLoading={homePagePositionsIsLoading}
           toggleBid={toggleBid}
           bidList={bidList}
@@ -62,7 +66,7 @@ const HomePagePositions = ({ homePagePositions, homePagePositionsIsLoading,
           toggleFavorite={toggleFavorite}
           userProfileFavoritePositionIsLoading={userProfileFavoritePositionIsLoading}
           userProfileFavoritePositionHasErrored={userProfileFavoritePositionHasErrored}
-          positions={homePagePositions.userSkillCodePositions}
+          positions={userSkillCodePositions}
           isLoading={homePagePositionsIsLoading}
           toggleBid={toggleBid}
           bidList={bidList}
@@ -77,7 +81,7 @@ const HomePagePositions = ({ homePagePositions, homePagePositionsIsLoading,
           toggleFavorite={toggleFavorite}
           userProfileFavoritePositionIsLoading={userProfileFavoritePositionIsLoading}
           userProfileFavoritePositionHasErrored={userProfileFavoritePositionHasErrored}
-          positions={homePagePositions.userGradeRecentPositions}
+          positions={userGradeRecentPositions}
           isLoading={homePagePositionsIsLoading}
           toggleBid={toggleBid}
           bidList={bidList}

--- a/src/Components/HomePagePositions/HomePagePositions.test.jsx
+++ b/src/Components/HomePagePositions/HomePagePositions.test.jsx
@@ -2,12 +2,15 @@ import { shallow } from 'enzyme';
 import toJSON from 'enzyme-to-json';
 import React from 'react';
 import HomePagePositions from './HomePagePositions';
-import { DEFAULT_HOME_PAGE_POSITIONS } from '../../Constants/DefaultProps';
 import bidListObject from '../../__mocks__/bidListObject';
 
 describe('HomePageComponent', () => {
   const props = {
-    homePagePositions: DEFAULT_HOME_PAGE_POSITIONS,
+    homePagePositions: {
+      userSkillCodePositions: [{ id: 1 }],
+      serviceNeedPositions: [{ id: 2 }],
+      userGradeRecentPositions: [{ id: 3 }],
+    },
     toggleFavorite: () => {},
     userProfileFavoritePositionIsLoading: false,
     userProfileFavoritePositionHasErrored: false,
@@ -28,6 +31,9 @@ describe('HomePageComponent', () => {
       {...props}
     />);
     expect(wrapper.instance().props.bidList).toBe(props.bidList);
+    expect(wrapper.find('HomePagePositionsSection').at(0).prop('positions').length).toBeGreaterThan(0);
+    expect(wrapper.find('HomePagePositionsSection').at(1).prop('positions').length).toBeGreaterThan(0);
+    expect(wrapper.find('HomePagePositionsSection').at(2).prop('positions').length).toBeGreaterThan(0);
   });
 
   it('matches snapshot', () => {
@@ -39,9 +45,9 @@ describe('HomePageComponent', () => {
     const wrapper = shallow(<HomePagePositions
       {...props}
       homePagePositions={{
-        isGradeAndRecent: [{ id: 1 }],
-        isServiceNeed: [{ id: 2 }],
-        isSkillCode: [{ id: 3 }],
+        userGradeRecentPositions: [{ id: 1 }],
+        serviceNeedPositions: [{ id: 2 }],
+        userSkillCodePositions: [{ id: 3 }],
       }}
     />);
     expect(toJSON(wrapper)).toMatchSnapshot();

--- a/src/Components/HomePagePositions/HomePagePositions.test.jsx
+++ b/src/Components/HomePagePositions/HomePagePositions.test.jsx
@@ -3,13 +3,15 @@ import toJSON from 'enzyme-to-json';
 import React from 'react';
 import HomePagePositions from './HomePagePositions';
 import bidListObject from '../../__mocks__/bidListObject';
+import { USER_SKILL_CODE_POSITIONS, USER_GRADE_RECENT_POSITIONS, SERVICE_NEED_POSITIONS } from '../../Constants/PropTypes';
+import { DEFAULT_HOME_PAGE_POSITIONS } from '../../Constants/DefaultProps';
 
 describe('HomePageComponent', () => {
   const props = {
     homePagePositions: {
-      userSkillCodePositions: [{ id: 1 }],
-      serviceNeedPositions: [{ id: 2 }],
-      userGradeRecentPositions: [{ id: 3 }],
+      [USER_SKILL_CODE_POSITIONS]: [{ id: 1, skill: 'skill 1' }],
+      [USER_GRADE_RECENT_POSITIONS]: [{ id: 2, grade: '03' }],
+      [SERVICE_NEED_POSITIONS]: [{ id: 3 }],
     },
     toggleFavorite: () => {},
     userProfileFavoritePositionIsLoading: false,
@@ -36,19 +38,25 @@ describe('HomePageComponent', () => {
     expect(wrapper.find('HomePagePositionsSection').at(2).prop('positions').length).toBeGreaterThan(0);
   });
 
-  it('matches snapshot', () => {
-    const wrapper = shallow(<HomePagePositions {...props} />);
+  it('can set position section titles correctly', () => {
+    const wrapper = shallow(<HomePagePositions
+      {...props}
+    />);
+    expect(wrapper.find('HomePagePositionsSection').at(1).prop('title')).toBe('Positions in skill 1');
+    expect(wrapper.find('HomePagePositionsSection').at(2).prop('title')).toBe('Recently Posted Positions in Grade 03');
+  });
+
+  it('matches snapshot when the positions arrays are empty', () => {
+    const wrapper = shallow(<HomePagePositions
+      {...props}
+      homePagePositions={DEFAULT_HOME_PAGE_POSITIONS}
+    />);
     expect(toJSON(wrapper)).toMatchSnapshot();
   });
 
   it('matches snapshot when position arrays are filled', () => {
     const wrapper = shallow(<HomePagePositions
       {...props}
-      homePagePositions={{
-        userGradeRecentPositions: [{ id: 1 }],
-        serviceNeedPositions: [{ id: 2 }],
-        userSkillCodePositions: [{ id: 3 }],
-      }}
     />);
     expect(toJSON(wrapper)).toMatchSnapshot();
   });

--- a/src/Components/HomePagePositions/__snapshots__/HomePagePositions.test.jsx.snap
+++ b/src/Components/HomePagePositions/__snapshots__/HomePagePositions.test.jsx.snap
@@ -139,6 +139,13 @@ exports[`HomePageComponent matches snapshot 1`] = `
       icon="bolt"
       isLoading={false}
       maxLength="3"
+      positions={
+        Array [
+          Object {
+            "id": 2,
+          },
+        ]
+      }
       title="Service Needs Positions"
       toggleBid={[Function]}
       toggleFavorite={[Function]}
@@ -279,7 +286,14 @@ exports[`HomePageComponent matches snapshot 1`] = `
       icon="briefcase"
       isLoading={false}
       maxLength="3"
-      title="Positions in Skill"
+      positions={
+        Array [
+          Object {
+            "id": 1,
+          },
+        ]
+      }
+      title="Positions in undefined"
       toggleBid={[Function]}
       toggleFavorite={[Function]}
       type="default"
@@ -419,7 +433,14 @@ exports[`HomePageComponent matches snapshot 1`] = `
       icon="flag"
       isLoading={false}
       maxLength="3"
-      title="Recently Posted Positions in Grade"
+      positions={
+        Array [
+          Object {
+            "id": 3,
+          },
+        ]
+      }
+      title="Recently Posted Positions in Grade undefined"
       toggleBid={[Function]}
       toggleFavorite={[Function]}
       type="default"
@@ -570,6 +591,13 @@ exports[`HomePageComponent matches snapshot when position arrays are filled 1`] 
       icon="bolt"
       isLoading={false}
       maxLength="3"
+      positions={
+        Array [
+          Object {
+            "id": 2,
+          },
+        ]
+      }
       title="Service Needs Positions"
       toggleBid={[Function]}
       toggleFavorite={[Function]}
@@ -710,6 +738,13 @@ exports[`HomePageComponent matches snapshot when position arrays are filled 1`] 
       icon="briefcase"
       isLoading={false}
       maxLength="3"
+      positions={
+        Array [
+          Object {
+            "id": 3,
+          },
+        ]
+      }
       title="Positions in undefined"
       toggleBid={[Function]}
       toggleFavorite={[Function]}
@@ -850,6 +885,13 @@ exports[`HomePageComponent matches snapshot when position arrays are filled 1`] 
       icon="flag"
       isLoading={false}
       maxLength="3"
+      positions={
+        Array [
+          Object {
+            "id": 1,
+          },
+        ]
+      }
       title="Recently Posted Positions in Grade undefined"
       toggleBid={[Function]}
       toggleFavorite={[Function]}

--- a/src/Components/HomePagePositions/__snapshots__/HomePagePositions.test.jsx.snap
+++ b/src/Components/HomePagePositions/__snapshots__/HomePagePositions.test.jsx.snap
@@ -1,457 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`HomePageComponent matches snapshot 1`] = `
-<div
-  className="homepage-positions-section-container"
->
-  <div
-    className="usa-grid-full homepage-positions-section-container-inner padded-main-content"
-  >
-    <HomePagePositionsSection
-      bidList={
-        Array [
-          Object {
-            "approved_date": "2017-12-20",
-            "bidcycle": "Demo BidCycle 2017-10-31 16:00:51.254762",
-            "closed_date": "2017-12-20",
-            "create_date": "2017-12-20",
-            "declined_date": "2017-12-20",
-            "draft_date": "2017-12-20",
-            "handshake_accepted_date": "2017-12-20",
-            "handshake_declined_date": "2017-12-20",
-            "handshake_offered_date": "2017-12-20",
-            "id": 3,
-            "in_panel_date": "2017-12-20",
-            "is_priority": false,
-            "position": Object {
-              "bureau": "(AF) BUREAU OF AFRICAN AFFAIRS",
-              "create_date": "2015-08-05",
-              "grade": "03",
-              "id": 226,
-              "position_number": "10035561",
-              "post": Object {
-                "id": 199,
-                "location": "Curacao",
-              },
-              "skill": "POLITICAL AND ECONOMIC AFFAIRS (6050)",
-              "title": "POLITICAL/ECONOMIC OFFICER",
-              "update_date": "2017-06-08",
-            },
-            "reviewer": Object {
-              "email": "woodwardw@state.gov",
-              "first_name": "Wendy",
-              "is_cdo": false,
-              "last_name": "Woodward",
-              "phone_number": "555-555-5555",
-              "username": "woodwardw",
-            },
-            "scheduled_panel_date": "2017-12-20",
-            "status": "approved",
-            "submitted_date": "2017-12-20",
-            "update_date": "2017-12-20",
-            "user": "rehmant",
-          },
-          Object {
-            "approved_date": "2017-12-20",
-            "bidcycle": "Demo BidCycle 2017-10-31 16:00:51.254762",
-            "closed_date": "2017-12-20",
-            "create_date": "2017-12-20",
-            "declined_date": "2017-12-20",
-            "draft_date": "2017-12-20",
-            "handshake_accepted_date": "2017-12-20",
-            "handshake_declined_date": "2017-12-20",
-            "handshake_offered_date": "2017-12-20",
-            "id": 1,
-            "in_panel_date": "2017-12-20",
-            "is_priority": true,
-            "position": Object {
-              "bureau": "(AF) BUREAU OF AFRICAN AFFAIRS",
-              "create_date": "2006-09-20",
-              "grade": "05",
-              "id": 1,
-              "position_number": "00003026",
-              "post": Object {
-                "id": 235,
-                "location": "Freetown, Sierra Leone",
-              },
-              "skill": "OFFICE MANAGEMENT (9017)",
-              "title": "OMS (COM)",
-              "update_date": "2017-06-08",
-            },
-            "reviewer": Object {
-              "email": "woodwardw@state.gov",
-              "first_name": "Wendy",
-              "is_cdo": false,
-              "last_name": "Woodward",
-              "phone_number": "555-555-5555",
-              "username": "woodwardw",
-            },
-            "scheduled_panel_date": "2017-12-20",
-            "status": "closed",
-            "submitted_date": "2017-12-20",
-            "update_date": "2017-12-20",
-            "user": "rehmant",
-          },
-          Object {
-            "approved_date": "2017-12-20",
-            "bidcycle": "Demo BidCycle 2017-10-31 16:00:51.254762",
-            "closed_date": "2017-12-20",
-            "create_date": "2017-12-20",
-            "declined_date": "2017-12-20",
-            "draft_date": "2017-12-20",
-            "handshake_accepted_date": "2017-12-20",
-            "handshake_declined_date": "2017-12-20",
-            "handshake_offered_date": "2017-12-20",
-            "id": 2,
-            "in_panel_date": "2017-12-20",
-            "is_priority": false,
-            "position": Object {
-              "bureau": "(AF) BUREAU OF AFRICAN AFFAIRS",
-              "create_date": "2006-09-20",
-              "grade": "04",
-              "id": 84,
-              "position_number": "56001600",
-              "post": Object {
-                "id": 195,
-                "location": "The Hague, Netherlands",
-              },
-              "skill": "SECURITY (2501)",
-              "title": "SPECIAL AGENT",
-              "update_date": "2017-06-08",
-            },
-            "reviewer": Object {
-              "email": "woodwardw@state.gov",
-              "first_name": "Wendy",
-              "is_cdo": false,
-              "last_name": "Woodward",
-              "phone_number": "555-555-5555",
-              "username": "woodwardw",
-            },
-            "scheduled_panel_date": "2017-12-20",
-            "status": "closed",
-            "submitted_date": "2017-12-20",
-            "update_date": "2017-12-20",
-            "user": "rehmant",
-          },
-        ]
-      }
-      favorites={Array []}
-      icon="bolt"
-      isLoading={false}
-      maxLength="3"
-      positions={
-        Array [
-          Object {
-            "id": 2,
-          },
-        ]
-      }
-      title="Service Needs Positions"
-      toggleBid={[Function]}
-      toggleFavorite={[Function]}
-      type="serviceNeed"
-      userProfileFavoritePositionHasErrored={false}
-      userProfileFavoritePositionIsLoading={false}
-      viewMoreLink="/results?post__has_service_needs_differential=true"
-    />
-    <HomePagePositionsSection
-      bidList={
-        Array [
-          Object {
-            "approved_date": "2017-12-20",
-            "bidcycle": "Demo BidCycle 2017-10-31 16:00:51.254762",
-            "closed_date": "2017-12-20",
-            "create_date": "2017-12-20",
-            "declined_date": "2017-12-20",
-            "draft_date": "2017-12-20",
-            "handshake_accepted_date": "2017-12-20",
-            "handshake_declined_date": "2017-12-20",
-            "handshake_offered_date": "2017-12-20",
-            "id": 3,
-            "in_panel_date": "2017-12-20",
-            "is_priority": false,
-            "position": Object {
-              "bureau": "(AF) BUREAU OF AFRICAN AFFAIRS",
-              "create_date": "2015-08-05",
-              "grade": "03",
-              "id": 226,
-              "position_number": "10035561",
-              "post": Object {
-                "id": 199,
-                "location": "Curacao",
-              },
-              "skill": "POLITICAL AND ECONOMIC AFFAIRS (6050)",
-              "title": "POLITICAL/ECONOMIC OFFICER",
-              "update_date": "2017-06-08",
-            },
-            "reviewer": Object {
-              "email": "woodwardw@state.gov",
-              "first_name": "Wendy",
-              "is_cdo": false,
-              "last_name": "Woodward",
-              "phone_number": "555-555-5555",
-              "username": "woodwardw",
-            },
-            "scheduled_panel_date": "2017-12-20",
-            "status": "approved",
-            "submitted_date": "2017-12-20",
-            "update_date": "2017-12-20",
-            "user": "rehmant",
-          },
-          Object {
-            "approved_date": "2017-12-20",
-            "bidcycle": "Demo BidCycle 2017-10-31 16:00:51.254762",
-            "closed_date": "2017-12-20",
-            "create_date": "2017-12-20",
-            "declined_date": "2017-12-20",
-            "draft_date": "2017-12-20",
-            "handshake_accepted_date": "2017-12-20",
-            "handshake_declined_date": "2017-12-20",
-            "handshake_offered_date": "2017-12-20",
-            "id": 1,
-            "in_panel_date": "2017-12-20",
-            "is_priority": true,
-            "position": Object {
-              "bureau": "(AF) BUREAU OF AFRICAN AFFAIRS",
-              "create_date": "2006-09-20",
-              "grade": "05",
-              "id": 1,
-              "position_number": "00003026",
-              "post": Object {
-                "id": 235,
-                "location": "Freetown, Sierra Leone",
-              },
-              "skill": "OFFICE MANAGEMENT (9017)",
-              "title": "OMS (COM)",
-              "update_date": "2017-06-08",
-            },
-            "reviewer": Object {
-              "email": "woodwardw@state.gov",
-              "first_name": "Wendy",
-              "is_cdo": false,
-              "last_name": "Woodward",
-              "phone_number": "555-555-5555",
-              "username": "woodwardw",
-            },
-            "scheduled_panel_date": "2017-12-20",
-            "status": "closed",
-            "submitted_date": "2017-12-20",
-            "update_date": "2017-12-20",
-            "user": "rehmant",
-          },
-          Object {
-            "approved_date": "2017-12-20",
-            "bidcycle": "Demo BidCycle 2017-10-31 16:00:51.254762",
-            "closed_date": "2017-12-20",
-            "create_date": "2017-12-20",
-            "declined_date": "2017-12-20",
-            "draft_date": "2017-12-20",
-            "handshake_accepted_date": "2017-12-20",
-            "handshake_declined_date": "2017-12-20",
-            "handshake_offered_date": "2017-12-20",
-            "id": 2,
-            "in_panel_date": "2017-12-20",
-            "is_priority": false,
-            "position": Object {
-              "bureau": "(AF) BUREAU OF AFRICAN AFFAIRS",
-              "create_date": "2006-09-20",
-              "grade": "04",
-              "id": 84,
-              "position_number": "56001600",
-              "post": Object {
-                "id": 195,
-                "location": "The Hague, Netherlands",
-              },
-              "skill": "SECURITY (2501)",
-              "title": "SPECIAL AGENT",
-              "update_date": "2017-06-08",
-            },
-            "reviewer": Object {
-              "email": "woodwardw@state.gov",
-              "first_name": "Wendy",
-              "is_cdo": false,
-              "last_name": "Woodward",
-              "phone_number": "555-555-5555",
-              "username": "woodwardw",
-            },
-            "scheduled_panel_date": "2017-12-20",
-            "status": "closed",
-            "submitted_date": "2017-12-20",
-            "update_date": "2017-12-20",
-            "user": "rehmant",
-          },
-        ]
-      }
-      favorites={Array []}
-      icon="briefcase"
-      isLoading={false}
-      maxLength="3"
-      positions={
-        Array [
-          Object {
-            "id": 1,
-          },
-        ]
-      }
-      title="Positions in undefined"
-      toggleBid={[Function]}
-      toggleFavorite={[Function]}
-      type="default"
-      userProfileFavoritePositionHasErrored={false}
-      userProfileFavoritePositionIsLoading={false}
-      viewMoreLink="/results?skill__code__in=,"
-    />
-    <HomePagePositionsSection
-      bidList={
-        Array [
-          Object {
-            "approved_date": "2017-12-20",
-            "bidcycle": "Demo BidCycle 2017-10-31 16:00:51.254762",
-            "closed_date": "2017-12-20",
-            "create_date": "2017-12-20",
-            "declined_date": "2017-12-20",
-            "draft_date": "2017-12-20",
-            "handshake_accepted_date": "2017-12-20",
-            "handshake_declined_date": "2017-12-20",
-            "handshake_offered_date": "2017-12-20",
-            "id": 3,
-            "in_panel_date": "2017-12-20",
-            "is_priority": false,
-            "position": Object {
-              "bureau": "(AF) BUREAU OF AFRICAN AFFAIRS",
-              "create_date": "2015-08-05",
-              "grade": "03",
-              "id": 226,
-              "position_number": "10035561",
-              "post": Object {
-                "id": 199,
-                "location": "Curacao",
-              },
-              "skill": "POLITICAL AND ECONOMIC AFFAIRS (6050)",
-              "title": "POLITICAL/ECONOMIC OFFICER",
-              "update_date": "2017-06-08",
-            },
-            "reviewer": Object {
-              "email": "woodwardw@state.gov",
-              "first_name": "Wendy",
-              "is_cdo": false,
-              "last_name": "Woodward",
-              "phone_number": "555-555-5555",
-              "username": "woodwardw",
-            },
-            "scheduled_panel_date": "2017-12-20",
-            "status": "approved",
-            "submitted_date": "2017-12-20",
-            "update_date": "2017-12-20",
-            "user": "rehmant",
-          },
-          Object {
-            "approved_date": "2017-12-20",
-            "bidcycle": "Demo BidCycle 2017-10-31 16:00:51.254762",
-            "closed_date": "2017-12-20",
-            "create_date": "2017-12-20",
-            "declined_date": "2017-12-20",
-            "draft_date": "2017-12-20",
-            "handshake_accepted_date": "2017-12-20",
-            "handshake_declined_date": "2017-12-20",
-            "handshake_offered_date": "2017-12-20",
-            "id": 1,
-            "in_panel_date": "2017-12-20",
-            "is_priority": true,
-            "position": Object {
-              "bureau": "(AF) BUREAU OF AFRICAN AFFAIRS",
-              "create_date": "2006-09-20",
-              "grade": "05",
-              "id": 1,
-              "position_number": "00003026",
-              "post": Object {
-                "id": 235,
-                "location": "Freetown, Sierra Leone",
-              },
-              "skill": "OFFICE MANAGEMENT (9017)",
-              "title": "OMS (COM)",
-              "update_date": "2017-06-08",
-            },
-            "reviewer": Object {
-              "email": "woodwardw@state.gov",
-              "first_name": "Wendy",
-              "is_cdo": false,
-              "last_name": "Woodward",
-              "phone_number": "555-555-5555",
-              "username": "woodwardw",
-            },
-            "scheduled_panel_date": "2017-12-20",
-            "status": "closed",
-            "submitted_date": "2017-12-20",
-            "update_date": "2017-12-20",
-            "user": "rehmant",
-          },
-          Object {
-            "approved_date": "2017-12-20",
-            "bidcycle": "Demo BidCycle 2017-10-31 16:00:51.254762",
-            "closed_date": "2017-12-20",
-            "create_date": "2017-12-20",
-            "declined_date": "2017-12-20",
-            "draft_date": "2017-12-20",
-            "handshake_accepted_date": "2017-12-20",
-            "handshake_declined_date": "2017-12-20",
-            "handshake_offered_date": "2017-12-20",
-            "id": 2,
-            "in_panel_date": "2017-12-20",
-            "is_priority": false,
-            "position": Object {
-              "bureau": "(AF) BUREAU OF AFRICAN AFFAIRS",
-              "create_date": "2006-09-20",
-              "grade": "04",
-              "id": 84,
-              "position_number": "56001600",
-              "post": Object {
-                "id": 195,
-                "location": "The Hague, Netherlands",
-              },
-              "skill": "SECURITY (2501)",
-              "title": "SPECIAL AGENT",
-              "update_date": "2017-06-08",
-            },
-            "reviewer": Object {
-              "email": "woodwardw@state.gov",
-              "first_name": "Wendy",
-              "is_cdo": false,
-              "last_name": "Woodward",
-              "phone_number": "555-555-5555",
-              "username": "woodwardw",
-            },
-            "scheduled_panel_date": "2017-12-20",
-            "status": "closed",
-            "submitted_date": "2017-12-20",
-            "update_date": "2017-12-20",
-            "user": "rehmant",
-          },
-        ]
-      }
-      favorites={Array []}
-      icon="flag"
-      isLoading={false}
-      maxLength="3"
-      positions={
-        Array [
-          Object {
-            "id": 3,
-          },
-        ]
-      }
-      title="Recently Posted Positions in Grade undefined"
-      toggleBid={[Function]}
-      toggleFavorite={[Function]}
-      type="default"
-      userProfileFavoritePositionHasErrored={false}
-      userProfileFavoritePositionIsLoading={false}
-      viewMoreLink="/results?grade__code__in=03"
-    />
-  </div>
-</div>
-`;
-
 exports[`HomePageComponent matches snapshot when position arrays are filled 1`] = `
 <div
   className="homepage-positions-section-container"
@@ -594,7 +142,7 @@ exports[`HomePageComponent matches snapshot when position arrays are filled 1`] 
       positions={
         Array [
           Object {
-            "id": 2,
+            "id": 3,
           },
         ]
       }
@@ -741,11 +289,12 @@ exports[`HomePageComponent matches snapshot when position arrays are filled 1`] 
       positions={
         Array [
           Object {
-            "id": 3,
+            "id": 1,
+            "skill": "skill 1",
           },
         ]
       }
-      title="Positions in undefined"
+      title="Positions in skill 1"
       toggleBid={[Function]}
       toggleFavorite={[Function]}
       type="default"
@@ -888,11 +437,446 @@ exports[`HomePageComponent matches snapshot when position arrays are filled 1`] 
       positions={
         Array [
           Object {
-            "id": 1,
+            "grade": "03",
+            "id": 2,
           },
         ]
       }
-      title="Recently Posted Positions in Grade undefined"
+      title="Recently Posted Positions in Grade 03"
+      toggleBid={[Function]}
+      toggleFavorite={[Function]}
+      type="default"
+      userProfileFavoritePositionHasErrored={false}
+      userProfileFavoritePositionIsLoading={false}
+      viewMoreLink="/results?grade__code__in=03"
+    />
+  </div>
+</div>
+`;
+
+exports[`HomePageComponent matches snapshot when the positions arrays are empty 1`] = `
+<div
+  className="homepage-positions-section-container"
+>
+  <div
+    className="usa-grid-full homepage-positions-section-container-inner padded-main-content"
+  >
+    <HomePagePositionsSection
+      bidList={
+        Array [
+          Object {
+            "approved_date": "2017-12-20",
+            "bidcycle": "Demo BidCycle 2017-10-31 16:00:51.254762",
+            "closed_date": "2017-12-20",
+            "create_date": "2017-12-20",
+            "declined_date": "2017-12-20",
+            "draft_date": "2017-12-20",
+            "handshake_accepted_date": "2017-12-20",
+            "handshake_declined_date": "2017-12-20",
+            "handshake_offered_date": "2017-12-20",
+            "id": 3,
+            "in_panel_date": "2017-12-20",
+            "is_priority": false,
+            "position": Object {
+              "bureau": "(AF) BUREAU OF AFRICAN AFFAIRS",
+              "create_date": "2015-08-05",
+              "grade": "03",
+              "id": 226,
+              "position_number": "10035561",
+              "post": Object {
+                "id": 199,
+                "location": "Curacao",
+              },
+              "skill": "POLITICAL AND ECONOMIC AFFAIRS (6050)",
+              "title": "POLITICAL/ECONOMIC OFFICER",
+              "update_date": "2017-06-08",
+            },
+            "reviewer": Object {
+              "email": "woodwardw@state.gov",
+              "first_name": "Wendy",
+              "is_cdo": false,
+              "last_name": "Woodward",
+              "phone_number": "555-555-5555",
+              "username": "woodwardw",
+            },
+            "scheduled_panel_date": "2017-12-20",
+            "status": "approved",
+            "submitted_date": "2017-12-20",
+            "update_date": "2017-12-20",
+            "user": "rehmant",
+          },
+          Object {
+            "approved_date": "2017-12-20",
+            "bidcycle": "Demo BidCycle 2017-10-31 16:00:51.254762",
+            "closed_date": "2017-12-20",
+            "create_date": "2017-12-20",
+            "declined_date": "2017-12-20",
+            "draft_date": "2017-12-20",
+            "handshake_accepted_date": "2017-12-20",
+            "handshake_declined_date": "2017-12-20",
+            "handshake_offered_date": "2017-12-20",
+            "id": 1,
+            "in_panel_date": "2017-12-20",
+            "is_priority": true,
+            "position": Object {
+              "bureau": "(AF) BUREAU OF AFRICAN AFFAIRS",
+              "create_date": "2006-09-20",
+              "grade": "05",
+              "id": 1,
+              "position_number": "00003026",
+              "post": Object {
+                "id": 235,
+                "location": "Freetown, Sierra Leone",
+              },
+              "skill": "OFFICE MANAGEMENT (9017)",
+              "title": "OMS (COM)",
+              "update_date": "2017-06-08",
+            },
+            "reviewer": Object {
+              "email": "woodwardw@state.gov",
+              "first_name": "Wendy",
+              "is_cdo": false,
+              "last_name": "Woodward",
+              "phone_number": "555-555-5555",
+              "username": "woodwardw",
+            },
+            "scheduled_panel_date": "2017-12-20",
+            "status": "closed",
+            "submitted_date": "2017-12-20",
+            "update_date": "2017-12-20",
+            "user": "rehmant",
+          },
+          Object {
+            "approved_date": "2017-12-20",
+            "bidcycle": "Demo BidCycle 2017-10-31 16:00:51.254762",
+            "closed_date": "2017-12-20",
+            "create_date": "2017-12-20",
+            "declined_date": "2017-12-20",
+            "draft_date": "2017-12-20",
+            "handshake_accepted_date": "2017-12-20",
+            "handshake_declined_date": "2017-12-20",
+            "handshake_offered_date": "2017-12-20",
+            "id": 2,
+            "in_panel_date": "2017-12-20",
+            "is_priority": false,
+            "position": Object {
+              "bureau": "(AF) BUREAU OF AFRICAN AFFAIRS",
+              "create_date": "2006-09-20",
+              "grade": "04",
+              "id": 84,
+              "position_number": "56001600",
+              "post": Object {
+                "id": 195,
+                "location": "The Hague, Netherlands",
+              },
+              "skill": "SECURITY (2501)",
+              "title": "SPECIAL AGENT",
+              "update_date": "2017-06-08",
+            },
+            "reviewer": Object {
+              "email": "woodwardw@state.gov",
+              "first_name": "Wendy",
+              "is_cdo": false,
+              "last_name": "Woodward",
+              "phone_number": "555-555-5555",
+              "username": "woodwardw",
+            },
+            "scheduled_panel_date": "2017-12-20",
+            "status": "closed",
+            "submitted_date": "2017-12-20",
+            "update_date": "2017-12-20",
+            "user": "rehmant",
+          },
+        ]
+      }
+      favorites={Array []}
+      icon="bolt"
+      isLoading={false}
+      maxLength="3"
+      positions={Array []}
+      title="Service Needs Positions"
+      toggleBid={[Function]}
+      toggleFavorite={[Function]}
+      type="serviceNeed"
+      userProfileFavoritePositionHasErrored={false}
+      userProfileFavoritePositionIsLoading={false}
+      viewMoreLink="/results?post__has_service_needs_differential=true"
+    />
+    <HomePagePositionsSection
+      bidList={
+        Array [
+          Object {
+            "approved_date": "2017-12-20",
+            "bidcycle": "Demo BidCycle 2017-10-31 16:00:51.254762",
+            "closed_date": "2017-12-20",
+            "create_date": "2017-12-20",
+            "declined_date": "2017-12-20",
+            "draft_date": "2017-12-20",
+            "handshake_accepted_date": "2017-12-20",
+            "handshake_declined_date": "2017-12-20",
+            "handshake_offered_date": "2017-12-20",
+            "id": 3,
+            "in_panel_date": "2017-12-20",
+            "is_priority": false,
+            "position": Object {
+              "bureau": "(AF) BUREAU OF AFRICAN AFFAIRS",
+              "create_date": "2015-08-05",
+              "grade": "03",
+              "id": 226,
+              "position_number": "10035561",
+              "post": Object {
+                "id": 199,
+                "location": "Curacao",
+              },
+              "skill": "POLITICAL AND ECONOMIC AFFAIRS (6050)",
+              "title": "POLITICAL/ECONOMIC OFFICER",
+              "update_date": "2017-06-08",
+            },
+            "reviewer": Object {
+              "email": "woodwardw@state.gov",
+              "first_name": "Wendy",
+              "is_cdo": false,
+              "last_name": "Woodward",
+              "phone_number": "555-555-5555",
+              "username": "woodwardw",
+            },
+            "scheduled_panel_date": "2017-12-20",
+            "status": "approved",
+            "submitted_date": "2017-12-20",
+            "update_date": "2017-12-20",
+            "user": "rehmant",
+          },
+          Object {
+            "approved_date": "2017-12-20",
+            "bidcycle": "Demo BidCycle 2017-10-31 16:00:51.254762",
+            "closed_date": "2017-12-20",
+            "create_date": "2017-12-20",
+            "declined_date": "2017-12-20",
+            "draft_date": "2017-12-20",
+            "handshake_accepted_date": "2017-12-20",
+            "handshake_declined_date": "2017-12-20",
+            "handshake_offered_date": "2017-12-20",
+            "id": 1,
+            "in_panel_date": "2017-12-20",
+            "is_priority": true,
+            "position": Object {
+              "bureau": "(AF) BUREAU OF AFRICAN AFFAIRS",
+              "create_date": "2006-09-20",
+              "grade": "05",
+              "id": 1,
+              "position_number": "00003026",
+              "post": Object {
+                "id": 235,
+                "location": "Freetown, Sierra Leone",
+              },
+              "skill": "OFFICE MANAGEMENT (9017)",
+              "title": "OMS (COM)",
+              "update_date": "2017-06-08",
+            },
+            "reviewer": Object {
+              "email": "woodwardw@state.gov",
+              "first_name": "Wendy",
+              "is_cdo": false,
+              "last_name": "Woodward",
+              "phone_number": "555-555-5555",
+              "username": "woodwardw",
+            },
+            "scheduled_panel_date": "2017-12-20",
+            "status": "closed",
+            "submitted_date": "2017-12-20",
+            "update_date": "2017-12-20",
+            "user": "rehmant",
+          },
+          Object {
+            "approved_date": "2017-12-20",
+            "bidcycle": "Demo BidCycle 2017-10-31 16:00:51.254762",
+            "closed_date": "2017-12-20",
+            "create_date": "2017-12-20",
+            "declined_date": "2017-12-20",
+            "draft_date": "2017-12-20",
+            "handshake_accepted_date": "2017-12-20",
+            "handshake_declined_date": "2017-12-20",
+            "handshake_offered_date": "2017-12-20",
+            "id": 2,
+            "in_panel_date": "2017-12-20",
+            "is_priority": false,
+            "position": Object {
+              "bureau": "(AF) BUREAU OF AFRICAN AFFAIRS",
+              "create_date": "2006-09-20",
+              "grade": "04",
+              "id": 84,
+              "position_number": "56001600",
+              "post": Object {
+                "id": 195,
+                "location": "The Hague, Netherlands",
+              },
+              "skill": "SECURITY (2501)",
+              "title": "SPECIAL AGENT",
+              "update_date": "2017-06-08",
+            },
+            "reviewer": Object {
+              "email": "woodwardw@state.gov",
+              "first_name": "Wendy",
+              "is_cdo": false,
+              "last_name": "Woodward",
+              "phone_number": "555-555-5555",
+              "username": "woodwardw",
+            },
+            "scheduled_panel_date": "2017-12-20",
+            "status": "closed",
+            "submitted_date": "2017-12-20",
+            "update_date": "2017-12-20",
+            "user": "rehmant",
+          },
+        ]
+      }
+      favorites={Array []}
+      icon="briefcase"
+      isLoading={false}
+      maxLength="3"
+      positions={Array []}
+      title="Positions in Skill"
+      toggleBid={[Function]}
+      toggleFavorite={[Function]}
+      type="default"
+      userProfileFavoritePositionHasErrored={false}
+      userProfileFavoritePositionIsLoading={false}
+      viewMoreLink="/results?skill__code__in=,"
+    />
+    <HomePagePositionsSection
+      bidList={
+        Array [
+          Object {
+            "approved_date": "2017-12-20",
+            "bidcycle": "Demo BidCycle 2017-10-31 16:00:51.254762",
+            "closed_date": "2017-12-20",
+            "create_date": "2017-12-20",
+            "declined_date": "2017-12-20",
+            "draft_date": "2017-12-20",
+            "handshake_accepted_date": "2017-12-20",
+            "handshake_declined_date": "2017-12-20",
+            "handshake_offered_date": "2017-12-20",
+            "id": 3,
+            "in_panel_date": "2017-12-20",
+            "is_priority": false,
+            "position": Object {
+              "bureau": "(AF) BUREAU OF AFRICAN AFFAIRS",
+              "create_date": "2015-08-05",
+              "grade": "03",
+              "id": 226,
+              "position_number": "10035561",
+              "post": Object {
+                "id": 199,
+                "location": "Curacao",
+              },
+              "skill": "POLITICAL AND ECONOMIC AFFAIRS (6050)",
+              "title": "POLITICAL/ECONOMIC OFFICER",
+              "update_date": "2017-06-08",
+            },
+            "reviewer": Object {
+              "email": "woodwardw@state.gov",
+              "first_name": "Wendy",
+              "is_cdo": false,
+              "last_name": "Woodward",
+              "phone_number": "555-555-5555",
+              "username": "woodwardw",
+            },
+            "scheduled_panel_date": "2017-12-20",
+            "status": "approved",
+            "submitted_date": "2017-12-20",
+            "update_date": "2017-12-20",
+            "user": "rehmant",
+          },
+          Object {
+            "approved_date": "2017-12-20",
+            "bidcycle": "Demo BidCycle 2017-10-31 16:00:51.254762",
+            "closed_date": "2017-12-20",
+            "create_date": "2017-12-20",
+            "declined_date": "2017-12-20",
+            "draft_date": "2017-12-20",
+            "handshake_accepted_date": "2017-12-20",
+            "handshake_declined_date": "2017-12-20",
+            "handshake_offered_date": "2017-12-20",
+            "id": 1,
+            "in_panel_date": "2017-12-20",
+            "is_priority": true,
+            "position": Object {
+              "bureau": "(AF) BUREAU OF AFRICAN AFFAIRS",
+              "create_date": "2006-09-20",
+              "grade": "05",
+              "id": 1,
+              "position_number": "00003026",
+              "post": Object {
+                "id": 235,
+                "location": "Freetown, Sierra Leone",
+              },
+              "skill": "OFFICE MANAGEMENT (9017)",
+              "title": "OMS (COM)",
+              "update_date": "2017-06-08",
+            },
+            "reviewer": Object {
+              "email": "woodwardw@state.gov",
+              "first_name": "Wendy",
+              "is_cdo": false,
+              "last_name": "Woodward",
+              "phone_number": "555-555-5555",
+              "username": "woodwardw",
+            },
+            "scheduled_panel_date": "2017-12-20",
+            "status": "closed",
+            "submitted_date": "2017-12-20",
+            "update_date": "2017-12-20",
+            "user": "rehmant",
+          },
+          Object {
+            "approved_date": "2017-12-20",
+            "bidcycle": "Demo BidCycle 2017-10-31 16:00:51.254762",
+            "closed_date": "2017-12-20",
+            "create_date": "2017-12-20",
+            "declined_date": "2017-12-20",
+            "draft_date": "2017-12-20",
+            "handshake_accepted_date": "2017-12-20",
+            "handshake_declined_date": "2017-12-20",
+            "handshake_offered_date": "2017-12-20",
+            "id": 2,
+            "in_panel_date": "2017-12-20",
+            "is_priority": false,
+            "position": Object {
+              "bureau": "(AF) BUREAU OF AFRICAN AFFAIRS",
+              "create_date": "2006-09-20",
+              "grade": "04",
+              "id": 84,
+              "position_number": "56001600",
+              "post": Object {
+                "id": 195,
+                "location": "The Hague, Netherlands",
+              },
+              "skill": "SECURITY (2501)",
+              "title": "SPECIAL AGENT",
+              "update_date": "2017-06-08",
+            },
+            "reviewer": Object {
+              "email": "woodwardw@state.gov",
+              "first_name": "Wendy",
+              "is_cdo": false,
+              "last_name": "Woodward",
+              "phone_number": "555-555-5555",
+              "username": "woodwardw",
+            },
+            "scheduled_panel_date": "2017-12-20",
+            "status": "closed",
+            "submitted_date": "2017-12-20",
+            "update_date": "2017-12-20",
+            "user": "rehmant",
+          },
+        ]
+      }
+      favorites={Array []}
+      icon="flag"
+      isLoading={false}
+      maxLength="3"
+      positions={Array []}
+      title="Recently Posted Positions in Grade"
       toggleBid={[Function]}
       toggleFavorite={[Function]}
       type="default"

--- a/src/Constants/DefaultProps.js
+++ b/src/Constants/DefaultProps.js
@@ -1,9 +1,11 @@
+import { USER_SKILL_CODE_POSITIONS, USER_GRADE_RECENT_POSITIONS, SERVICE_NEED_POSITIONS } from './PropTypes';
+
 export const ACCORDION_SELECTION = { main: '', sub: '' };
 
 export const DEFAULT_HOME_PAGE_POSITIONS = {
-  userSkillCodePositions: [],
-  serviceNeedPositions: [],
-  userGradeRecentPositions: [],
+  [USER_SKILL_CODE_POSITIONS]: [],
+  [USER_GRADE_RECENT_POSITIONS]: [],
+  [SERVICE_NEED_POSITIONS]: [],
 };
 
 export const DEFAULT_USER_PROFILE = {

--- a/src/Constants/DefaultProps.js
+++ b/src/Constants/DefaultProps.js
@@ -1,9 +1,9 @@
 export const ACCORDION_SELECTION = { main: '', sub: '' };
 
 export const DEFAULT_HOME_PAGE_POSITIONS = {
-  isGradeAndRecent: [],
-  isServiceNeed: [],
-  isSkillCode: [],
+  userSkillCodePositions: [],
+  serviceNeedPositions: [],
+  userGradeRecentPositions: [],
 };
 
 export const DEFAULT_USER_PROFILE = {

--- a/src/Constants/PropTypes.js
+++ b/src/Constants/PropTypes.js
@@ -89,10 +89,13 @@ export const POST_SEARCH_RESULTS = PropTypes.shape({
   results: POST_DETAILS_ARRAY,
 });
 
+export const USER_SKILL_CODE_POSITIONS = 'userSkillCodePositions';
+export const USER_GRADE_RECENT_POSITIONS = 'userGradeRecentPositions';
+export const SERVICE_NEED_POSITIONS = 'serviceNeedPositions';
 export const HOME_PAGE_POSITIONS = PropTypes.shape({
-  userSkillCodePositions: POSITION_DETAILS_ARRAY,
-  userGradeRecentPositions: POSITION_DETAILS_ARRAY,
-  serviceNeedPositions: POSITION_DETAILS_ARRAY,
+  [USER_SKILL_CODE_POSITIONS]: POSITION_DETAILS_ARRAY,
+  [USER_GRADE_RECENT_POSITIONS]: POSITION_DETAILS_ARRAY,
+  [SERVICE_NEED_POSITIONS]: POSITION_DETAILS_ARRAY,
 });
 
 export const FILTER = PropTypes.shape({

--- a/src/Containers/HomePagePositionsContainer/HomePagePositionsContainer.test.jsx
+++ b/src/Containers/HomePagePositionsContainer/HomePagePositionsContainer.test.jsx
@@ -21,7 +21,9 @@ describe('Home', () => {
         toggleBid={() => {}}
         onNavigateTo={() => {}}
         bidList={[]}
-        homePagePositions={{ isServiceNeed: [], isSkillCode: [], isGradeAndRecent: [] }}
+        homePagePositions={
+          { serviceNeedPositions: [], userSkillCodePositions: [], userGradeRecentPositions: [] }
+        }
       />
     </MemoryRouter></Provider>);
     expect(home).toBeDefined();

--- a/src/Containers/HomePagePositionsContainer/HomePagePositionsContainer.test.jsx
+++ b/src/Containers/HomePagePositionsContainer/HomePagePositionsContainer.test.jsx
@@ -6,6 +6,7 @@ import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { testDispatchFunctions } from '../../testUtilities/testUtilities';
 import HomePagePositionsContainer, { mapDispatchToProps } from './HomePagePositionsContainer';
+import { DEFAULT_HOME_PAGE_POSITIONS } from '../../Constants/DefaultProps';
 
 const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
@@ -21,9 +22,7 @@ describe('Home', () => {
         toggleBid={() => {}}
         onNavigateTo={() => {}}
         bidList={[]}
-        homePagePositions={
-          { serviceNeedPositions: [], userSkillCodePositions: [], userGradeRecentPositions: [] }
-        }
+        homePagePositions={DEFAULT_HOME_PAGE_POSITIONS}
       />
     </MemoryRouter></Provider>);
     expect(home).toBeDefined();


### PR DESCRIPTION
After changing property names in #1436, homepage position card titles did not fully render because old property references were still being used. This abstracts those prop names (`serviceNeedPositions`, `userSkillCodePositions`, `userGradeRecentPositions`) to constants and uses those instead of calling directly calling the property name. Also adds tests to check that the card section titles rendered correctly.