### PR TITLE
Homepage Card Bid Statistics

### DIFF
--- a/src/Components/BidCount/BidCount.jsx
+++ b/src/Components/BidCount/BidCount.jsx
@@ -1,21 +1,26 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import BidCountNumber from './BidCountNumber';
+import { BID_STATISTICS_OBJECT } from '../../Constants/PropTypes';
 
-const BidCount = ({ totalBids, inGradeBids, atSkillBids, inGradeAtSkillBids }) => (
-  <ul className="bid-count-list">
-    <BidCountNumber type="totalBids" number={totalBids} />
-    <BidCountNumber type="inGradeBids" number={inGradeBids} />
-    <BidCountNumber type="atSkillBids" number={atSkillBids} />
-    <BidCountNumber type="inGradeAtSkillBids" number={inGradeAtSkillBids} />
-  </ul>
+const BidCount = ({ bidStatistics }) => (
+  <div>
+    <div className="bid-count-label" id="bid-counts">Bid Counts:</div>
+    {/* set an aria-labelledby so that screen readers understand the purpose of the list */}
+    <ul className="bid-count-list" aria-labelledby="bid-counts">
+      <BidCountNumber type="totalBids" number={bidStatistics.total_bids || 0} />
+      <BidCountNumber type="inGradeBids" number={bidStatistics.in_grade || 0} />
+      <BidCountNumber type="atSkillBids" number={bidStatistics.at_skill || 0} />
+      <BidCountNumber type="inGradeAtSkillBids" number={bidStatistics.in_grade_at_skill || 0} />
+    </ul>
+  </div>
 );
 
 BidCount.propTypes = {
-  totalBids: PropTypes.number.isRequired,
-  inGradeBids: PropTypes.number.isRequired,
-  atSkillBids: PropTypes.number.isRequired,
-  inGradeAtSkillBids: PropTypes.number.isRequired,
+  bidStatistics: BID_STATISTICS_OBJECT,
+};
+
+BidCount.defaultProps = {
+  bidStatistics: {},
 };
 
 export default BidCount;

--- a/src/Components/BidCount/BidCount.jsx
+++ b/src/Components/BidCount/BidCount.jsx
@@ -4,7 +4,7 @@ import { BID_STATISTICS_OBJECT } from '../../Constants/PropTypes';
 
 const BidCount = ({ bidStatistics }) => (
   <div>
-    <div className="bid-count-label" id="bid-counts">Bid Counts:</div>
+    <div className="bid-count-label" id="bid-counts">Bid Count:</div>
     {/* set an aria-labelledby so that screen readers understand the purpose of the list */}
     <ul className="bid-count-list" aria-labelledby="bid-counts">
       <BidCountNumber type="totalBids" number={bidStatistics.total_bids || 0} />

--- a/src/Components/BidCount/BidCount.test.jsx
+++ b/src/Components/BidCount/BidCount.test.jsx
@@ -4,26 +4,39 @@ import toJSON from 'enzyme-to-json';
 import BidCount from './BidCount';
 
 describe('BidCountComponent', () => {
+  const props = {
+    bidStatistics: {
+      total_bids: 5,
+      in_grade: 5,
+      at_skill: 5,
+      in_grade_at_skill: 5,
+    },
+  };
   it('is defined', () => {
     const wrapper = shallow(
-      <BidCount
-        totalBids={5}
-        inGradeBids={5}
-        atSkillBids={5}
-        inGradeAtSkillBids={5}
-      />,
+      <BidCount {...props} />,
     );
     expect(wrapper).toBeDefined();
   });
 
+  it('displays 0 when a prop is not defined', () => {
+    const bidStatistics = {
+      total_bids: undefined,
+      in_grade: null,
+      at_skill: 5,
+    };
+    const wrapper = shallow(
+      <BidCount {...props} bidStatistics={bidStatistics} />,
+    );
+    expect(wrapper.find('BidCountNumber').at(0).props().number).toBe(0);
+    expect(wrapper.find('BidCountNumber').at(1).props().number).toBe(0);
+    expect(wrapper.find('BidCountNumber').at(2).props().number).toBe(5);
+    expect(wrapper.find('BidCountNumber').at(3).props().number).toBe(0);
+  });
+
   it('matches snapshot', () => {
     const wrapper = shallow(
-      <BidCount
-        totalBids={5}
-        inGradeBids={5}
-        atSkillBids={5}
-        inGradeAtSkillBids={5}
-      />,
+      <BidCount {...props} />,
     );
     expect(toJSON(wrapper)).toMatchSnapshot();
   });

--- a/src/Components/BidCount/BidCountNumber/BidCountNumber.jsx
+++ b/src/Components/BidCount/BidCountNumber/BidCountNumber.jsx
@@ -4,9 +4,9 @@ import { Tooltip } from 'react-tippy';
 import BID_COUNT_DEFINITIONS from '../../../Constants/BidCountDefinitions';
 
 const BidCountNumber = ({ type, number }) => (
-  <li className="bid-count-list-item">
+  <li className="bid-count-list-item" title={BID_COUNT_DEFINITIONS[type].title}>
     <Tooltip
-      title={BID_COUNT_DEFINITIONS[type]}
+      title={BID_COUNT_DEFINITIONS[type].definition}
       arrow
       offset={-50}
       tabIndex="0"

--- a/src/Components/BidCount/BidCountNumber/__snapshots__/BidCountNumber.test.jsx.snap
+++ b/src/Components/BidCount/BidCountNumber/__snapshots__/BidCountNumber.test.jsx.snap
@@ -3,6 +3,7 @@
 exports[`BidCountNumberComponent matches snapshot where type = atSkillBids 1`] = `
 <li
   className="bid-count-list-item"
+  title="At-skill bids"
 >
   <Tooltip
     animateFill={true}
@@ -54,6 +55,7 @@ exports[`BidCountNumberComponent matches snapshot where type = atSkillBids 1`] =
 exports[`BidCountNumberComponent matches snapshot where type = inGradeAtSkillBids 1`] = `
 <li
   className="bid-count-list-item"
+  title="In-grade and at-skill bids"
 >
   <Tooltip
     animateFill={true}
@@ -105,6 +107,7 @@ exports[`BidCountNumberComponent matches snapshot where type = inGradeAtSkillBid
 exports[`BidCountNumberComponent matches snapshot where type = inGradeBids 1`] = `
 <li
   className="bid-count-list-item"
+  title="In-grade bids"
 >
   <Tooltip
     animateFill={true}
@@ -156,6 +159,7 @@ exports[`BidCountNumberComponent matches snapshot where type = inGradeBids 1`] =
 exports[`BidCountNumberComponent matches snapshot where type = totalBids 1`] = `
 <li
   className="bid-count-list-item"
+  title="Total bids"
 >
   <Tooltip
     animateFill={true}

--- a/src/Components/BidCount/__snapshots__/BidCount.test.jsx.snap
+++ b/src/Components/BidCount/__snapshots__/BidCount.test.jsx.snap
@@ -6,7 +6,7 @@ exports[`BidCountComponent matches snapshot 1`] = `
     className="bid-count-label"
     id="bid-counts"
   >
-    Bid Counts:
+    Bid Count:
   </div>
   <ul
     aria-labelledby="bid-counts"

--- a/src/Components/BidCount/__snapshots__/BidCount.test.jsx.snap
+++ b/src/Components/BidCount/__snapshots__/BidCount.test.jsx.snap
@@ -1,24 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BidCountComponent matches snapshot 1`] = `
-<ul
-  className="bid-count-list"
->
-  <BidCountNumber
-    number={5}
-    type="totalBids"
-  />
-  <BidCountNumber
-    number={5}
-    type="inGradeBids"
-  />
-  <BidCountNumber
-    number={5}
-    type="atSkillBids"
-  />
-  <BidCountNumber
-    number={5}
-    type="inGradeAtSkillBids"
-  />
-</ul>
+<div>
+  <div
+    className="bid-count-label"
+    id="bid-counts"
+  >
+    Bid Counts:
+  </div>
+  <ul
+    aria-labelledby="bid-counts"
+    className="bid-count-list"
+  >
+    <BidCountNumber
+      number={5}
+      type="totalBids"
+    />
+    <BidCountNumber
+      number={5}
+      type="inGradeBids"
+    />
+    <BidCountNumber
+      number={5}
+      type="atSkillBids"
+    />
+    <BidCountNumber
+      number={5}
+      type="inGradeAtSkillBids"
+    />
+  </ul>
+</div>
 `;

--- a/src/Components/PositionTitle/PositionTitle.jsx
+++ b/src/Components/PositionTitle/PositionTitle.jsx
@@ -8,7 +8,7 @@ import EditContentButton from '../EditContentButton';
 import BidCount from '../BidCount';
 import { POSITION_DETAILS, GO_BACK_TO_LINK, BID_LIST } from '../../Constants/PropTypes';
 import { NO_POSITION_WEB_SITE, NO_POSITION_POC, NO_POSITION_DESCRIPTION } from '../../Constants/SystemMessages';
-import { getAssetPath, shortenString, propOrDefault } from '../../utilities';
+import { getAssetPath, shortenString, propOrDefault, getBidStatisticsObject } from '../../utilities';
 
 const seal = getAssetPath('/assets/img/rsz_dos-seal-bw.png');
 
@@ -110,7 +110,7 @@ class PositionTitle extends Component {
 
     const isAllowedToEdit = !!(propOrDefault(details, 'description.is_editable_by_user'));
 
-    const bidStatistics = Array.isArray(details.bid_statistics) ? details.bid_statistics[0] : null;
+    const bidStatistics = getBidStatisticsObject(details.bid_statistics);
 
     const shouldShowBidStats = !!details.bid_statistics && !!bidStatistics;
 
@@ -193,10 +193,7 @@ class PositionTitle extends Component {
             {
               shouldShowBidStats &&
                 <BidCount
-                  totalBids={bidStatistics.total_bids}
-                  inGradeBids={bidStatistics.in_grade}
-                  atSkillBids={bidStatistics.at_skill}
-                  inGradeAtSkillBids={bidStatistics.in_grade_at_skill}
+                  bidStatistics={bidStatistics}
                 />
             }
           </div>

--- a/src/Components/PositionTitle/__snapshots__/PositionTitle.test.jsx.snap
+++ b/src/Components/PositionTitle/__snapshots__/PositionTitle.test.jsx.snap
@@ -96,10 +96,16 @@ exports[`PositionTitleComponent matches snapshot 1`] = `
       className="offset-bid-button-container-count"
     >
       <BidCount
-        atSkillBids={0}
-        inGradeAtSkillBids={0}
-        inGradeBids={0}
-        totalBids={3}
+        bidStatistics={
+          Object {
+            "at_skill": 0,
+            "bidcycle": 1,
+            "id": 1,
+            "in_grade": 0,
+            "in_grade_at_skill": 0,
+            "total_bids": 3,
+          }
+        }
       />
     </div>
     <div

--- a/src/Components/ResultsCard/__snapshots__/ResultsCard.test.jsx.snap
+++ b/src/Components/ResultsCard/__snapshots__/ResultsCard.test.jsx.snap
@@ -123,6 +123,7 @@ exports[`ResultsCardComponent matches snapshot 1`] = `
       >
         <BidCount
           atSkillBids={0}
+          bidStatistics={Object {}}
           inGradeAtSkillBids={0}
           inGradeBids={0}
           totalBids={3}

--- a/src/Components/ResultsCondensedCard/ResultsCondensedCard.jsx
+++ b/src/Components/ResultsCondensedCard/ResultsCondensedCard.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import ResultsCondensedCardTop from '../ResultsCondensedCardTop';
 import ResultsCondensedCardBottom from '../ResultsCondensedCardBottom';
 import ResultsCondensedCardFooter from '../ResultsCondensedCardFooter';
+import ResultsCondensedCardStats from '../ResultsCondensedCardStats';
 import { POSITION_DETAILS, FAVORITE_POSITIONS_ARRAY, BID_RESULTS, HOME_PAGE_CARD_TYPE } from '../../Constants/PropTypes';
 
 const ResultsCondensedCard = ({ position, toggleFavorite, favorites, bidList,
@@ -18,6 +19,7 @@ const ResultsCondensedCard = ({ position, toggleFavorite, favorites, bidList,
         position={position}
         type={type}
       />
+      <ResultsCondensedCardStats bidStatisticsArray={position.bid_statistics} />
       <ResultsCondensedCardBottom
         toggleFavorite={toggleFavorite}
         position={position}

--- a/src/Components/ResultsCondensedCard/__snapshots__/ResultsCondensedCard.test.jsx.snap
+++ b/src/Components/ResultsCondensedCard/__snapshots__/ResultsCondensedCard.test.jsx.snap
@@ -66,6 +66,20 @@ exports[`ResultsCondensedCardComponent matches snapshot 1`] = `
     userProfileFavoritePositionHasErrored={false}
     userProfileFavoritePositionIsLoading={false}
   />
+  <ResultsCondensedCardStats
+    bidStatisticsArray={
+      Array [
+        Object {
+          "at_skill": 0,
+          "bidcycle": "Demo BidCycle 2018-01-12 15:11:38.004793",
+          "id": 1,
+          "in_grade": 0,
+          "in_grade_at_skill": 0,
+          "total_bids": 3,
+        },
+      ]
+    }
+  />
   <ResultsCondensedCardBottom
     bidList={
       Array [

--- a/src/Components/ResultsCondensedCardBottom/ResultsCondensedCardBottom.jsx
+++ b/src/Components/ResultsCondensedCardBottom/ResultsCondensedCardBottom.jsx
@@ -10,7 +10,7 @@ favorites }) => (
   <div className="condensed-card-bottom-container">
     <div className="usa-grid-full condensed-card-bottom">
       <CondensedCardData position={position} />
-      <div className="usa-grid-full">
+      <div className="usa-grid-full condensed-card-buttons-section">
         <Favorite
           hasBorder
           hideText
@@ -27,7 +27,7 @@ favorites }) => (
       </div>
     </div>
   </div>
-);
+  );
 
 ResultsCondensedCardBottom.propTypes = {
   position: POSITION_DETAILS.isRequired,

--- a/src/Components/ResultsCondensedCardBottom/__snapshots__/ResultsCondensedCardBottom.test.jsx.snap
+++ b/src/Components/ResultsCondensedCardBottom/__snapshots__/ResultsCondensedCardBottom.test.jsx.snap
@@ -65,7 +65,7 @@ exports[`ResultsCondensedCardBottomComponent matches snapshot 1`] = `
       }
     />
     <div
-      className="usa-grid-full"
+      className="usa-grid-full condensed-card-buttons-section"
     >
       <Favorite
         compareArray={

--- a/src/Components/ResultsCondensedCardStats/ResultsCondensedCardStats.jsx
+++ b/src/Components/ResultsCondensedCardStats/ResultsCondensedCardStats.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { BID_STATISTICS_ARRAY } from '../../Constants/PropTypes';
+import BidCount from '../BidCount';
+import { getBidStatisticsObject } from '../../utilities';
+
+const ResultsCondensedCardStats = ({ bidStatisticsArray }) => {
+  const bidStatistics = getBidStatisticsObject(bidStatisticsArray);
+  return (
+    <div className="condensed-card-footer condensed-card-statistics">
+      <div className="usa-grid-full condensed-card-footer-container">
+        <BidCount bidStatistics={bidStatistics} />
+      </div>
+    </div>
+  );
+};
+
+ResultsCondensedCardStats.propTypes = {
+  bidStatisticsArray: BID_STATISTICS_ARRAY,
+};
+
+ResultsCondensedCardStats.defaultProps = {
+  bidStatisticsArray: [],
+};
+
+export default ResultsCondensedCardStats;

--- a/src/Components/ResultsCondensedCardStats/ResultsCondensedCardStats.test.jsx
+++ b/src/Components/ResultsCondensedCardStats/ResultsCondensedCardStats.test.jsx
@@ -1,0 +1,37 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import toJSON from 'enzyme-to-json';
+import ResultsCondensedCardStats from './ResultsCondensedCardStats';
+
+describe('ResultsCondensedCardStatsComponent', () => {
+  const props = {
+    bidStatisticsArray: [
+      {
+        total_bids: 5,
+        in_grade: 5,
+        at_skill: 5,
+        in_grade_at_skill: 5,
+      },
+    ],
+  };
+  it('is defined', () => {
+    const wrapper = shallow(
+      <ResultsCondensedCardStats {...props} />,
+    );
+    expect(wrapper).toBeDefined();
+  });
+
+  it('can receive props', () => {
+    const wrapper = shallow(
+      <ResultsCondensedCardStats {...props} />,
+    );
+    expect(wrapper.instance().props.bidStatisticsArray).toBe(props.bidStatisticsArray);
+  });
+
+  it('matches snapshot', () => {
+    const wrapper = shallow(
+      <ResultsCondensedCardStats {...props} />,
+    );
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/Components/ResultsCondensedCardStats/__snapshots__/ResultsCondensedCardStats.test.jsx.snap
+++ b/src/Components/ResultsCondensedCardStats/__snapshots__/ResultsCondensedCardStats.test.jsx.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ResultsCondensedCardStatsComponent matches snapshot 1`] = `
+<div
+  className="condensed-card-footer condensed-card-statistics"
+>
+  <div
+    className="usa-grid-full condensed-card-footer-container"
+  >
+    <BidCount
+      bidStatistics={
+        Object {
+          "at_skill": 5,
+          "in_grade": 5,
+          "in_grade_at_skill": 5,
+          "total_bids": 5,
+        }
+      }
+    />
+  </div>
+</div>
+`;

--- a/src/Components/ResultsCondensedCardStats/index.js
+++ b/src/Components/ResultsCondensedCardStats/index.js
@@ -1,0 +1,1 @@
+export { default } from './ResultsCondensedCardStats';

--- a/src/Constants/BidCountDefinitions.js
+++ b/src/Constants/BidCountDefinitions.js
@@ -1,8 +1,8 @@
 const BID_COUNT_DEFINITIONS = {
-  totalBids: 'Number of bids on this position.',
-  inGradeBids: 'Number of bidders who are at Grade.',
-  atSkillBids: 'Number of bidders who are at Skill Code.',
-  inGradeAtSkillBids: 'Number of bidders who are at Grade and Skill Code.',
+  totalBids: { title: 'Total bids', definition: 'Number of bids on this position.' },
+  inGradeBids: { title: 'In-grade bids', definition: 'Number of bidders who are at Grade.' },
+  atSkillBids: { title: 'At-skill bids', definition: 'Number of bidders who are at Skill Code.' },
+  inGradeAtSkillBids: { title: 'In-grade and at-skill bids', definition: 'Number of bidders who are at Grade and Skill Code.' },
 };
 
 export default BID_COUNT_DEFINITIONS;

--- a/src/Constants/BidCountDefinitions.test.js
+++ b/src/Constants/BidCountDefinitions.test.js
@@ -2,9 +2,14 @@ import BID_COUNT_DEFINITIONS from './BidCountDefinitions';
 
 describe('BidCountDefinitions', () => {
   it('should return a value for valid bid count property', () => {
-    expect(BID_COUNT_DEFINITIONS.totalBids).toBeDefined();
-    expect(BID_COUNT_DEFINITIONS.inGradeBids).toBeDefined();
-    expect(BID_COUNT_DEFINITIONS.atSkillBids).toBeDefined();
-    expect(BID_COUNT_DEFINITIONS.inGradeAtSkillBids).toBeDefined();
+    expect(BID_COUNT_DEFINITIONS.totalBids.title).toBeDefined();
+    expect(BID_COUNT_DEFINITIONS.inGradeBids.title).toBeDefined();
+    expect(BID_COUNT_DEFINITIONS.atSkillBids.title).toBeDefined();
+    expect(BID_COUNT_DEFINITIONS.inGradeAtSkillBids.title).toBeDefined();
+
+    expect(BID_COUNT_DEFINITIONS.totalBids.definition).toBeDefined();
+    expect(BID_COUNT_DEFINITIONS.inGradeBids.definition).toBeDefined();
+    expect(BID_COUNT_DEFINITIONS.atSkillBids.definition).toBeDefined();
+    expect(BID_COUNT_DEFINITIONS.inGradeAtSkillBids.definition).toBeDefined();
   });
 });

--- a/src/Constants/PropTypes.js
+++ b/src/Constants/PropTypes.js
@@ -487,6 +487,8 @@ export const BID_STATISTICS_OBJECT = PropTypes.shape({
   bidding_days_remaining: PropTypes.number,
 });
 
+export const BID_STATISTICS_ARRAY = PropTypes.arrayOf(BID_STATISTICS_OBJECT);
+
 export const CLIENT_BY_ID = PropTypes.shape({
   id: PropTypes.number,
   current_assignment: ASSIGNMENT_OBJECT,

--- a/src/sass/_condensedCard.scss
+++ b/src/sass/_condensedCard.scss
@@ -1,5 +1,5 @@
 $condensed-card-margin-bottom: 15px;
-$condensed-card-padding: 14px 20px 9px;
+$condensed-card-padding: 9px 20px 9px;
 
 .condensed-card {
 
@@ -102,6 +102,40 @@ $condensed-card-padding: 14px 20px 9px;
     font-size: 16px;
   }
 
+  .condensed-card-buttons-section {
+    margin-bottom: 10px;
+  }
+
+  .condensed-card-statistics {
+    border-bottom: 1px solid $color-gray-lighter;
+    border-top: 0;
+
+    .bid-count-list-item {
+      background: $blue-primary;
+      color: $color-white;
+      margin-bottom: 0;
+    }
+
+    .bid-count-list-item:first-child {
+      border-radius: 5px 0 0 5px;
+    }
+
+    .bid-count-list-item:last-child {
+      border-radius: 0 5px 5px 0;
+    }
+
+    .bid-count-list {
+      float: right;
+      padding-left: 0;
+    }
+
+    .bid-count-label {
+      float: left;
+      margin-right: .5em;
+      padding-top: .2em;
+    }
+  }
+
   .condensed-card-data {
     margin-bottom: 20px;
 
@@ -175,7 +209,6 @@ $condensed-card-padding: 14px 20px 9px;
 
   .condensed-card-footer-container {
     padding: $condensed-card-padding;
-    padding-bottom: 14px;
   }
 
   .condensed-card-footer-left {

--- a/src/sass/_condensedCard.scss
+++ b/src/sass/_condensedCard.scss
@@ -116,6 +116,10 @@ $condensed-card-padding: 9px 20px 9px;
       margin-bottom: 0;
     }
 
+    .bid-count-number {
+      padding: .2em 1em;
+    }
+
     .bid-count-list-item:first-child {
       border-radius: 5px 0 0 5px;
     }
@@ -131,6 +135,7 @@ $condensed-card-padding: 9px 20px 9px;
 
     .bid-count-label {
       float: left;
+      font-weight: bold;
       margin-right: .5em;
       padding-top: .2em;
     }

--- a/src/sass/_details.scss
+++ b/src/sass/_details.scss
@@ -128,7 +128,7 @@
 .offset-bid-button-container {
   left: 63%;
   position: absolute;
-  top: 70%;
+  top: 55%;
 
   .offset-bid-button-container-count {
     min-height: 38px;

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -275,3 +275,12 @@ export const formatWaiverTitle = waiver => `${waiver.position} - ${waiver.catego
 // for traversing nested objects
 export const propOrDefault = (obj, path, defaultToReturn = null) =>
   dotProp.get(obj, path) || defaultToReturn;
+
+// Return the correct object from the bidStatisticsArray.
+// If it doesn't exist, return an empty object.
+export const getBidStatisticsObject = (bidStatisticsArray) => {
+  if (Array.isArray(bidStatisticsArray) && bidStatisticsArray.length) {
+    return bidStatisticsArray[0];
+  }
+  return {};
+};


### PR DESCRIPTION
Adds bid statistics to the homepage cards. Refactors the `BidCount` component to expect an object instead of individual numbers so that we can ensure consistency of the properties being used. Also adds a label to the `BidCount` component whose visibility can be toggled with a `hideLabel` prop.