### PR TITLE
Re-add the bid tracker link

### DIFF
--- a/src/Components/ProfileMenu/ProfileMenuExpanded/ProfileMenuExpanded.jsx
+++ b/src/Components/ProfileMenu/ProfileMenuExpanded/ProfileMenuExpanded.jsx
@@ -28,6 +28,10 @@ const ProfileMenuExpanded = ({ isCDO, expandedSection, collapse, toggleMenuSecti
           search="?type=all"
           hidden={!isCDO}
         />
+        <NavLink
+          title="Bidder Tracker"
+          link="/profile/bidtracker/"
+        />
         <NavLink title="Favorites" link="/profile/favorites/" />
         <NavLink title="Saved Searches" link="/profile/searches/" />
       </NavLink>

--- a/src/Components/ProfileMenu/ProfileMenuExpanded/__snapshots__/ProfileMenuExpanded.test.jsx.snap
+++ b/src/Components/ProfileMenu/ProfileMenuExpanded/__snapshots__/ProfileMenuExpanded.test.jsx.snap
@@ -45,6 +45,10 @@ exports[`ProfileMenuExpandedComponent matches snapshot when isCDO is false 1`] =
         title="Bidder Portfolio"
       />
       <withRouter(NavLink)
+        link="/profile/bidtracker/"
+        title="Bidder Tracker"
+      />
+      <withRouter(NavLink)
         link="/profile/favorites/"
         title="Favorites"
       />
@@ -132,6 +136,10 @@ exports[`ProfileMenuExpandedComponent matches snapshot when isCDO is true 1`] = 
         link="/profile/bidderportfolio/"
         search="?type=all"
         title="Bidder Portfolio"
+      />
+      <withRouter(NavLink)
+        link="/profile/bidtracker/"
+        title="Bidder Tracker"
       />
       <withRouter(NavLink)
         link="/profile/favorites/"


### PR DESCRIPTION
I accidentally removed the Bid Tracker link in https://github.com/18F/State-TalentMAP/pull/1452. That's fine for `release-candidate-1`, but the Bid Tracker should be included in our main branch.