### PR TITLE
Replace dot-prop with local utility

### DIFF
--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -158,7 +158,6 @@ module.exports = {
       // Process JS with Babel.
       {
         test: /\.(js|jsx)$/,
-        exclude: /node_modules\/(?!dot-prop)\/*/,
         loader: require.resolve('babel-loader'),
 
       },

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -158,6 +158,7 @@ module.exports = {
       // Process JS with Babel.
       {
         test: /\.(js|jsx)$/,
+        include: paths.appSrc,
         loader: require.resolve('babel-loader'),
 
       },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "axios": "^0.17.1",
     "babel-polyfill": "^6.26.0",
     "date-fns": "^1.29.0",
-    "dot-prop": "^4.2.0",
     "draft-js": "^0.10.4",
     "draft-js-plugins-editor": "^2.0.4",
     "express": "^4.16.2",

--- a/src/Components/PositionDetailsItem/__snapshots__/PositionDetailsItem.test.jsx.snap
+++ b/src/Components/PositionDetailsItem/__snapshots__/PositionDetailsItem.test.jsx.snap
@@ -104,7 +104,7 @@ exports[`PositionDetailsItem matches snapshot 1`] = `
             title="Skill Code"
           />
           <PositionDetailsDataPoint
-            description="None listed"
+            description={0}
             title="Danger Pay"
           />
           <PositionDetailsDataPoint

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -2,7 +2,6 @@ import Scroll from 'react-scroll';
 import queryString from 'query-string';
 import distanceInWords from 'date-fns/distance_in_words';
 import format from 'date-fns/format';
-import dotProp from 'dot-prop';
 import numeral from 'numeral';
 import { VALID_PARAMS } from './Constants/EndpointParams';
 
@@ -272,9 +271,30 @@ export const formatBidTitle = bid => `${bid.position.title} (${bid.position.posi
 
 export const formatWaiverTitle = waiver => `${waiver.position} - ${waiver.category.toUpperCase()}`;
 
-// for traversing nested objects
-export const propOrDefault = (obj, path, defaultToReturn = null) =>
-  dotProp.get(obj, path) || defaultToReturn;
+// for traversing nested objects.
+// obj should be an object, such as { a: { b: 1, c: { d: 2 } } }
+// path should be a string to the desired path - "a.b.c.d"
+// defaultToReturn should be the default value you want to return if the traversal fails
+export const propOrDefault = (obj, path, defaultToReturn = null) => {
+  // split the path into individual
+  const args = path.split('.');
+
+  let valueToReturn = obj;
+
+  // function to determine if object contains the next i property
+  const returnSubProp = i => Object.prototype.hasOwnProperty.call(valueToReturn, args[i]);
+
+  // iterate through each arg and change valueToReturn to the next i property if it exists,
+  // otherwise return the defaultToReturn
+  for (let i = 0; i < args.length; i += 1) {
+    if (valueToReturn && returnSubProp(i)) {
+      valueToReturn = valueToReturn[args[i]];
+    } else if (!valueToReturn || !returnSubProp(i)) {
+      return defaultToReturn;
+    }
+  }
+  return valueToReturn;
+};
 
 // Return the correct object from the bidStatisticsArray.
 // If it doesn't exist, return an empty object.

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -276,7 +276,7 @@ export const formatWaiverTitle = waiver => `${waiver.position} - ${waiver.catego
 // path should be a string to the desired path - "a.b.c.d"
 // defaultToReturn should be the default value you want to return if the traversal fails
 export const propOrDefault = (obj, path, defaultToReturn = null) => {
-  // split the path into individual
+  // split the path into individual strings
   const args = path.split('.');
 
   let valueToReturn = obj;

--- a/src/utilities.test.js
+++ b/src/utilities.test.js
@@ -357,20 +357,25 @@ describe('propOrDefault', () => {
       c: {
         d: {},
         e: 1,
+        f: 0,
       },
     },
   };
 
-  it('can traverse nested objects', () => {
+  it('traverses nested objects', () => {
     expect(propOrDefault(nestedObject, 'a.b')).toBe(true);
     expect(propOrDefault(nestedObject, 'a.c.d')).toBeDefined();
     expect(propOrDefault(nestedObject, 'a.c.e')).toBe(1);
   });
 
-  it('can return the default value when the nested property does not exist', () => {
+  it('returns the default value when the nested property does not exist', () => {
     expect(propOrDefault(nestedObject, 'a.b.e.e.e')).toBe(null);
     expect(propOrDefault(nestedObject, 'a.g')).toBe(null);
     expect(propOrDefault(nestedObject, 'a.b.c.d.d', 'value')).toBe('value');
+  });
+
+  it('returns the property value when the property value exists, but is 0', () => {
+    expect(propOrDefault(nestedObject, 'a.c.f')).toBe(0);
   });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2498,12 +2498,6 @@ dot-prop@^3.0.0:
   dependencies:
     is-obj "^1.0.0"
 
-dot-prop@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.0.tgz#1f19e0c2e1aa0e32797c49799f2837ac6af69c57"
-  dependencies:
-    is-obj "^1.0.0"
-
 dotenv@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-4.0.0.tgz#864ef1379aced55ce6f95debecdce179f7a0cd1d"


### PR DESCRIPTION
IE11 has issues with `dot-prop`, so I replaced it with a local utility that performs the same job. It has the added benefit of returning the property value for `0`s.