### PR TITLE
Add short vs long text for Favorite component

### DIFF
--- a/src/Components/Favorite/Favorite.jsx
+++ b/src/Components/Favorite/Favorite.jsx
@@ -25,14 +25,29 @@ class Favorite extends Component {
   }
 
   render() {
+    const { useLongText } = this.props;
+
+    const shortTextFavorite = 'Favorite';
+    const longTextFavorite = 'Add to Favorites';
+    const shortTextRemove = 'Remove';
+    const longTextRemove = 'Remove from Favorites';
+
+    let favoriteText = shortTextFavorite;
+    let removeText = shortTextRemove;
+
+    if (useLongText) {
+      favoriteText = longTextFavorite;
+      removeText = longTextRemove;
+    }
+
     // set defaults
-    let text = 'Favorite';
+    let text = favoriteText;
     let title = 'Add to Favorites';
     let iconClass = 'star-o';
 
     // update for saved state
     if (this.getSavedState()) {
-      text = 'Remove';
+      text = removeText;
       title = 'Remove from Favorites';
       iconClass = 'star';
     }
@@ -62,6 +77,7 @@ Favorite.propTypes = {
   compareArray: FAVORITE_POSITIONS_ARRAY.isRequired,
   isLoading: PropTypes.bool,
   hasBorder: PropTypes.bool,
+  useLongText: PropTypes.bool,
 };
 
 Favorite.defaultProps = {
@@ -69,6 +85,7 @@ Favorite.defaultProps = {
   isLoading: false,
   compareArray: [],
   hasBorder: false,
+  useLongText: false,
 };
 
 export default Favorite;

--- a/src/Components/Favorite/Favorite.test.jsx
+++ b/src/Components/Favorite/Favorite.test.jsx
@@ -18,6 +18,19 @@ describe('Favorite', () => {
     expect(favorite).toBeDefined();
   });
 
+  it('is defined with different props', () => {
+    const wrapper = shallow(
+      <Favorite
+        onToggle={() => {}}
+        compareArray={[{ id: refKey }]}
+        refKey={refKey}
+        isLoading
+        hasBorder
+        hideText
+      />);
+    expect(wrapper).toBeDefined();
+  });
+
   it('handles being in the enabled state', () => {
     const spy = sinon.spy();
     const wrapper = shallow(
@@ -37,7 +50,28 @@ describe('Favorite', () => {
     expect(toJSON(wrapper)).toMatchSnapshot();
   });
 
+  it('matches snapshot when useLongText is true - Add state', () => {
+    const wrapper = shallow(<Favorite
+      onToggle={() => {}}
+      compareArray={[]}
+      refKey={refKey}
+      useLongText
+    />);
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+
   it('matches snapshot - Remove state', () => {
+    const array = [{ id: refKey }];
+    const wrapper = shallow(<Favorite
+      onToggle={() => {}}
+      compareArray={array}
+      refKey={refKey}
+      useLongText
+    />);
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+
+  it('matches snapshot when useLongText is true - Remove state', () => {
     const array = [{ id: refKey }];
     const wrapper = shallow(<Favorite onToggle={() => {}} compareArray={array} refKey={refKey} />);
     expect(toJSON(wrapper)).toMatchSnapshot();

--- a/src/Components/Favorite/__snapshots__/Favorite.test.jsx.snap
+++ b/src/Components/Favorite/__snapshots__/Favorite.test.jsx.snap
@@ -36,6 +36,46 @@ exports[`Favorite matches snapshot - Remove state 1`] = `
     name="star"
   />
    
+  Remove from Favorites
+</InteractiveElement>
+`;
+
+exports[`Favorite matches snapshot when useLongText is true - Add state 1`] = `
+<InteractiveElement
+  className="favorite-container "
+  onClick={[Function]}
+  style={
+    Object {
+      "pointerEvents": "inherit",
+    }
+  }
+  title="Add to Favorites"
+  type="div"
+>
+  <FontAwesome
+    name="star-o"
+  />
+   
+  Add to Favorites
+</InteractiveElement>
+`;
+
+exports[`Favorite matches snapshot when useLongText is true - Remove state 1`] = `
+<InteractiveElement
+  className="favorite-container "
+  onClick={[Function]}
+  style={
+    Object {
+      "pointerEvents": "inherit",
+    }
+  }
+  title="Remove from Favorites"
+  type="div"
+>
+  <FontAwesome
+    name="star"
+  />
+   
   Remove
 </InteractiveElement>
 `;

--- a/src/Components/ResultsCard/__snapshots__/ResultsCard.test.jsx.snap
+++ b/src/Components/ResultsCard/__snapshots__/ResultsCard.test.jsx.snap
@@ -25,6 +25,7 @@ exports[`ResultsCardComponent matches snapshot 1`] = `
         isLoading={false}
         onToggle={[Function]}
         refKey={6}
+        useLongText={false}
       />
     </div>
   </div>

--- a/src/Components/ResultsCondensedCardBottom/__snapshots__/ResultsCondensedCardBottom.test.jsx.snap
+++ b/src/Components/ResultsCondensedCardBottom/__snapshots__/ResultsCondensedCardBottom.test.jsx.snap
@@ -85,6 +85,7 @@ exports[`ResultsCondensedCardBottomComponent matches snapshot 1`] = `
         isLoading={false}
         onToggle={[Function]}
         refKey={6}
+        useLongText={false}
       />
       <BidListButton
         className="tm-button"


### PR DESCRIPTION
Adds a prop the `Favorite` component to enable displaying a long version of the text. Could be helpful in `release-candidate-1`, but as a general feature should be included in `sprint-15` as well.