### PR TITLE
Sprint 15 PR Feedback

### DIFF
--- a/src/Components/FavoritePositions/FavoritePositions.jsx
+++ b/src/Components/FavoritePositions/FavoritePositions.jsx
@@ -8,7 +8,7 @@ import Spinner from '../Spinner';
 const FavoritePositions = ({ favorites, favoritePositionsIsLoading, favoritePositionsHasErrored,
 toggleFavorite, toggleFavoritePositionIsLoading, toggleFavoritePositionHasErrored,
 toggleBid, bidList }) => (
-  <div className={`usa-grid-full favorite-positions-container profile-content-inner-container ${favoritePositionsIsLoading ? 'results-loading' : null}`}>
+  <div className={`usa-grid-full favorite-positions-container profile-content-inner-container ${favoritePositionsIsLoading ? 'results-loading' : ''}`}>
     <ProfileSectionTitle title="Your Favorite Positions:" />
     {
       favoritePositionsIsLoading && !favoritePositionsHasErrored &&

--- a/src/Components/FavoritePositions/__snapshots__/FavoritePositions.test.jsx.snap
+++ b/src/Components/FavoritePositions/__snapshots__/FavoritePositions.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`FavoritePositionsComponent matches snapshot 1`] = `
 <div
-  className="usa-grid-full favorite-positions-container profile-content-inner-container null"
+  className="usa-grid-full favorite-positions-container profile-content-inner-container "
 >
   <ProfileSectionTitle
     title="Your Favorite Positions:"

--- a/src/Components/GlossaryEditor/ArchiveIcon/ArchiveIcon.jsx
+++ b/src/Components/GlossaryEditor/ArchiveIcon/ArchiveIcon.jsx
@@ -12,14 +12,11 @@ class ArchiveIcon extends Component {
     };
   }
 
-  componentWillReceiveProps(props) {
+  componentWillReceiveProps(nextProp) {
     // Reset the isArchived state to the object's value if
     // hasErrored becomes true after the initial mount.
-    //
-    // codeclimate and local dev in Atom catch prop types errors differently:
-    // eslint-disable-next-line react/prop-types
-    if (props.hasErrored) {
-      this.setState({ isArchived: props.isArchived });
+    if (nextProp.hasErrored) {
+      this.setState({ isArchived: nextProp.isArchived });
     }
   }
 

--- a/src/Components/GlossaryEditor/GlossaryEditorCardBottom/History/History.test.jsx
+++ b/src/Components/GlossaryEditor/GlossaryEditorCardBottom/History/History.test.jsx
@@ -31,4 +31,14 @@ describe('HistoryComponent', () => {
     const wrapper = shallow(<History {...props} isArchived={false} />);
     expect(toJSON(wrapper)).toMatchSnapshot();
   });
+
+  it('matches snapshot when dateUpdated is undefined', () => {
+    const wrapper = shallow(<History {...props} isArchived={false} dateUpdated={undefined} />);
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+
+  it('matches snapshot when updatedBy is undefined', () => {
+    const wrapper = shallow(<History {...props} isArchived={false} updatedBy={undefined} />);
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
 });

--- a/src/Components/GlossaryEditor/GlossaryEditorCardBottom/History/__snapshots__/History.test.jsx.snap
+++ b/src/Components/GlossaryEditor/GlossaryEditorCardBottom/History/__snapshots__/History.test.jsx.snap
@@ -20,6 +20,26 @@ exports[`HistoryComponent matches snapshot 1`] = `
 </div>
 `;
 
+exports[`HistoryComponent matches snapshot when dateUpdated is undefined 1`] = `
+<div
+  className="usa-grid-full glossary-editor-card-bottom"
+>
+  <div>
+    Date updated unknown
+  </div>
+  <div>
+    Editor: 
+    John Doe
+  </div>
+  <ArchiveIcon
+    hasErrored={false}
+    id={1}
+    isArchived={false}
+    onSubmitOption={[Function]}
+  />
+</div>
+`;
+
 exports[`HistoryComponent matches snapshot when isArchived is false 1`] = `
 <div
   className="usa-grid-full glossary-editor-card-bottom"
@@ -30,6 +50,26 @@ exports[`HistoryComponent matches snapshot when isArchived is false 1`] = `
   <div>
     Editor: 
     John Doe
+  </div>
+  <ArchiveIcon
+    hasErrored={false}
+    id={1}
+    isArchived={false}
+    onSubmitOption={[Function]}
+  />
+</div>
+`;
+
+exports[`HistoryComponent matches snapshot when updatedBy is undefined 1`] = `
+<div
+  className="usa-grid-full glossary-editor-card-bottom"
+>
+  <div>
+    Updated on 2.12.2018
+  </div>
+  <div>
+    Editor: 
+    None listed
   </div>
   <ArchiveIcon
     hasErrored={false}


### PR DESCRIPTION
Fixes from sprint-15 feedback (https://github.com/18F/State-TalentMAP/pull/1500), including:

- [Render empty string instead of `null` in `className`](https://github.com/18F/State-TalentMAP/pull/1500/files/9aab4ccff939bc7c412c59f51c5cc9e7edc64967#diff-bea1d7b2b56ce6f93bff222a0d70f016)
- [Use `nextProp` instead of `props` for properties used in `componentWillReceiveProps`](https://github.com/18F/State-TalentMAP/pull/1500/files/9aab4ccff939bc7c412c59f51c5cc9e7edc64967#diff-82c82977c2df13d0521bb1a7b6ebb8c4)
- [Add snapshot tests for the `History` component](https://github.com/18F/State-TalentMAP/pull/1500/files/9aab4ccff939bc7c412c59f51c5cc9e7edc64967#diff-a7c4b3e9354f261f5b138857c530bcc7)