### PR TITLE
Date difference in NotificationsItem snapshot

### DIFF
--- a/src/Components/ProfileDashboard/Notifications/NotificationItem/NotificationItem.test.jsx
+++ b/src/Components/ProfileDashboard/Notifications/NotificationItem/NotificationItem.test.jsx
@@ -17,9 +17,10 @@ describe('NotificationItemComponent', () => {
 
   it('matches snapshot', () => {
     // Use subMonths so that snapshot doesn't go out of date every month.
-    // Using "2" means that our snapshot should always render "about 2 months ago"
-    // as its title. We subtract 2.1 so that it's not exactly 2 months ago, which
-    // some times renders "2 months ago" since it's exact.
+    // Using "2" means that our snapshot will some times render "about 2 months ago"
+    // and some times "2 months ago" as its title, since it's technically exact.
+    // We subtract 2.1 so that it's not exactly 2 months ago, which
+    // should always render "about 2 months ago".
     // https://date-fns.org/v1.29.0/docs/distanceInWords
     const notificationTime = subMonths(new Date(), 2.1).toString();
     const wrapper = shallow(

--- a/src/Components/ProfileDashboard/Notifications/NotificationItem/NotificationItem.test.jsx
+++ b/src/Components/ProfileDashboard/Notifications/NotificationItem/NotificationItem.test.jsx
@@ -17,9 +17,11 @@ describe('NotificationItemComponent', () => {
 
   it('matches snapshot', () => {
     // Use subMonths so that snapshot doesn't go out of date every month.
-    // Using "2" means that our snapshot should always render "2 months ago"
-    // as its title.
-    const notificationTime = subMonths(new Date(), 2).toString();
+    // Using "2" means that our snapshot should always render "about 2 months ago"
+    // as its title. We subtract 2.1 so that it's not exactly 2 months ago, which
+    // some times renders "2 months ago" since it's exact.
+    // https://date-fns.org/v1.29.0/docs/distanceInWords
+    const notificationTime = subMonths(new Date(), 2.1).toString();
     const wrapper = shallow(
       <NotificationItem
         content="content"

--- a/src/Components/ProfileDashboard/Notifications/NotificationItem/__snapshots__/NotificationItem.test.jsx.snap
+++ b/src/Components/ProfileDashboard/Notifications/NotificationItem/__snapshots__/NotificationItem.test.jsx.snap
@@ -8,7 +8,7 @@ exports[`NotificationItemComponent matches snapshot 1`] = `
     className=""
     content="content"
     sideBySide={false}
-    title="2 months ago"
+    title="about 2 months ago"
     titleOnBottom={true}
   />
 </div>


### PR DESCRIPTION
The date difference we used in this test was exactly 2, which caused it to some times render "about 2 months ago" and some times render "2 months ago". This changes the mock date difference to 2.1, which should cause it to always render as "about 2 months ago".

This should then be pushed to `staging` to resolve test errors.