### PR TITLE
Permission Groups

### DIFF
--- a/src/Components/ProfileMenu/ProfileMenu.jsx
+++ b/src/Components/ProfileMenu/ProfileMenu.jsx
@@ -24,7 +24,7 @@ class ProfileMenu extends Component {
 
   render() {
     const { profileMenuExpanded, profileMenuSectionExpanded, isCDO,
-      onSetProfileMenuExpanded, onSetProfileMenuSectionExpanded } = this.props;
+      onSetProfileMenuExpanded, onSetProfileMenuSectionExpanded, isGlossaryEditor } = this.props;
     return (
         profileMenuExpanded ?
           <ProfileMenuExpanded
@@ -32,11 +32,13 @@ class ProfileMenu extends Component {
             collapse={this.collapseMenu}
             toggleMenuSection={onSetProfileMenuSectionExpanded}
             isCDO={isCDO}
+            isGlossaryEditor={isGlossaryEditor}
           />
           :
           <ProfileMenuCollapsed
             toggleMenu={onSetProfileMenuExpanded}
             expand={this.expandMenu}
+            isGlossaryEditor={isGlossaryEditor}
           />
     );
   }
@@ -48,6 +50,7 @@ ProfileMenu.propTypes = {
   onSetProfileMenuExpanded: PropTypes.func.isRequired,
   onSetProfileMenuSectionExpanded: PropTypes.func.isRequired,
   isCDO: PropTypes.bool,
+  isGlossaryEditor: PropTypes.bool,
 };
 
 ProfileMenu.defaultProps = {
@@ -56,6 +59,7 @@ ProfileMenu.defaultProps = {
   onSetProfileMenuExpanded: EMPTY_FUNCTION,
   onSetProfileMenuSectionExpanded: EMPTY_FUNCTION,
   isCDO: false,
+  isGlossaryEditor: false,
 };
 
 const mapStateToProps = state => ({

--- a/src/Components/ProfileMenu/ProfileMenuCollapsed/ProfileMenuCollapsed.jsx
+++ b/src/Components/ProfileMenu/ProfileMenuCollapsed/ProfileMenuCollapsed.jsx
@@ -4,7 +4,7 @@ import FontAwesome from 'react-fontawesome';
 import NavLinksContainer from '../NavLinksContainer';
 import NavLink from '../NavLink';
 
-const ProfileMenuCollapsed = ({ expand }) => (
+const ProfileMenuCollapsed = ({ expand, isGlossaryEditor }) => (
   <div className="usa-grid-full profile-menu profile-menu-collapsed">
     <div className="menu-title">
       <button className="unstyled-button" title="Expand menu" onClick={expand}>
@@ -14,7 +14,7 @@ const ProfileMenuCollapsed = ({ expand }) => (
     <NavLinksContainer>
       <NavLink iconName="user" link="/profile/dashboard/" />
       <NavLink iconName="pie-chart" link="/profile/statistics/" />
-      <NavLink iconName="book" link="/profile/glossaryeditor/" search="?type=all" />
+      <NavLink iconName="book" link="/profile/glossaryeditor/" search="?type=all" hidden={!isGlossaryEditor} />
       <NavLink iconName="comments-o" link="/profile/inbox/" />
       <NavLink iconName="globe" link="/profile/notifications/" />
       <NavLink iconName="users" link="/profile/contacts/" />
@@ -25,6 +25,11 @@ const ProfileMenuCollapsed = ({ expand }) => (
 
 ProfileMenuCollapsed.propTypes = {
   expand: PropTypes.func.isRequired,
+  isGlossaryEditor: PropTypes.bool,
+};
+
+ProfileMenuCollapsed.defaultProps = {
+  isGlossaryEditor: false,
 };
 
 export default ProfileMenuCollapsed;

--- a/src/Components/ProfileMenu/ProfileMenuCollapsed/ProfileMenuCollapsed.test.jsx
+++ b/src/Components/ProfileMenu/ProfileMenuCollapsed/ProfileMenuCollapsed.test.jsx
@@ -5,6 +5,7 @@ import ProfileMenuCollapsed from './ProfileMenuCollapsed';
 
 describe('ProfileMenuCollapsedComponent', () => {
   const props = {
+    isGlossaryEditor: true,
     expand: () => {},
     toggleMenuSection: () => {},
   };
@@ -19,6 +20,13 @@ describe('ProfileMenuCollapsedComponent', () => {
   it('matches snapshot', () => {
     const wrapper = shallow(
       <ProfileMenuCollapsed {...props} />,
+    );
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+
+  it('matches snapshot when isGlossaryEditor is false', () => {
+    const wrapper = shallow(
+      <ProfileMenuCollapsed {...props} isGlossaryEditor={false} />,
     );
     expect(toJSON(wrapper)).toMatchSnapshot();
   });

--- a/src/Components/ProfileMenu/ProfileMenuCollapsed/__snapshots__/ProfileMenuCollapsed.test.jsx.snap
+++ b/src/Components/ProfileMenu/ProfileMenuCollapsed/__snapshots__/ProfileMenuCollapsed.test.jsx.snap
@@ -27,6 +27,59 @@ exports[`ProfileMenuCollapsedComponent matches snapshot 1`] = `
       link="/profile/statistics/"
     />
     <withRouter(NavLink)
+      hidden={false}
+      iconName="book"
+      link="/profile/glossaryeditor/"
+      search="?type=all"
+    />
+    <withRouter(NavLink)
+      iconName="comments-o"
+      link="/profile/inbox/"
+    />
+    <withRouter(NavLink)
+      iconName="globe"
+      link="/profile/notifications/"
+    />
+    <withRouter(NavLink)
+      iconName="users"
+      link="/profile/contacts/"
+    />
+    <withRouter(NavLink)
+      iconName="file-text"
+      link="/profile/documents/"
+    />
+  </NavLinksContainer>
+</div>
+`;
+
+exports[`ProfileMenuCollapsedComponent matches snapshot when isGlossaryEditor is false 1`] = `
+<div
+  className="usa-grid-full profile-menu profile-menu-collapsed"
+>
+  <div
+    className="menu-title"
+  >
+    <button
+      className="unstyled-button"
+      onClick={[Function]}
+      title="Expand menu"
+    >
+      <FontAwesome
+        name="exchange"
+      />
+    </button>
+  </div>
+  <NavLinksContainer>
+    <withRouter(NavLink)
+      iconName="user"
+      link="/profile/dashboard/"
+    />
+    <withRouter(NavLink)
+      iconName="pie-chart"
+      link="/profile/statistics/"
+    />
+    <withRouter(NavLink)
+      hidden={true}
       iconName="book"
       link="/profile/glossaryeditor/"
       search="?type=all"

--- a/src/Components/ProfileMenu/ProfileMenuExpanded/ProfileMenuExpanded.jsx
+++ b/src/Components/ProfileMenu/ProfileMenuExpanded/ProfileMenuExpanded.jsx
@@ -6,7 +6,8 @@ import { PROFILE_MENU_SECTION_EXPANDED } from '../../../Constants/PropTypes';
 import NavLinksContainer from '../NavLinksContainer';
 import NavLink from '../NavLink';
 
-const ProfileMenuExpanded = ({ isCDO, expandedSection, collapse, toggleMenuSection }) => (
+const ProfileMenuExpanded = ({ isCDO, expandedSection, collapse, toggleMenuSection,
+isGlossaryEditor }) => (
   <div className="usa-grid-full profile-menu">
     <div className="menu-title">
       <div className="menu-title-text">Menu</div>
@@ -41,7 +42,7 @@ const ProfileMenuExpanded = ({ isCDO, expandedSection, collapse, toggleMenuSecti
         link="/profile/statistics/"
         hidden={!isCDO}
       />
-      <NavLink title="Glossary Editor" iconName="book" link="/profile/glossaryeditor/" search="?type=all" />
+      <NavLink title="Glossary Editor" iconName="book" link="/profile/glossaryeditor/" search="?type=all" hidden={!isGlossaryEditor} />
       <NavLink title="Inbox" iconName="comments-o" link="/profile/inbox/" />
       <NavLink title="Notifications" iconName="globe" link="/profile/notifications/" />
       <NavLink title="Contacts" iconName="users" link="/profile/contacts/" />
@@ -55,11 +56,13 @@ ProfileMenuExpanded.propTypes = {
   expandedSection: PROFILE_MENU_SECTION_EXPANDED,
   collapse: PropTypes.func.isRequired,
   toggleMenuSection: PropTypes.func.isRequired,
+  isGlossaryEditor: PropTypes.bool,
 };
 
 ProfileMenuExpanded.defaultProps = {
   isCDO: false,
   expandedSection: PROFILE_MENU_SECTION_EXPANDED_OBJECT,
+  isGlossaryEditor: false,
 };
 
 export default ProfileMenuExpanded;

--- a/src/Components/ProfileMenu/ProfileMenuExpanded/ProfileMenuExpanded.test.jsx
+++ b/src/Components/ProfileMenu/ProfileMenuExpanded/ProfileMenuExpanded.test.jsx
@@ -6,6 +6,7 @@ import ProfileMenuExpanded from './ProfileMenuExpanded';
 describe('ProfileMenuExpandedComponent', () => {
   const props = {
     isCDO: true,
+    isGlossaryEditor: true,
     collapse: () => {},
     toggleMenuSection: () => {},
   };
@@ -20,6 +21,13 @@ describe('ProfileMenuExpandedComponent', () => {
   it('matches snapshot when isCDO is false', () => {
     const wrapper = shallow(
       <ProfileMenuExpanded {...props} isCDO={false} />,
+    );
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+
+  it('matches snapshot when isGlossaryEditor is false', () => {
+    const wrapper = shallow(
+      <ProfileMenuExpanded {...props} isGlossaryEditor={false} />,
     );
     expect(toJSON(wrapper)).toMatchSnapshot();
   });

--- a/src/Components/ProfileMenu/ProfileMenuExpanded/__snapshots__/ProfileMenuExpanded.test.jsx.snap
+++ b/src/Components/ProfileMenu/ProfileMenuExpanded/__snapshots__/ProfileMenuExpanded.test.jsx.snap
@@ -64,6 +64,7 @@ exports[`ProfileMenuExpandedComponent matches snapshot when isCDO is false 1`] =
       title="Statistics"
     />
     <withRouter(NavLink)
+      hidden={false}
       iconName="book"
       link="/profile/glossaryeditor/"
       search="?type=all"
@@ -157,6 +158,101 @@ exports[`ProfileMenuExpandedComponent matches snapshot when isCDO is true 1`] = 
       title="Statistics"
     />
     <withRouter(NavLink)
+      hidden={false}
+      iconName="book"
+      link="/profile/glossaryeditor/"
+      search="?type=all"
+      title="Glossary Editor"
+    />
+    <withRouter(NavLink)
+      iconName="comments-o"
+      link="/profile/inbox/"
+      title="Inbox"
+    />
+    <withRouter(NavLink)
+      iconName="globe"
+      link="/profile/notifications/"
+      title="Notifications"
+    />
+    <withRouter(NavLink)
+      iconName="users"
+      link="/profile/contacts/"
+      title="Contacts"
+    />
+    <withRouter(NavLink)
+      iconName="file-text"
+      link="/profile/documents/"
+      title="Documents"
+    />
+  </NavLinksContainer>
+</div>
+`;
+
+exports[`ProfileMenuExpandedComponent matches snapshot when isGlossaryEditor is false 1`] = `
+<div
+  className="usa-grid-full profile-menu"
+>
+  <div
+    className="menu-title"
+  >
+    <div
+      className="menu-title-text"
+    >
+      Menu
+    </div>
+    <button
+      className="unstyled-button"
+      onClick={[Function]}
+      title="Collapse menu"
+    >
+      <FontAwesome
+        name="exchange"
+      />
+    </button>
+  </div>
+  <NavLinksContainer>
+    <withRouter(NavLink)
+      expandedSection={
+        Object {
+          "display": false,
+          "title": "",
+        }
+      }
+      iconName="user"
+      title="Profile"
+      toggleMenuSection={[Function]}
+    >
+      <withRouter(NavLink)
+        link="/profile/dashboard/"
+        title="Dashboard"
+      />
+      <withRouter(NavLink)
+        hidden={false}
+        link="/profile/bidderportfolio/"
+        search="?type=all"
+        title="Bidder Portfolio"
+      />
+      <withRouter(NavLink)
+        link="/profile/bidtracker/"
+        title="Bidder Tracker"
+      />
+      <withRouter(NavLink)
+        link="/profile/favorites/"
+        title="Favorites"
+      />
+      <withRouter(NavLink)
+        link="/profile/searches/"
+        title="Saved Searches"
+      />
+    </withRouter(NavLink)>
+    <withRouter(NavLink)
+      hidden={false}
+      iconName="pie-chart"
+      link="/profile/statistics/"
+      title="Statistics"
+    />
+    <withRouter(NavLink)
+      hidden={true}
       iconName="book"
       link="/profile/glossaryeditor/"
       search="?type=all"

--- a/src/Components/ProfilePage/ProfilePage.jsx
+++ b/src/Components/ProfilePage/ProfilePage.jsx
@@ -9,10 +9,11 @@ import BidStatistics from '../../Containers/BidStatistics';
 import GlossaryEditor from '../../Containers/GlossaryEditor';
 import ProfileMenu from '../ProfileMenu';
 import { USER_PROFILE } from '../../Constants/PropTypes';
+import { userHasPermissions } from '../../utilities';
 
 const ProfilePage = ({ user }) => (
   <div className="profile-page">
-    <ProfileMenu isCDO={user.is_cdo} />
+    <ProfileMenu isCDO={user.is_cdo} isGlossaryEditor={userHasPermissions(['glossary_editors'], user.permission_groups)} />
     <div className="usa-grid-full profile-content-container">
       <Switch>
         <Route path="/profile/dashboard" component={Dashboard} />

--- a/src/Components/ProfilePage/ProfilePage.jsx
+++ b/src/Components/ProfilePage/ProfilePage.jsx
@@ -10,10 +10,14 @@ import GlossaryEditor from '../../Containers/GlossaryEditor';
 import ProfileMenu from '../ProfileMenu';
 import { USER_PROFILE } from '../../Constants/PropTypes';
 import { userHasPermissions } from '../../utilities';
+import GLOSSARY_EDITOR_PERM from '../../Constants/Permissions';
 
 const ProfilePage = ({ user }) => (
   <div className="profile-page">
-    <ProfileMenu isCDO={user.is_cdo} isGlossaryEditor={userHasPermissions(['glossary_editors'], user.permission_groups)} />
+    <ProfileMenu
+      isCDO={user.is_cdo}
+      isGlossaryEditor={userHasPermissions([GLOSSARY_EDITOR_PERM], user.permission_groups)}
+    />
     <div className="usa-grid-full profile-content-container">
       <Switch>
         <Route path="/profile/dashboard" component={Dashboard} />

--- a/src/Components/ProfilePage/__snapshots__/ProfilePage.test.jsx.snap
+++ b/src/Components/ProfilePage/__snapshots__/ProfilePage.test.jsx.snap
@@ -6,6 +6,7 @@ exports[`ProfilePageComponent matches snapshot 1`] = `
 >
   <Connect(ProfileMenu)
     isCDO={false}
+    isGlossaryEditor={false}
   />
   <div
     className="usa-grid-full profile-content-container"

--- a/src/Constants/Permissions.js
+++ b/src/Constants/Permissions.js
@@ -1,0 +1,3 @@
+const GLOSSARY_EDITOR_PERM = 'glossary_editors';
+
+export default GLOSSARY_EDITOR_PERM;

--- a/src/actions/userProfile.test.js
+++ b/src/actions/userProfile.test.js
@@ -17,6 +17,13 @@ describe('async actions', () => {
     received_shares: [],
   };
 
+  const permission = {
+    groups: [
+      'post_editors_215',
+      'glossary_editors',
+    ],
+  };
+
   // reset the mockAdapter since we repeat specific requests
   beforeEach(() => {
     mockAdapter.reset();
@@ -27,6 +34,10 @@ describe('async actions', () => {
 
     mockAdapter.onGet('http://localhost:8000/api/v1/profile/').reply(200,
       profile,
+    );
+
+    mockAdapter.onGet('http://localhost:8000/api/v1/permission/user/').reply(200,
+      permission,
     );
 
     const f = () => {
@@ -89,7 +100,13 @@ describe('async actions', () => {
   it('can handle errors', (done) => {
     const store = mockStore({ profile: {} });
 
-    mockAdapter.onGet('http://localhost:8000/api/v1/profile').reply(404,
+    mockAdapter.reset();
+
+    mockAdapter.onGet('http://localhost:8000/api/v1/profile/').reply(404,
+      {},
+    );
+
+    mockAdapter.onGet('http://localhost:8000/api/v1/permission/user/').reply(404,
       {},
     );
 

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -316,12 +316,5 @@ export const formatIdSpacing = (id) => {
 };
 
 // provide an array of permissions to check if they all exist in an array of user permissions
-export const userHasPermissions = (permissionsToCheck = [], userPermissions = []) => {
-  let hasPermissions = true;
-  permissionsToCheck.forEach((perm) => {
-    if (userPermissions.indexOf(perm) <= -1) {
-      hasPermissions = false;
-    }
-  });
-  return hasPermissions;
-};
+export const userHasPermissions = (permissionsToCheck = [], userPermissions = []) =>
+  permissionsToCheck.every(val => userPermissions.indexOf(val) >= 0);

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -314,3 +314,14 @@ export const formatIdSpacing = (id) => {
   // if id is not defined, return null
   return null;
 };
+
+// provide an array of permissions to check if they all exist in an array of user permissions
+export const userHasPermissions = (permissionsToCheck = [], userPermissions = []) => {
+  let hasPermissions = true;
+  permissionsToCheck.forEach((perm) => {
+    if (userPermissions.indexOf(perm) <= -1) {
+      hasPermissions = false;
+    }
+  });
+  return hasPermissions;
+};

--- a/src/utilities.test.js
+++ b/src/utilities.test.js
@@ -24,6 +24,7 @@ import { validStateEmail,
          formatWaiverTitle,
          propOrDefault,
          formatIdSpacing,
+         userHasPermissions,
        } from './utilities';
 
 describe('local storage', () => {
@@ -393,5 +394,44 @@ describe('formatIdSpacing', () => {
     expect(formatIdSpacing(undefined)).toBe(null);
     expect(formatIdSpacing(null)).toBe(null);
     expect(formatIdSpacing(false)).toBe(null);
+  });
+});
+
+describe('userHasPermissions', () => {
+  let userPermissions;
+  let permissionsToCheck;
+  beforeEach(() => {
+    userPermissions = ['a', 'b', 'c'];
+    permissionsToCheck = ['a', 'c'];
+  });
+
+  it('returns true if the user has all the needed permissions', () => {
+    expect(userHasPermissions(permissionsToCheck, userPermissions)).toBe(true);
+  });
+
+  it('returns false if the user has some of the needed permissions', () => {
+    userPermissions = ['a'];
+    expect(userHasPermissions(permissionsToCheck, userPermissions)).toBe(false);
+  });
+
+  it('returns true if the user has more than the needed permissions', () => {
+    userPermissions.push('d', 'e');
+    expect(userHasPermissions(permissionsToCheck, userPermissions)).toBe(true);
+  });
+
+  it('returns false if userPermissions are not provided', () => {
+    userPermissions = [];
+    expect(userHasPermissions(permissionsToCheck, userPermissions)).toBe(false);
+  });
+
+  it('returns true if permissionsToCheck are not provided', () => {
+    permissionsToCheck = [];
+    expect(userHasPermissions(permissionsToCheck, userPermissions)).toBe(true);
+  });
+
+  it('returns true if permissionsToCheck and userPermissions are not provided', () => {
+    permissionsToCheck = [];
+    userPermissions = [];
+    expect(userHasPermissions(permissionsToCheck, userPermissions)).toBe(true);
   });
 });


### PR DESCRIPTION
Fetches the user's permission groups along with their profile and combines the two objects into one. Then uses this data to determine whether to display the Glossary Editor link in the profile menu.