### PR TITLE
Create function to format ids

### DIFF
--- a/src/Components/Accordion/AccordionItem/AccordionItem.jsx
+++ b/src/Components/Accordion/AccordionItem/AccordionItem.jsx
@@ -1,20 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { EMPTY_FUNCTION } from '../../../Constants/PropTypes';
+import { formatIdSpacing } from '../../../utilities';
 
 const AccordionItem = ({ id, title, expanded, setAccordion, children, className, useIdClass }) => {
-  const idClass = useIdClass ? `accordion-${(id || 'accordion').toLowerCase()}` : '';
+  const formattedId = formatIdSpacing(id);
+  const idClass = useIdClass ? `accordion-${(formattedId || 'accordion').toLowerCase()}` : '';
   return (
     <li className={className}>
       <button
         className="usa-accordion-button"
         aria-expanded={expanded}
-        aria-controls={id}
+        aria-controls={formattedId}
         onClick={() => setAccordion(expanded || !title ? '' : title)}
       >
         <div className="accordion-item-title">{title}</div>
       </button>
-      <div id={id} className={`usa-accordion-content ${idClass}`} aria-hidden={!expanded}>
+      <div id={formattedId} className={`usa-accordion-content ${idClass}`} aria-hidden={!expanded}>
         {children}
       </div>
     </li>

--- a/src/Components/Accordion/AccordionItem/AccordionItem.test.jsx
+++ b/src/Components/Accordion/AccordionItem/AccordionItem.test.jsx
@@ -22,7 +22,7 @@ describe('AccordionItemComponent', () => {
     const expanded = { value: null };
     const wrapper = shallow(
       <AccordionItem
-        id=""
+        id="id"
         title="title"
         expanded={false}
         setAccordion={(e) => { expanded.value = e; }}
@@ -37,8 +37,8 @@ describe('AccordionItemComponent', () => {
   it('matches snapshot', () => {
     const wrapper = shallow(
       <AccordionItem
-        id=""
-        title=""
+        id="id"
+        title="title"
         expanded
         setAccordion={() => {}}
       >

--- a/src/Components/Accordion/AccordionItem/__snapshots__/AccordionItem.test.jsx.snap
+++ b/src/Components/Accordion/AccordionItem/__snapshots__/AccordionItem.test.jsx.snap
@@ -5,7 +5,7 @@ exports[`AccordionItemComponent matches snapshot 1`] = `
   className=""
 >
   <button
-    aria-controls=""
+    aria-controls={null}
     aria-expanded={true}
     className="usa-accordion-button"
     onClick={[Function]}
@@ -17,7 +17,7 @@ exports[`AccordionItemComponent matches snapshot 1`] = `
   <div
     aria-hidden={false}
     className="usa-accordion-content accordion-accordion"
-    id=""
+    id={null}
   >
     <span>
       child

--- a/src/Components/Accordion/AccordionItem/__snapshots__/AccordionItem.test.jsx.snap
+++ b/src/Components/Accordion/AccordionItem/__snapshots__/AccordionItem.test.jsx.snap
@@ -5,19 +5,21 @@ exports[`AccordionItemComponent matches snapshot 1`] = `
   className=""
 >
   <button
-    aria-controls={null}
+    aria-controls="id"
     aria-expanded={true}
     className="usa-accordion-button"
     onClick={[Function]}
   >
     <div
       className="accordion-item-title"
-    />
+    >
+      title
+    </div>
   </button>
   <div
     aria-hidden={false}
-    className="usa-accordion-content accordion-accordion"
-    id={null}
+    className="usa-accordion-content accordion-id"
+    id="id"
   >
     <span>
       child

--- a/src/Components/Glossary/GlossaryListing/GlossaryListing.jsx
+++ b/src/Components/Glossary/GlossaryListing/GlossaryListing.jsx
@@ -1,12 +1,18 @@
 import React from 'react';
 import Accordion, { AccordionItem } from '../../Accordion';
 import { GLOSSARY_ARRAY } from '../../../Constants/PropTypes';
+import { formatIdSpacing } from '../../../utilities';
 
 const GlossaryComponent = ({ glossaryItems }) => (
   <Accordion className="accordion-inverse" isMultiselectable>
     {
       glossaryItems.map(item =>
-        (<AccordionItem key={item.id} title={item.title} id={item.title} useIdClass={false}>
+        (<AccordionItem
+          key={item.id}
+          title={item.title}
+          id={formatIdSpacing(item.title)}
+          useIdClass={false}
+        >
           {item.definition}
         </AccordionItem>),
      )

--- a/src/Components/Glossary/GlossaryListing/__snapshots__/GlossaryListing.test.jsx.snap
+++ b/src/Components/Glossary/GlossaryListing/__snapshots__/GlossaryListing.test.jsx.snap
@@ -18,7 +18,7 @@ exports[`GlossaryListingComponent matches snapshot 1`] = `
   <AccordionItem
     className=""
     expanded={false}
-    id="Assignments Officer (AO)"
+    id="Assignments-Officer-(AO)"
     setAccordion={[Function]}
     title="Assignments Officer (AO)"
     useIdClass={false}

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -275,3 +275,13 @@ export const formatWaiverTitle = waiver => `${waiver.position} - ${waiver.catego
 // for traversing nested objects
 export const propOrDefault = (obj, path, defaultToReturn = null) =>
   dotProp.get(obj, path) || defaultToReturn;
+
+// replace spaces with hyphens so that id attributes are valid
+export const formatIdSpacing = (id) => {
+  if (id) {
+    const idString = id.toString();
+    return idString.split(' ').join('-');
+  }
+  // if id is not defined, return null
+  return null;
+};

--- a/src/utilities.test.js
+++ b/src/utilities.test.js
@@ -23,6 +23,7 @@ import { validStateEmail,
          formatBidTitle,
          formatWaiverTitle,
          propOrDefault,
+         formatIdSpacing,
        } from './utilities';
 
 describe('local storage', () => {
@@ -371,5 +372,22 @@ describe('propOrDefault', () => {
     expect(propOrDefault(nestedObject, 'a.b.e.e.e')).toBe(null);
     expect(propOrDefault(nestedObject, 'a.g')).toBe(null);
     expect(propOrDefault(nestedObject, 'a.b.c.d.d', 'value')).toBe('value');
+  });
+});
+
+describe('formatIdSpacing', () => {
+  it('can format strings', () => {
+    expect(formatIdSpacing('two words')).toBe('two-words');
+    expect(formatIdSpacing('has Three words')).toBe('has-Three-words');
+  });
+
+  it('can format numbers', () => {
+    expect(formatIdSpacing(3)).toBe('3');
+  });
+
+  it('can format undefined values', () => {
+    expect(formatIdSpacing(undefined)).toBe(null);
+    expect(formatIdSpacing(null)).toBe(null);
+    expect(formatIdSpacing(false)).toBe(null);
   });
 });


### PR DESCRIPTION
Adds a function to remove white space from `id`s (or anything really) and replace them with `-`. Applies the function to the `GlossaryListing` and `AccordionItem` components.