### PR TITLE
Stale Token API Interceptors

### DIFF
--- a/src/Components/GlossaryEditor/GlossaryEditorCardBottom/ErrorMessage/ErrorMessage.test.jsx
+++ b/src/Components/GlossaryEditor/GlossaryEditorCardBottom/ErrorMessage/ErrorMessage.test.jsx
@@ -41,7 +41,7 @@ describe('ErrorMessageComponent', () => {
   });
 
   it('matches snapshot when showResponseError and showEmptyWarning are true', () => {
-    const wrapper = shallow(<ErrorMessage error={errorProp} showEmptyWarning  />);
+    const wrapper = shallow(<ErrorMessage error={errorProp} showEmptyWarning />);
     expect(toJSON(wrapper)).toMatchSnapshot();
   });
 });

--- a/src/Components/Header/Notifications/Notifications.jsx
+++ b/src/Components/Header/Notifications/Notifications.jsx
@@ -4,14 +4,32 @@ import { withRouter } from 'react-router';
 import { connect } from 'react-redux';
 import { notificationsCountFetchData } from '../../../actions/notifications';
 import IconAlert from '../../IconAlert';
+import isCurrentPath from '../../ProfileMenu/navigation';
+import { PUBLIC_ROOT } from '../../../login/DefaultRoutes';
 
 class Notifications extends Component {
   componentWillMount() {
-    const { fetchNotificationsCount, history } = this.props;
-    fetchNotificationsCount();
-    // listen for a route change to refresh notifications
-    history.listen(() => {
+    const { fetchNotificationsCount, history, location } = this.props;
+
+    // If the user is on the login page, don't try to pull notifications.
+    //
+    // Define the login route
+    const loginRoute = PUBLIC_ROOT;
+
+    // Check if the user is on the login route
+    const isOnLoginPage = isCurrentPath(loginRoute, location.pathname);
+
+    // If the user is not on the login route, fetch notifications
+    if (!isOnLoginPage) {
       fetchNotificationsCount();
+    }
+
+    // Listen for a route change to refresh notifications,
+    // unless the login page is the current route.
+    history.listen((newLocation) => {
+      if (newLocation.pathname !== loginRoute) {
+        fetchNotificationsCount();
+      }
     });
   }
   render() {
@@ -32,6 +50,7 @@ Notifications.propTypes = {
   notificationsCount: PropTypes.number.isRequired,
   fetchNotificationsCount: PropTypes.func.isRequired,
   history: PropTypes.shape({}).isRequired,
+  location: PropTypes.shape({}).isRequired,
 };
 
 Notifications.defaultProps = {

--- a/src/Components/Header/Notifications/Notifications.test.jsx
+++ b/src/Components/Header/Notifications/Notifications.test.jsx
@@ -18,7 +18,7 @@ const history = createHistory();
 describe('NotificationsComponent', () => {
   it('is defined', () => {
     const wrapper = TestUtils.renderIntoDocument(<Provider store={mockStore({})}><MemoryRouter>
-      <Notifications history={history} notificationsCount={4} fetchNotificationsCount={() => {}} />
+      <Notifications history={history} notificationsCount={4} fetchNotificationsCount={() => {}} location={{ pathname: '/results' }} />
     </MemoryRouter></Provider>);
     expect(wrapper).toBeDefined();
   });
@@ -30,10 +30,29 @@ describe('NotificationsComponent', () => {
         history={history}
         notificationsCount={4}
         fetchNotificationsCount={spy}
+        location={{ pathname: '/results' }}
       />,
     );
     wrapper.instance().props.history.push('/home');
+    wrapper.setProps({ location: { pathname: '/home' } });
     sinon.assert.calledTwice(spy);
+  });
+
+  it('does not refresh data on mount or on history change if history.pathname is "/login"', () => {
+    const spy = sinon.spy();
+    const wrapper = shallow(
+      <Notifications.WrappedComponent
+        history={history}
+        notificationsCount={4}
+        fetchNotificationsCount={spy}
+        location={{ pathname: '/login' }}
+      />,
+    );
+    // should not be called on mount
+    sinon.assert.notCalled(spy);
+    wrapper.instance().props.history.push('/login');
+    // should not be called on subsequent history push of '/login'
+    sinon.assert.notCalled(spy);
   });
 
   it('matches snapshot', () => {
@@ -42,6 +61,7 @@ describe('NotificationsComponent', () => {
         history={history}
         notificationsCount={4}
         fetchNotificationsCount={() => {}}
+        location={{ pathname: '/results' }}
       />,
     );
     expect(toJSON(wrapper)).toMatchSnapshot();

--- a/src/Components/PositionDetailsItem/PositionDetailsContact/__snapshots__/PositionDetailsContact.test.jsx.snap
+++ b/src/Components/PositionDetailsItem/PositionDetailsContact/__snapshots__/PositionDetailsContact.test.jsx.snap
@@ -38,7 +38,7 @@ exports[`PositionDetailsContact matches snapshot 1`] = `
     className="contact-container"
   >
     Updated Date: 
-    6.8.2017
+    06/08/2017
   </div>
 </div>
 `;

--- a/src/Containers/Main/Main.jsx
+++ b/src/Containers/Main/Main.jsx
@@ -1,9 +1,6 @@
-/* eslint-disable */
 import React from 'react';
 import { Provider } from 'react-redux';
-
 import { ConnectedRouter } from 'react-router-redux';
-
 import Routes from '../../Containers/Routes/Routes';
 import Header from '../../Components/Header/Header';
 import Footer from '../../Components/Footer/Footer';
@@ -11,9 +8,7 @@ import Glossary from '../../Containers/Glossary';
 import Feedback from '../../Containers/Feedback';
 import FeedbackButton from '../../Containers/FeedbackButton';
 import AuthorizedWrapper from '../../Containers/AuthorizedWrapper';
-
 import checkIndexAuthorization from '../../lib/check-auth';
-
 import { store, history } from '../../store';
 
 const isAuthorized = () => checkIndexAuthorization(store);

--- a/src/actions/assignment.js
+++ b/src/actions/assignment.js
@@ -1,5 +1,3 @@
-import axios from 'axios';
-import { fetchUserToken } from '../utilities';
 import api from '../api';
 
 export function assignmentHasErrored(bool) {
@@ -23,16 +21,17 @@ export function assignmentFetchDataSuccess(assignment) {
 
 export function assignmentFetchData(status = 'active') {
   return (dispatch) => {
-    axios.get(`${api}/profile/assignments/?status=${status}`, { headers: { Authorization: fetchUserToken() } })
-            .then(({ data }) => data.results[0] || {})
-            .then((assignment) => {
-              dispatch(assignmentFetchDataSuccess(assignment));
-              dispatch(assignmentIsLoading(false));
-              dispatch(assignmentHasErrored(false));
-            })
-            .catch(() => {
-              dispatch(assignmentHasErrored(true));
-              dispatch(assignmentIsLoading(false));
-            });
+    api
+      .get(`/profile/assignments/?status=${status}`)
+      .then(({ data }) => data.results[0] || {})
+      .then((assignment) => {
+        dispatch(assignmentFetchDataSuccess(assignment));
+        dispatch(assignmentIsLoading(false));
+        dispatch(assignmentHasErrored(false));
+      })
+      .catch(() => {
+        dispatch(assignmentHasErrored(true));
+        dispatch(assignmentIsLoading(false));
+      });
   };
 }

--- a/src/actions/autocomplete/missionAutocomplete.js
+++ b/src/actions/autocomplete/missionAutocomplete.js
@@ -1,4 +1,4 @@
-import axios, { CancelToken } from 'axios';
+import { CancelToken } from 'axios';
 import api from '../../api';
 
 let cancel;
@@ -9,12 +9,14 @@ export function missionSearchHasErrored(bool) {
     hasErrored: bool,
   };
 }
+
 export function missionSearchIsLoading(bool) {
   return {
     type: 'MISSION_SEARCH_IS_LOADING',
     isLoading: bool,
   };
 }
+
 export function missionSearchSuccess(missions) {
   return {
     type: 'MISSION_SEARCH_FETCH_DATA_SUCCESS',
@@ -27,20 +29,19 @@ export function missionSearchFetchData(query) {
     if (cancel) { cancel(); }
     dispatch(missionSearchHasErrored(false));
     dispatch(missionSearchIsLoading(true));
-    axios.get(`${api}/country/?q=${query}&limit=3`, {
+    api.get(`/country/?q=${query}&limit=3`, {
       cancelToken: new CancelToken((c) => {
         cancel = c;
       }),
-    },
-    )
-      .then((response) => {
-        dispatch(missionSearchIsLoading(false));
-        return response.data.results;
-      })
-      .then(results => dispatch(missionSearchSuccess(results)))
-      .catch(() => {
-        dispatch(missionSearchHasErrored(true));
-        dispatch(missionSearchIsLoading(false));
-      });
+    })
+    .then((response) => {
+      dispatch(missionSearchIsLoading(false));
+      return response.data.results;
+    })
+    .then(results => dispatch(missionSearchSuccess(results)))
+    .catch(() => {
+      dispatch(missionSearchHasErrored(true));
+      dispatch(missionSearchIsLoading(false));
+    });
   };
 }

--- a/src/actions/autocomplete/missionAutocomplete.test.js
+++ b/src/actions/autocomplete/missionAutocomplete.test.js
@@ -1,6 +1,6 @@
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import axios from 'axios';
+import api from '../../api';
 import MockAdapter from 'axios-mock-adapter';
 import * as actions from './missionAutocomplete';
 
@@ -9,7 +9,7 @@ const mockStore = configureMockStore(middlewares);
 
 describe('async actions', () => {
   beforeEach(() => {
-    const mockAdapter = new MockAdapter(axios);
+    const mockAdapter = new MockAdapter(api);
 
     const results = [
       {
@@ -22,16 +22,16 @@ describe('async actions', () => {
       },
     ];
 
-    mockAdapter.onGet('http://localhost:8000/api/v1/country/?q=Afgh&limit=3').reply(200,
+    mockAdapter.onGet('/country/?q=Afgh&limit=3').reply(200,
       results,
     );
 
-    mockAdapter.onGet('http://localhost:8000/api/v1/country/?q=fake&limit=3').reply(404,
+    mockAdapter.onGet('/country/?q=fake&limit=3').reply(404,
       null,
     );
   });
 
-  it('can fetch post reuslts', (done) => {
+  it('can fetch post results', (done) => {
     const store = mockStore({ results: [] });
 
     const f = () => {

--- a/src/actions/autocomplete/missionAutocomplete.test.js
+++ b/src/actions/autocomplete/missionAutocomplete.test.js
@@ -1,7 +1,7 @@
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import api from '../../api';
 import MockAdapter from 'axios-mock-adapter';
+import api from '../../api';
 import * as actions from './missionAutocomplete';
 
 const middlewares = [thunk];

--- a/src/actions/autocomplete/postAutocomplete.js
+++ b/src/actions/autocomplete/postAutocomplete.js
@@ -1,4 +1,4 @@
-import axios, { CancelToken } from 'axios';
+import { CancelToken } from 'axios';
 import api from '../../api';
 
 let cancel;
@@ -9,12 +9,14 @@ export function postSearchHasErrored(bool) {
     hasErrored: bool,
   };
 }
+
 export function postSearchIsLoading(bool) {
   return {
     type: 'POST_SEARCH_IS_LOADING',
     isLoading: bool,
   };
 }
+
 export function postSearchSuccess(posts) {
   return {
     type: 'POST_SEARCH_FETCH_DATA_SUCCESS',
@@ -27,25 +29,24 @@ export function postSearchFetchData(query) {
     if (cancel) { cancel(); }
     dispatch(postSearchHasErrored(false));
     dispatch(postSearchIsLoading(true));
-    axios.get(`${api}/orgpost/?q=${query}&limit=3`, {
+    api.get(`/orgpost/?q=${query}&limit=3`, {
       cancelToken: new CancelToken((c) => {
         cancel = c;
       }),
-    },
-    )
-      .then(({ data }) => {
-        dispatch(postSearchIsLoading(false));
-        let filteredResults = [];
-        if (data.results) {
-          // results should have a location
-          filteredResults = data.results.filter(post => post.location !== null);
-        }
-        return filteredResults;
-      })
-      .then(results => dispatch(postSearchSuccess(results)))
-      .catch(() => {
-        dispatch(postSearchHasErrored(true));
-        dispatch(postSearchIsLoading(false));
-      });
+    })
+    .then(({ data }) => {
+      dispatch(postSearchIsLoading(false));
+      let filteredResults = [];
+      if (data.results) {
+        // results should have a location
+        filteredResults = data.results.filter(post => post.location !== null);
+      }
+      return filteredResults;
+    })
+    .then(results => dispatch(postSearchSuccess(results)))
+    .catch(() => {
+      dispatch(postSearchHasErrored(true));
+      dispatch(postSearchIsLoading(false));
+    });
   };
 }

--- a/src/actions/autocomplete/postAutocomplete.test.js
+++ b/src/actions/autocomplete/postAutocomplete.test.js
@@ -1,12 +1,12 @@
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
+import api from '../../api';
 import * as actions from './postAutocomplete';
 
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
-const mockAdapter = new MockAdapter(axios);
+const mockAdapter = new MockAdapter(api);
 
 const results = [
   {
@@ -23,11 +23,11 @@ const results = [
   },
 ];
 
-mockAdapter.onGet('http://localhost:8000/api/v1/orgpost/?q=Dubai&limit=3').reply(200,
+mockAdapter.onGet('/orgpost/?q=Dubai&limit=3').reply(200,
   { results },
 );
 
-mockAdapter.onGet('http://localhost:8000/api/v1/orgpost/?q=fake&limit=3').reply(404,
+mockAdapter.onGet('/v1/orgpost/?q=fake&limit=3').reply(404,
   null,
 );
 
@@ -48,7 +48,7 @@ describe('async actions', () => {
   it('can handle responses with null locations', (done) => {
     const store = mockStore({ posts: [] });
 
-    mockAdapter.onGet('http://localhost:8000/api/v1/orgpost/?q=Dubai&limit=3').reply(200,
+    mockAdapter.onGet('/api/v1/orgpost/?q=Dubai&limit=3').reply(200,
       { results: [
         Object.assign({}, results[0]),
         Object.assign(results[0], { location: null }),

--- a/src/actions/bidList.js
+++ b/src/actions/bidList.js
@@ -1,7 +1,5 @@
-import axios from 'axios';
 import api from '../api';
 import * as SystemMessages from '../Constants/SystemMessages';
-import { fetchUserToken } from '../utilities';
 
 export function bidListHasErrored(bool) {
   return {
@@ -130,17 +128,17 @@ export function bidListFetchData(ordering = 'draft_date') {
   return (dispatch) => {
     dispatch(bidListIsLoading(true));
     dispatch(bidListHasErrored(false));
-    axios.get(`${api}/bidlist/?ordering=${ordering}`, { headers: { Authorization: fetchUserToken() } })
-            .then(response => response.data)
-            .then((results) => {
-              dispatch(bidListHasErrored(false));
-              dispatch(bidListIsLoading(false));
-              dispatch(bidListFetchDataSuccess(results));
-            })
-            .catch(() => {
-              dispatch(bidListHasErrored(true));
-              dispatch(bidListIsLoading(false));
-            });
+    api.get(`/bidlist/?ordering=${ordering}`)
+      .then(response => response.data)
+      .then((results) => {
+        dispatch(bidListHasErrored(false));
+        dispatch(bidListIsLoading(false));
+        dispatch(bidListFetchDataSuccess(results));
+      })
+      .catch(() => {
+        dispatch(bidListHasErrored(true));
+        dispatch(bidListIsLoading(false));
+      });
   };
 }
 
@@ -151,18 +149,18 @@ export function submitBid(id) {
     dispatch(routeChangeResetState());
     dispatch(submitBidIsLoading(true));
     dispatch(submitBidHasErrored(false));
-    axios.get(`${api}/bid/${idString}/submit/`, { headers: { Authorization: fetchUserToken() } })
-            .then(response => response.data)
-            .then(() => {
-              dispatch(submitBidHasErrored(false));
-              dispatch(submitBidIsLoading(false));
-              dispatch(submitBidSuccess(SystemMessages.SUBMIT_BID_SUCCESS));
-              dispatch(bidListFetchData());
-            })
-            .catch(() => {
-              dispatch(submitBidHasErrored(SystemMessages.SUBMIT_BID_ERROR));
-              dispatch(submitBidIsLoading(false));
-            });
+    api.get(`/bid/${idString}/submit/`)
+      .then(response => response.data)
+      .then(() => {
+        dispatch(submitBidHasErrored(false));
+        dispatch(submitBidIsLoading(false));
+        dispatch(submitBidSuccess(SystemMessages.SUBMIT_BID_SUCCESS));
+        dispatch(bidListFetchData());
+      })
+      .catch(() => {
+        dispatch(submitBidHasErrored(SystemMessages.SUBMIT_BID_ERROR));
+        dispatch(submitBidIsLoading(false));
+      });
   };
 }
 
@@ -173,18 +171,18 @@ export function acceptBid(id) {
     dispatch(routeChangeResetState());
     dispatch(acceptBidIsLoading(true));
     dispatch(acceptBidHasErrored(false));
-    axios.get(`${api}/bid/${idString}/accept_handshake/`, { headers: { Authorization: fetchUserToken() } })
-            .then(response => response.data)
-            .then(() => {
-              dispatch(acceptBidHasErrored(false));
-              dispatch(acceptBidIsLoading(false));
-              dispatch(acceptBidSuccess(SystemMessages.ACCEPT_BID_SUCCESS));
-              dispatch(bidListFetchData());
-            })
-            .catch(() => {
-              dispatch(acceptBidHasErrored(SystemMessages.ACCEPT_BID_ERROR));
-              dispatch(acceptBidIsLoading(false));
-            });
+    api.get(`/bid/${idString}/accept_handshake/`)
+      .then(response => response.data)
+      .then(() => {
+        dispatch(acceptBidHasErrored(false));
+        dispatch(acceptBidIsLoading(false));
+        dispatch(acceptBidSuccess(SystemMessages.ACCEPT_BID_SUCCESS));
+        dispatch(bidListFetchData());
+      })
+      .catch(() => {
+        dispatch(acceptBidHasErrored(SystemMessages.ACCEPT_BID_ERROR));
+        dispatch(acceptBidIsLoading(false));
+      });
   };
 }
 
@@ -195,18 +193,18 @@ export function declineBid(id) {
     dispatch(routeChangeResetState());
     dispatch(declineBidIsLoading(true));
     dispatch(declineBidHasErrored(false));
-    axios.get(`${api}/bid/${idString}/decline_handshake/`, { headers: { Authorization: fetchUserToken() } })
-            .then(response => response.data)
-            .then(() => {
-              dispatch(declineBidHasErrored(false));
-              dispatch(declineBidIsLoading(false));
-              dispatch(declineBidSuccess(SystemMessages.DECLINE_BID_SUCCESS));
-              dispatch(bidListFetchData());
-            })
-            .catch(() => {
-              dispatch(declineBidHasErrored(SystemMessages.DECLINE_BID_ERROR));
-              dispatch(declineBidIsLoading(false));
-            });
+    api.get(`/bid/${idString}/decline_handshake/`)
+      .then(response => response.data)
+      .then(() => {
+        dispatch(declineBidHasErrored(false));
+        dispatch(declineBidIsLoading(false));
+        dispatch(declineBidSuccess(SystemMessages.DECLINE_BID_SUCCESS));
+        dispatch(bidListFetchData());
+      })
+      .catch(() => {
+        dispatch(declineBidHasErrored(SystemMessages.DECLINE_BID_ERROR));
+        dispatch(declineBidIsLoading(false));
+      });
   };
 }
 
@@ -218,33 +216,28 @@ export function toggleBidPosition(id, remove) {
     dispatch(bidListToggleIsLoading(true));
     dispatch(bidListToggleSuccess(false));
     dispatch(bidListToggleHasErrored(false));
-    let action = 'put';
-    if (remove) {
-      action = 'delete';
-    }
-    const auth = { headers: { Authorization: fetchUserToken() } };
-    // Now we can patch our profile with the new favorites.
-    // Axios is a little weird here in that for PUTs, it expects a body as the second argument,
-    // whereas for DELETEs, it expects the headers object...
-    // so we have to conditionally decide what position to put the headers object in.
-    const firstArg = action === 'delete' ? auth : {};
-    const secondArg = action === 'put' ? auth : null;
-    axios[action](`${api}/bidlist/position/${idString}/`, firstArg, secondArg)
-            .then(() => {
-              dispatch(bidListToggleSuccess(
-                remove ?
-                  SystemMessages.DELETE_BID_ITEM_SUCCESS : SystemMessages.ADD_BID_ITEM_SUCCESS,
-              ));
-              dispatch(bidListToggleIsLoading(false));
-              dispatch(bidListToggleHasErrored(false));
-              dispatch(bidListFetchData());
-            })
-            .catch(() => {
-              dispatch(bidListToggleHasErrored(
-                remove ?
-                  SystemMessages.DELETE_BID_ITEM_ERROR : SystemMessages.ADD_BID_ITEM_ERROR,
-              ));
-              dispatch(bidListToggleIsLoading(false));
-            });
+
+    const config = {
+      method: remove ? 'delete' : 'put',
+      url: `/bidlist/position/${idString}/`,
+    };
+
+    api(config)
+      .then(() => {
+        dispatch(bidListToggleSuccess(
+          remove ?
+            SystemMessages.DELETE_BID_ITEM_SUCCESS : SystemMessages.ADD_BID_ITEM_SUCCESS,
+        ));
+        dispatch(bidListToggleIsLoading(false));
+        dispatch(bidListToggleHasErrored(false));
+        dispatch(bidListFetchData());
+      })
+      .catch(() => {
+        dispatch(bidListToggleHasErrored(
+          remove ?
+            SystemMessages.DELETE_BID_ITEM_ERROR : SystemMessages.ADD_BID_ITEM_ERROR,
+        ));
+        dispatch(bidListToggleIsLoading(false));
+      });
   };
 }

--- a/src/actions/bidStatistics.js
+++ b/src/actions/bidStatistics.js
@@ -1,5 +1,3 @@
-import axios from 'axios';
-import { fetchUserToken } from '../utilities';
 import api from '../api';
 
 export function bidStatisticsHasErrored(bool) {
@@ -8,12 +6,14 @@ export function bidStatisticsHasErrored(bool) {
     hasErrored: bool,
   };
 }
+
 export function bidStatisticsIsLoading(bool) {
   return {
     type: 'BID_STATISTICS_IS_LOADING',
     isLoading: bool,
   };
 }
+
 export function bidStatisticsFetchDataSuccess(bidStatistics) {
   return {
     type: 'BID_STATISTICS_FETCH_DATA_SUCCESS',
@@ -25,20 +25,20 @@ export function bidStatisticsFetchData(queryString = '?ordering=-cycle_start_dat
   return (dispatch) => {
     dispatch(bidStatisticsIsLoading(true));
     dispatch(bidStatisticsHasErrored(false));
-    axios.get(`${api}/bidcycle/statistics/${queryString}`, { headers: { Authorization: fetchUserToken() } })
-        .then(({ data }) => {
-          if (data.results.length) {
-            dispatch(bidStatisticsFetchDataSuccess(data.results[0]));
-            dispatch(bidStatisticsIsLoading(false));
-            dispatch(bidStatisticsHasErrored(false));
-          } else {
-            dispatch(bidStatisticsIsLoading(false));
-            dispatch(bidStatisticsHasErrored(true));
-          }
-        })
-        .catch(() => {
+    api.get(`/bidcycle/statistics/${queryString}`)
+      .then(({ data }) => {
+        if (data.results.length) {
+          dispatch(bidStatisticsFetchDataSuccess(data.results[0]));
+          dispatch(bidStatisticsIsLoading(false));
+          dispatch(bidStatisticsHasErrored(false));
+        } else {
           dispatch(bidStatisticsIsLoading(false));
           dispatch(bidStatisticsHasErrored(true));
-        });
+        }
+      })
+      .catch(() => {
+        dispatch(bidStatisticsIsLoading(false));
+        dispatch(bidStatisticsHasErrored(true));
+      });
   };
 }

--- a/src/actions/bidderPortfolio.js
+++ b/src/actions/bidderPortfolio.js
@@ -1,6 +1,4 @@
-import axios from 'axios';
 import api from '../api';
-import { fetchUserToken } from '../utilities';
 
 export function bidderPortfolioHasErrored(bool) {
   return {
@@ -44,16 +42,16 @@ export function bidderPortfolioCountsFetchData() {
   return (dispatch) => {
     dispatch(bidderPortfolioCountsIsLoading(true));
     dispatch(bidderPortfolioCountsHasErrored(false));
-    axios.get(`${api}/client/statistics/`, { headers: { Authorization: fetchUserToken() } })
-            .then(({ data }) => {
-              dispatch(bidderPortfolioCountsHasErrored(false));
-              dispatch(bidderPortfolioCountsIsLoading(false));
-              dispatch(bidderPortfolioCountsFetchDataSuccess(data));
-            })
-            .catch(() => {
-              dispatch(bidderPortfolioCountsHasErrored(true));
-              dispatch(bidderPortfolioCountsIsLoading(false));
-            });
+    api.get('/client/statistics/')
+      .then(({ data }) => {
+        dispatch(bidderPortfolioCountsHasErrored(false));
+        dispatch(bidderPortfolioCountsIsLoading(false));
+        dispatch(bidderPortfolioCountsFetchDataSuccess(data));
+      })
+      .catch(() => {
+        dispatch(bidderPortfolioCountsHasErrored(true));
+        dispatch(bidderPortfolioCountsIsLoading(false));
+      });
   };
 }
 
@@ -61,15 +59,15 @@ export function bidderPortfolioFetchData(query = '') {
   return (dispatch) => {
     dispatch(bidderPortfolioIsLoading(true));
     dispatch(bidderPortfolioHasErrored(false));
-    axios.get(`${api}/client/?${query}`, { headers: { Authorization: fetchUserToken() } })
-            .then(({ data }) => {
-              dispatch(bidderPortfolioHasErrored(false));
-              dispatch(bidderPortfolioIsLoading(false));
-              dispatch(bidderPortfolioFetchDataSuccess(data));
-            })
-            .catch(() => {
-              dispatch(bidderPortfolioHasErrored(true));
-              dispatch(bidderPortfolioIsLoading(false));
-            });
+    api.get(`/client/?${query}`)
+      .then(({ data }) => {
+        dispatch(bidderPortfolioHasErrored(false));
+        dispatch(bidderPortfolioIsLoading(false));
+        dispatch(bidderPortfolioFetchDataSuccess(data));
+      })
+      .catch(() => {
+        dispatch(bidderPortfolioHasErrored(true));
+        dispatch(bidderPortfolioIsLoading(false));
+      });
   };
 }

--- a/src/actions/client.js
+++ b/src/actions/client.js
@@ -1,21 +1,19 @@
-import axios from 'axios';
 import api from '../api';
-import { fetchUserToken } from '../utilities';
 
 export const fetchClient = clientId =>
-  axios.get(`${api}/client/${clientId}/`, { headers: { Authorization: fetchUserToken() } })
+  api.get(`/client/${clientId}/`)
     .then(({ data }) => data)
     .then(client => client)
     .catch(error => error);
 
 export const fetchClientWaivers = clientId =>
-  axios.get(`${api}/client/${clientId}/waivers/`, { headers: { Authorization: fetchUserToken() } })
+  api.get(`/client/${clientId}/waivers/`)
     .then(({ data }) => data)
     .then(client => client)
     .catch(error => error);
 
 export const fetchClientBids = clientId =>
-  axios.get(`${api}/client/${clientId}/bids/`, { headers: { Authorization: fetchUserToken() } })
+  api.get(`/client/${clientId}/bids/`)
     .then(({ data }) => data)
     .then(client => client)
     .catch(error => error);

--- a/src/actions/client.test.js
+++ b/src/actions/client.test.js
@@ -10,7 +10,7 @@ describe('async actions', () => {
   });
 
   it('can fetch a client', (done) => {
-    mockAdapter.onGet('http://localhost:8000/api/v1/client/1/').reply(200,
+    mockAdapter.onGet('/client/1/').reply(200,
       clientObject,
     );
 
@@ -28,7 +28,7 @@ describe('async actions', () => {
   });
 
   it('can handle errors when fetching a client', (done) => {
-    mockAdapter.onGet('http://localhost:8000/api/v1/client/2/').reply(404,
+    mockAdapter.onGet('/client/2/').reply(404,
       null,
     );
 
@@ -46,7 +46,7 @@ describe('async actions', () => {
   });
 
   it('can fetch client waivers', (done) => {
-    mockAdapter.onGet('http://localhost:8000/api/v1/client/1/waivers/').reply(200,
+    mockAdapter.onGet('/client/1/waivers/').reply(200,
       clientWaivers,
     );
 
@@ -64,7 +64,7 @@ describe('async actions', () => {
   });
 
   it('can handle errors when fetching client waivers', (done) => {
-    mockAdapter.onGet('http://localhost:8000/api/v1/client/2/waivers/').reply(404,
+    mockAdapter.onGet('/client/2/waivers/').reply(404,
       null,
     );
 
@@ -82,7 +82,7 @@ describe('async actions', () => {
   });
 
   it('can fetch client bids', (done) => {
-    mockAdapter.onGet('http://localhost:8000/api/v1/client/1/bids/').reply(200,
+    mockAdapter.onGet('/client/1/bids/').reply(200,
       clientBids,
     );
 
@@ -100,7 +100,7 @@ describe('async actions', () => {
   });
 
   it('can handle errors when fetching client bids', (done) => {
-    mockAdapter.onGet('http://localhost:8000/api/v1/client/2/bids/').reply(404,
+    mockAdapter.onGet('/client/2/bids/').reply(404,
       null,
     );
 
@@ -118,13 +118,13 @@ describe('async actions', () => {
   });
 
   it('can perform fetchAllClientData', (done) => {
-    mockAdapter.onGet('http://localhost:8000/api/v1/client/1/bids/').reply(200,
+    mockAdapter.onGet('/client/1/bids/').reply(200,
       clientBids,
     );
-    mockAdapter.onGet('http://localhost:8000/api/v1/client/1/waivers/').reply(200,
+    mockAdapter.onGet('/client/1/waivers/').reply(200,
       clientWaivers,
     );
-    mockAdapter.onGet('http://localhost:8000/api/v1/client/1/').reply(200,
+    mockAdapter.onGet('/client/1/').reply(200,
       clientObject,
     );
 
@@ -144,13 +144,13 @@ describe('async actions', () => {
   });
 
   it('can handle errors when performing fetchAllClientData', (done) => {
-    mockAdapter.onGet('http://localhost:8000/api/v1/client/1/bids/').reply(200,
+    mockAdapter.onGet('/client/1/bids/').reply(200,
       clientBids,
     );
-    mockAdapter.onGet('http://localhost:8000/api/v1/client/1/waivers/').reply(404,
+    mockAdapter.onGet('/client/1/waivers/').reply(404,
       null,
     );
-    mockAdapter.onGet('http://localhost:8000/api/v1/client/1/').reply(200,
+    mockAdapter.onGet('/client/1/').reply(200,
       clientObject,
     );
 

--- a/src/actions/comparisons.js
+++ b/src/actions/comparisons.js
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import api from '../api';
 
 export function comparisonsHasErrored(bool) {
@@ -7,12 +6,14 @@ export function comparisonsHasErrored(bool) {
     hasErrored: bool,
   };
 }
+
 export function comparisonsIsLoading(bool) {
   return {
     type: 'COMPARISONS_IS_LOADING',
     isLoading: bool,
   };
 }
+
 export function comparisonsFetchDataSuccess(comparisons) {
   return {
     type: 'COMPARISONS_FETCH_DATA_SUCCESS',
@@ -23,12 +24,12 @@ export function comparisonsFetchDataSuccess(comparisons) {
 export function comparisonsFetchData(query) {
   return (dispatch) => {
     dispatch(comparisonsIsLoading(true));
-    axios.get(`${api}/position/?position_number__in=${query}`)
-            .then((response) => {
-              dispatch(comparisonsIsLoading(false));
-              return response.data.results;
-            })
-            .then(comparisons => dispatch(comparisonsFetchDataSuccess(comparisons)))
-            .catch(() => dispatch(comparisonsHasErrored(true)));
+    api.get(`/position/?position_number__in=${query}`)
+      .then((response) => {
+        dispatch(comparisonsIsLoading(false));
+        return response.data.results;
+      })
+      .then(comparisons => dispatch(comparisonsFetchDataSuccess(comparisons)))
+      .catch(() => dispatch(comparisonsHasErrored(true)));
   };
 }

--- a/src/actions/descriptionEdit.js
+++ b/src/actions/descriptionEdit.js
@@ -1,5 +1,3 @@
-import axios from 'axios';
-import { fetchUserToken } from '../utilities';
 import api from '../api';
 
 export function descriptionEditHasErrored(bool) {
@@ -8,12 +6,14 @@ export function descriptionEditHasErrored(bool) {
     hasErrored: bool,
   };
 }
+
 export function descriptionEditIsSending(bool) {
   return {
     type: 'DESCRIPTION_EDIT_IS_SENDING',
     isLoading: bool,
   };
 }
+
 export function descriptionEditSuccess(bool) {
   return {
     type: 'DESCRIPTION_EDIT_SUCCESS',
@@ -31,10 +31,12 @@ export function resetMessages() {
 
 export function editDescription(id, content, pointOfContact, website) {
   return (dispatch) => {
+    const patchObject = {};
+
     dispatch(descriptionEditIsSending(true));
     dispatch(descriptionEditSuccess(false));
     dispatch(descriptionEditHasErrored(false));
-    const patchObject = Object.assign({});
+
     if (content) {
       patchObject.content = content;
     }
@@ -44,39 +46,29 @@ export function editDescription(id, content, pointOfContact, website) {
     if (website) {
       patchObject.website = website;
     }
-    axios.patch(`${api}/capsule_description/${id}/`, patchObject, { headers: { Authorization: fetchUserToken() } })
-            .then((response) => {
-              dispatch(descriptionEditIsSending(false));
-              dispatch(descriptionEditHasErrored(false));
-              return response;
-            })
-            .then(() => dispatch(descriptionEditSuccess(true)))
-            .catch((err) => {
-              dispatch(descriptionEditHasErrored('An error occurred trying to save this data. Click "edit" and try to save again.'));
-              dispatch(descriptionEditIsSending(false));
-              dispatch(descriptionEditSuccess(false));
-              if (err && err.response) {
-                return err.response.data.message;
-              }
-              return false;
-            });
+
+    api.patch(`/capsule_description/${id}/`, patchObject)
+      .then((response) => {
+        dispatch(descriptionEditIsSending(false));
+        dispatch(descriptionEditHasErrored(false));
+        return response;
+      })
+      .then(() => dispatch(descriptionEditSuccess(true)))
+      .catch((err) => {
+        dispatch(descriptionEditHasErrored('An error occurred trying to save this data. Click "edit" and try to save again.'));
+        dispatch(descriptionEditIsSending(false));
+        dispatch(descriptionEditSuccess(false));
+        if (err && err.response) {
+          return err.response.data.message;
+        }
+        return false;
+      });
   };
 }
 
-export function editDescriptionContent(id, content) {
-  return (dispatch) => {
-    dispatch(editDescription(id, content));
-  };
-}
-
-export function editPocContent(id, content) {
-  return (dispatch) => {
-    dispatch(editDescription(id, null, content));
-  };
-}
-
-export function editWebsiteContent(id, content) {
-  return (dispatch) => {
-    dispatch(editDescription(id, null, null, content));
-  };
-}
+export const editDescriptionContent = (id, content) =>
+  dispatch => dispatch(editDescription(id, content));
+export const editPocContent = (id, content) =>
+  dispatch => dispatch(editDescription(id, null, content));
+export const editWebsiteContent = (id, content) =>
+  dispatch => dispatch(editDescription(id, null, null, content));

--- a/src/actions/favoritePositions.js
+++ b/src/actions/favoritePositions.js
@@ -1,6 +1,4 @@
-import axios from 'axios';
 import api from '../api';
-import { fetchUserToken } from '../utilities';
 
 export function favoritePositionsHasErrored(bool) {
   return {
@@ -8,12 +6,14 @@ export function favoritePositionsHasErrored(bool) {
     hasErrored: bool,
   };
 }
+
 export function favoritePositionsIsLoading(bool) {
   return {
     type: 'FAVORITE_POSITIONS_IS_LOADING',
     isLoading: bool,
   };
 }
+
 export function favoritePositionsFetchDataSuccess(results) {
   return {
     type: 'FAVORITE_POSITIONS_FETCH_DATA_SUCCESS',
@@ -25,18 +25,19 @@ export function favoritePositionsFetchData(sortType) {
   return (dispatch) => {
     dispatch(favoritePositionsIsLoading(true));
     dispatch(favoritePositionsHasErrored(false));
-    let url = `${api}/position/favorites/`;
+    let url = '/position/favorites/';
     if (sortType) { url += `?ordering=${sortType}`; }
-    axios.get(url, { headers: { Authorization: fetchUserToken() } })
-            .then(response => response.data)
-            .then((results) => {
-              dispatch(favoritePositionsHasErrored(false));
-              dispatch(favoritePositionsIsLoading(false));
-              dispatch(favoritePositionsFetchDataSuccess(results));
-            })
-            .catch(() => {
-              dispatch(favoritePositionsHasErrored(true));
-              dispatch(favoritePositionsIsLoading(false));
-            });
+
+    api.get(url)
+      .then(response => response.data)
+      .then((results) => {
+        dispatch(favoritePositionsHasErrored(false));
+        dispatch(favoritePositionsIsLoading(false));
+        dispatch(favoritePositionsFetchDataSuccess(results));
+      })
+      .catch(() => {
+        dispatch(favoritePositionsHasErrored(true));
+        dispatch(favoritePositionsIsLoading(false));
+      });
   };
 }

--- a/src/actions/feedback.js
+++ b/src/actions/feedback.js
@@ -1,6 +1,5 @@
-import axios from 'axios';
-import { fetchUserToken, propOrDefault } from '../utilities';
 import api from '../api';
+import { propOrDefault } from '../utilities';
 
 export function feedbackHasErrored(message) {
   return {
@@ -8,12 +7,14 @@ export function feedbackHasErrored(message) {
     hasErrored: message,
   };
 }
+
 export function feedbackIsSending(bool) {
   return {
     type: 'FEEDBACK_IS_SENDING',
     isLoading: bool,
   };
 }
+
 export function feedbackSuccess(bool) {
   return {
     type: 'FEEDBACK_SUCCESS',
@@ -26,18 +27,23 @@ export function feedbackSubmitData(comments, isInterestedInHelping = false) {
     dispatch(feedbackIsSending(true));
     dispatch(feedbackSuccess(false));
     dispatch(feedbackHasErrored(false));
-    axios.post(`${api}/feedback/`, { comments, is_interested_in_helping: isInterestedInHelping }, { headers: { Authorization: fetchUserToken() } })
-            .then((response) => {
-              dispatch(feedbackIsSending(false));
-              dispatch(feedbackHasErrored(false));
-              return response.data;
-            })
-            .then(() => dispatch(feedbackSuccess(true)))
-            .catch((err) => {
-              const errorMessage = (propOrDefault(err, 'response.data.comments', ['An error occurred trying to submit feedback. Please try again.']))[0];
-              dispatch(feedbackHasErrored(errorMessage));
-              dispatch(feedbackIsSending(false));
-              dispatch(feedbackSuccess(false));
-            });
+    api.post('/feedback/', { comments, is_interested_in_helping: isInterestedInHelping })
+      .then((response) => {
+        dispatch(feedbackIsSending(false));
+        dispatch(feedbackHasErrored(false));
+        return response.data;
+      })
+      .then(() => dispatch(feedbackSuccess(true)))
+      .catch((err) => {
+        const errorMessage = propOrDefault(
+          err,
+          'response.data.comments[0]',
+          'An error occurred trying to submit feedback. Please try again.',
+        );
+
+        dispatch(feedbackHasErrored(errorMessage));
+        dispatch(feedbackIsSending(false));
+        dispatch(feedbackSuccess(false));
+      });
   };
 }

--- a/src/actions/filters/filters.js
+++ b/src/actions/filters/filters.js
@@ -218,7 +218,7 @@ export function filtersFetchData(items = { filters: [] }, queryParams = {}, save
       // our dynamic filters
       const dynamicFilters = items.filters.slice().filter(item => (item.item.endpoint));
       const queryProms = dynamicFilters.map(item => (
-        axios.get(`${api}/${item.item.endpoint}`)
+        api.get(`/${item.item.endpoint}`)
           .then((response) => {
             const itemFilter = Object.assign({}, item);
             itemFilter.data = response.data.results;

--- a/src/actions/glossary.js
+++ b/src/actions/glossary.js
@@ -1,8 +1,6 @@
-import axios from 'axios';
 import { first, get, isArray, merge } from 'lodash';
-import { EMPTY_FUNCTION } from '../Constants/PropTypes';
-import { fetchUserToken } from '../utilities';
 import api from '../api';
+import { EMPTY_FUNCTION } from '../Constants/PropTypes';
 
 export function glossaryHasErrored(bool) {
   return {
@@ -88,8 +86,8 @@ export function glossaryFetchData(bypassLoading = false) {
       dispatch(glossaryIsLoading(true));
     }
 
-    axios
-      .get(`${api}/glossary/?is_archived=false`, { headers: { Authorization: fetchUserToken() } })
+    api
+      .get('/glossary/?is_archived=false')
       .then(({ data }) => {
         dispatch(glossaryFetchDataSuccess(data));
         dispatch(glossaryIsLoading(false));
@@ -110,8 +108,8 @@ export function glossaryEditorFetchData(bypassLoading = false) {
       dispatch(glossaryEditorIsLoading(true));
     }
 
-    axios
-      .get(`${api}/glossary/`, { headers: { Authorization: fetchUserToken() } })
+    api
+      .get('/glossary/')
       .then(({ data }) => {
         dispatch(glossaryEditorFetchDataSuccess(data));
         dispatch(glossaryEditorIsLoading(false));
@@ -130,8 +128,8 @@ export function glossaryPatch(term = {}, onSuccess = EMPTY_FUNCTION) {
     dispatch(glossaryPatchIsLoading(true));
     dispatch(glossaryPatchHasErrored(false));
 
-    axios
-      .patch(`${api}/glossary/${term.id}/`, term, { headers: { Authorization: fetchUserToken() } })
+    api
+      .patch(`/glossary/${term.id}/`, term)
       .then(({ data }) => {
         dispatch(glossaryFetchData());
         dispatch(glossaryEditorFetchData(true));
@@ -161,8 +159,8 @@ export function glossaryPost(term = {}, onSuccess = EMPTY_FUNCTION) {
     dispatch(glossaryPostIsLoading(true));
     dispatch(glossaryPostHasErrored(false));
 
-    axios
-      .post(`${api}/glossary/`, term, { headers: { Authorization: fetchUserToken() } })
+    api
+      .post('/glossary/', term)
       .then(({ data }) => {
         dispatch(glossaryFetchData());
         dispatch(glossaryEditorFetchData());

--- a/src/actions/homePagePositions.js
+++ b/src/actions/homePagePositions.js
@@ -1,6 +1,4 @@
-import axios from 'axios';
 import api from '../api';
-import { fetchUserToken } from '../utilities';
 import { USER_SKILL_CODE_POSITIONS, USER_GRADE_RECENT_POSITIONS, SERVICE_NEED_POSITIONS,
 RECENTLY_POSTED_POSITIONS, FAVORITED_POSITIONS } from '../Constants/PropTypes';
 
@@ -17,12 +15,14 @@ export function homePagePositionsHasErrored(bool) {
     hasErrored: bool,
   };
 }
+
 export function homePagePositionsIsLoading(bool) {
   return {
     type: 'HOME_PAGE_POSITIONS_IS_LOADING',
     isLoading: bool,
   };
 }
+
 export function homePagePositionsFetchDataSuccess(results) {
   return {
     type: 'HOME_PAGE_POSITIONS_FETCH_DATA_SUCCESS',
@@ -78,7 +78,7 @@ export function homePagePositionsFetchData(skills = [], grade = null) {
     }
 
     // create a promise with all the queries we defined
-    const queryProms = queryTypes.map(type => axios.get(`${api}/position/${type.query}`, { headers: { Authorization: fetchUserToken() } }));
+    const queryProms = queryTypes.map(type => api.get(`/position/${type.query}`));
 
     Promise.all(queryProms)
       // Promise.all returns a single array which matches the order of the originating array...

--- a/src/actions/notifications.js
+++ b/src/actions/notifications.js
@@ -1,6 +1,5 @@
-import axios from 'axios';
-import { fetchUserToken } from '../utilities';
 import api from '../api';
+import { hasValidToken } from '../utilities';
 
 export function notificationsHasErrored(bool) {
   return {
@@ -67,18 +66,17 @@ export function unsetNotificationsCount() {
 
 export function notificationsCountFetchData() {
   return (dispatch) => {
-    const userToken = fetchUserToken();
-    if (userToken) {
-      axios.get(`${api}/notification/?limit=1&is_read=false`, { headers: { Authorization: userToken } })
-              .then(({ data }) => {
-                dispatch(notificationsCountFetchDataSuccess(data.count));
-                dispatch(notificationsCountIsLoading(false));
-                dispatch(notificationsCountHasErrored(false));
-              })
-              .catch(() => {
-                dispatch(notificationsCountHasErrored(true));
-                dispatch(notificationsCountIsLoading(false));
-              });
+    if (hasValidToken()) {
+      api.get('/notification/?limit=1&is_read=false')
+        .then(({ data }) => {
+          dispatch(notificationsCountFetchDataSuccess(data.count));
+          dispatch(notificationsCountIsLoading(false));
+          dispatch(notificationsCountHasErrored(false));
+        })
+        .catch(() => {
+          dispatch(notificationsCountHasErrored(true));
+          dispatch(notificationsCountIsLoading(false));
+        });
     } else {
       dispatch(notificationsCountHasErrored(true));
       dispatch(notificationsCountIsLoading(false));
@@ -88,16 +86,16 @@ export function notificationsCountFetchData() {
 
 export function notificationsFetchData(limit = 3, ordering = '-date_updated', tags = undefined, isRead = undefined) {
   return (dispatch) => {
-    axios.get(`${api}/notification/?limit=${limit}&ordering=${ordering}${tags !== undefined ? `&tags=${tags}` : ''}${isRead !== undefined ? `&is_read=${isRead}` : ''}`, { headers: { Authorization: fetchUserToken() } })
-            .then(({ data }) => {
-              dispatch(notificationsFetchDataSuccess(data));
-              dispatch(notificationsIsLoading(false));
-              dispatch(notificationsHasErrored(false));
-            })
-            .catch(() => {
-              dispatch(notificationsHasErrored(true));
-              dispatch(notificationsIsLoading(false));
-            });
+    api.get(`/notification/?limit=${limit}&ordering=${ordering}${tags !== undefined ? `&tags=${tags}` : ''}${isRead !== undefined ? `&is_read=${isRead}` : ''}`)
+      .then(({ data }) => {
+        dispatch(notificationsFetchDataSuccess(data));
+        dispatch(notificationsIsLoading(false));
+        dispatch(notificationsHasErrored(false));
+      })
+      .catch(() => {
+        dispatch(notificationsHasErrored(true));
+        dispatch(notificationsIsLoading(false));
+      });
   };
 }
 
@@ -109,16 +107,16 @@ export function bidTrackerNotificationsFetchData() {
 
 export function markNotification(id, isRead = true) {
   return (dispatch) => {
-    axios.patch(`${api}/notification/${id}/`, { is_read: isRead }, { headers: { Authorization: fetchUserToken() } })
-            .then(({ data }) => {
-              dispatch(markNotificationSuccess(data));
-              dispatch(markNotificationIsLoading(false));
-              dispatch(markNotificationHasErrored(false));
-              dispatch(bidTrackerNotificationsFetchData());
-            })
-            .catch(() => {
-              dispatch(markNotificationHasErrored(true));
-              dispatch(markNotificationIsLoading(false));
-            });
+    api.patch(`/notification/${id}/`, { is_read: isRead })
+      .then(({ data }) => {
+        dispatch(markNotificationSuccess(data));
+        dispatch(markNotificationIsLoading(false));
+        dispatch(markNotificationHasErrored(false));
+        dispatch(bidTrackerNotificationsFetchData());
+      })
+      .catch(() => {
+        dispatch(markNotificationHasErrored(true));
+        dispatch(markNotificationIsLoading(false));
+      });
   };
 }

--- a/src/actions/positionDetails.js
+++ b/src/actions/positionDetails.js
@@ -1,6 +1,4 @@
-import axios from 'axios';
 import api from '../api';
-import { fetchUserToken } from '../utilities';
 
 export function positionDetailsHasErrored(bool) {
   return {
@@ -8,12 +6,14 @@ export function positionDetailsHasErrored(bool) {
     hasErrored: bool,
   };
 }
+
 export function positionDetailsIsLoading(bool) {
   return {
     type: 'POSITION_DETAILS_IS_LOADING',
     isLoading: bool,
   };
 }
+
 export function positionDetailsFetchDataSuccess(positionDetails) {
   return {
     type: 'POSITION_DETAILS_FETCH_DATA_SUCCESS',
@@ -24,16 +24,16 @@ export function positionDetailsFetchDataSuccess(positionDetails) {
 export function positionDetailsFetchData(query) {
   return (dispatch) => {
     dispatch(positionDetailsIsLoading(true));
-    axios.get(`${api}/position/?position_number=${query}`, { headers: { Authorization: fetchUserToken() } })
-            .then(response => response.data.results)
-            .then((positionDetails) => {
-              dispatch(positionDetailsFetchDataSuccess(positionDetails));
-              dispatch(positionDetailsIsLoading(false));
-              dispatch(positionDetailsHasErrored(false));
-            })
-            .catch(() => {
-              dispatch(positionDetailsHasErrored(true));
-              dispatch(positionDetailsIsLoading(false));
-            });
+    api.get(`/position/?position_number=${query}`)
+      .then(response => response.data.results)
+      .then((positionDetails) => {
+        dispatch(positionDetailsFetchDataSuccess(positionDetails));
+        dispatch(positionDetailsIsLoading(false));
+        dispatch(positionDetailsHasErrored(false));
+      })
+      .catch(() => {
+        dispatch(positionDetailsHasErrored(true));
+        dispatch(positionDetailsIsLoading(false));
+      });
   };
 }

--- a/src/actions/post.js
+++ b/src/actions/post.js
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import api from '../api';
 
 export function postHasErrored(bool) {
@@ -7,12 +6,14 @@ export function postHasErrored(bool) {
     hasErrored: bool,
   };
 }
+
 export function postIsLoading(bool) {
   return {
     type: 'POST_IS_LOADING',
     isLoading: bool,
   };
 }
+
 export function postFetchDataSuccess(post) {
   return {
     type: 'POST_FETCH_DATA_SUCCESS',
@@ -23,12 +24,12 @@ export function postFetchDataSuccess(post) {
 export function postFetchData(query) {
   return (dispatch) => {
     dispatch(postIsLoading(true));
-    axios.get(`${api}/orgpost/${query}/`)
-            .then((response) => {
-              dispatch(postIsLoading(false));
-              return response.data;
-            })
-            .then(post => dispatch(postFetchDataSuccess(post)))
-            .catch(() => dispatch(postHasErrored(true)));
+    api.get(`/orgpost/${query}/`)
+      .then((response) => {
+        dispatch(postIsLoading(false));
+        return response.data;
+      })
+      .then(post => dispatch(postFetchDataSuccess(post)))
+      .catch(() => dispatch(postHasErrored(true)));
   };
 }

--- a/src/actions/results.js
+++ b/src/actions/results.js
@@ -1,8 +1,6 @@
-import axios from 'axios';
+import { CancelToken } from 'axios';
 import api from '../api';
-import { fetchUserToken } from '../utilities';
 
-const CancelToken = axios.CancelToken;
 let cancel;
 
 export function resultsHasErrored(bool) {
@@ -47,10 +45,7 @@ export function resultsFetchSimilarPositions(id) {
   return (dispatch) => {
     if (cancel) { cancel(); }
     dispatch(resultsSimilarPositionsIsLoading(true));
-    axios.get(`${api}/position/${id}/similar/?limit=3`, {
-      headers: { Authorization: fetchUserToken() },
-    },
-    )
+    api.get(`/position/${id}/similar/?limit=3`)
       .then(response => response.data)
       .then((results) => {
         dispatch(resultsSimilarPositionsFetchDataSuccess(results));
@@ -68,13 +63,10 @@ export function resultsFetchData(query) {
   return (dispatch) => {
     if (cancel) { cancel(); }
     dispatch(resultsIsLoading(true));
-    axios.get(`${api}/position/?${query}`, {
-      headers: { Authorization: fetchUserToken() },
-      cancelToken: new CancelToken((c) => {
-        cancel = c;
-      }),
-    },
-    )
+    api
+      .get(`/position/?${query}`, {
+        cancelToken: new CancelToken((c) => { cancel = c; }),
+      })
       .then(response => response.data)
       .then((results) => {
         dispatch(resultsFetchDataSuccess(results));

--- a/src/actions/savedSearch.js
+++ b/src/actions/savedSearch.js
@@ -1,7 +1,5 @@
-import axios from 'axios';
-import * as SystemMessages from '../Constants/SystemMessages';
-import { fetchUserToken } from '../utilities';
 import api from '../api';
+import * as SystemMessages from '../Constants/SystemMessages';
 
 export function newSavedSearchHasErrored(bool) {
   return {
@@ -9,72 +7,84 @@ export function newSavedSearchHasErrored(bool) {
     hasErrored: bool,
   };
 }
+
 export function newSavedSearchIsSaving(bool) {
   return {
     type: 'NEW_SAVED_SEARCH_IS_SAVING',
     isSaving: bool,
   };
 }
+
 export function deleteSavedSearchIsLoading(bool) {
   return {
     type: 'DELETE_SAVED_SEARCH_IS_LOADING',
     isLoading: bool,
   };
 }
+
 export function deleteSavedSearchHasErrored(bool) {
   return {
     type: 'DELETE_SAVED_SEARCH_HAS_ERRORED',
     hasErrored: bool,
   };
 }
+
 export function deleteSavedSearchSuccess(bool) {
   return {
     type: 'DELETE_SAVED_SEARCH_SUCCESS',
     hasDeleted: bool,
   };
 }
+
 export function cloneSavedSearchIsLoading(bool) {
   return {
     type: 'CLONE_SAVED_SEARCH_IS_LOADING',
     isLoading: bool,
   };
 }
+
 export function cloneSavedSearchHasErrored(bool) {
   return {
     type: 'CLONE_SAVED_SEARCH_HAS_ERRORED',
     hasErrored: bool,
   };
 }
+
 export function cloneSavedSearchSuccess(bool) {
   return {
     type: 'CLONE_SAVED_SEARCH_SUCCESS',
     hasCloned: bool,
   };
 }
+
 export function newSavedSearchSuccess(newSavedSearch) {
   return {
     type: 'NEW_SAVED_SEARCH_SUCCESS',
     newSavedSearch,
   };
 }
+
 export function currentSavedSearch(searchObject) {
   return {
     type: 'CURRENT_SAVED_SEARCH',
     searchObject,
   };
 }
+
 export function savedSearchesSuccess(savedSearches) {
   return {
     type: 'SAVED_SEARCHES_SUCCESS',
     savedSearches,
   };
 }
+
 export function savedSearchesIsLoading(bool) {
   return {
     type: 'SAVED_SEARCHES_IS_LOADING',
     isLoading: bool,
   };
 }
+
 export function savedSearchesHasErrored(bool) {
   return {
     type: 'SAVED_SEARCHES_HAS_ERRORED',
@@ -105,17 +115,17 @@ export function savedSearchesFetchData() {
   return (dispatch) => {
     dispatch(savedSearchesIsLoading(true));
     dispatch(savedSearchesHasErrored(false));
-    axios.get(`${api}/searches/`, { headers: { Authorization: fetchUserToken() } })
-            .then(response => response.data)
-            .then((results) => {
-              dispatch(savedSearchesIsLoading(false));
-              dispatch(savedSearchesHasErrored(false));
-              dispatch(savedSearchesSuccess(results));
-            })
-            .catch(() => {
-              dispatch(savedSearchesIsLoading(false));
-              dispatch(savedSearchesHasErrored(true));
-            });
+    api.get('/searches/')
+      .then(response => response.data)
+      .then((results) => {
+        dispatch(savedSearchesIsLoading(false));
+        dispatch(savedSearchesSuccess(results));
+        dispatch(savedSearchesHasErrored(false));
+      })
+      .catch(() => {
+        dispatch(savedSearchesIsLoading(false));
+        dispatch(savedSearchesHasErrored(true));
+      });
   };
 }
 
@@ -123,19 +133,19 @@ export function deleteSavedSearch(id) {
   return (dispatch) => {
     dispatch(deleteSavedSearchIsLoading(true));
     dispatch(routeChangeResetState());
-    axios.delete(`${api}/searches/${id}/`, { headers: { Authorization: fetchUserToken() } })
-            .then(() => {
-              dispatch(deleteSavedSearchIsLoading(false));
-              dispatch(deleteSavedSearchHasErrored(false));
-              dispatch(deleteSavedSearchSuccess('Successfully deleted the selected search.'));
-              dispatch(currentSavedSearch(false));
-              dispatch(savedSearchesFetchData());
-            })
-            .catch((err) => {
-              dispatch(deleteSavedSearchHasErrored(JSON.stringify(err.response.data) || 'An error occurred trying to delete this search.'));
-              dispatch(deleteSavedSearchIsLoading(false));
-              dispatch(deleteSavedSearchSuccess(false));
-            });
+    api.delete(`/searches/${id}/`)
+      .then(() => {
+        dispatch(deleteSavedSearchIsLoading(false));
+        dispatch(deleteSavedSearchHasErrored(false));
+        dispatch(deleteSavedSearchSuccess('Successfully deleted the selected search.'));
+        dispatch(currentSavedSearch(false));
+        dispatch(savedSearchesFetchData());
+      })
+      .catch((err) => {
+        dispatch(deleteSavedSearchHasErrored(JSON.stringify(err.response.data) || 'An error occurred trying to delete this search.'));
+        dispatch(deleteSavedSearchIsLoading(false));
+        dispatch(deleteSavedSearchSuccess(false));
+      });
   };
 }
 
@@ -150,71 +160,66 @@ export function cloneSavedSearch(id) {
       dispatch(cloneSavedSearchSuccess(false));
     };
     // get the original saved search
-    axios.get(`${api}/searches/${id}/`, { headers: { Authorization: fetchUserToken() } })
-            .then((response) => {
-              const responseObject = response.data;
-              // copy the object, but only with the properties we need
-              const clonedResponse = Object.assign({},
-                { name: responseObject.name,
-                  endpoint: responseObject.endpoint,
-                  filters: responseObject.filters },
-              );
-              // append a timestamp to the end of the name
-              clonedResponse.name += ` - Copy - ${new Date()}`;
-              axios.post(`${api}/searches/`, clonedResponse, { headers: { Authorization: fetchUserToken() } })
-                      .then((postResponse) => {
-                        dispatch(cloneSavedSearchIsLoading(false));
-                        dispatch(cloneSavedSearchHasErrored(false));
-                        dispatch(cloneSavedSearchSuccess(`Successfully cloned the selected search as "${postResponse.data.name}".`));
-                        dispatch(currentSavedSearch(false));
-                        dispatch(savedSearchesFetchData());
-                      })
-                      .catch((err) => {
-                        onCatch(err);
-                      });
-            })
-            .catch((err) => {
-              onCatch(err);
-            });
+    api.get(`/searches/${id}/`)
+      .then((response) => {
+        const responseObject = response.data;
+        // copy the object, but only with the properties we need
+        const clonedResponse = Object.assign({}, {
+          name: responseObject.name,
+          endpoint: responseObject.endpoint,
+          filters: responseObject.filters,
+        });
+
+        // append a timestamp to the end of the name
+        clonedResponse.name += ` - Copy - ${new Date()}`;
+        api.post('/searches/', clonedResponse)
+          .then((postResponse) => {
+            dispatch(cloneSavedSearchIsLoading(false));
+            dispatch(cloneSavedSearchHasErrored(false));
+            dispatch(cloneSavedSearchSuccess(`Successfully cloned the selected search as "${postResponse.data.name}".`));
+            dispatch(currentSavedSearch(false));
+            dispatch(savedSearchesFetchData());
+          })
+          .catch(err => onCatch(err));
+      })
+      .catch(err => onCatch(err));
   };
 }
 
-export function setCurrentSavedSearch(searchObject) {
-  return (dispatch) => {
-    dispatch(currentSavedSearch(searchObject));
-  };
-}
+export const setCurrentSavedSearch = searchObject =>
+  dispatch => dispatch(currentSavedSearch(searchObject));
 
 // save a new search OR pass an ID to patch an existing search
 export function saveSearch(data, id) {
   return (dispatch) => {
+    // here we handle based on the "id" param to decide whether
+    // to post or patch to the correct endpoint
+    const config = {
+      method: id ? 'patch' : 'post',
+      url: `/searches/${id ? '/id' : '/'}`,
+      data,
+    };
+
     dispatch(newSavedSearchIsSaving(true));
     dispatch(newSavedSearchSuccess(false));
     dispatch(newSavedSearchHasErrored(false));
-    // here we handle based on the "id" param to decide whether
-    // to post or patch to the correct endpoint
-    let action = 'post';
-    let endpoint = `${api}/searches/`;
-    if (id) {
-      action = 'patch';
-      endpoint = `${api}/searches/${id}/`;
-    }
-    axios[action](endpoint, data, { headers: { Authorization: fetchUserToken() } })
-            .then((response) => {
-              dispatch(newSavedSearchIsSaving(false));
-              dispatch(newSavedSearchHasErrored(false));
-              dispatch(newSavedSearchSuccess(
-                // if an ID was passed, we know to use the UPDATED message
-                id ?
-                  SystemMessages.UPDATED_SAVED_SEARCH_SUCCESS(response.data.name) :
-                  SystemMessages.NEW_SAVED_SEARCH_SUCCESS(response.data.name),
-              ));
-              dispatch(setCurrentSavedSearch(response.data));
-            })
-            .catch((err) => {
-              dispatch(newSavedSearchHasErrored(JSON.stringify(err.response.data) || 'An error occurred trying to save this search.'));
-              dispatch(newSavedSearchIsSaving(false));
-              dispatch(newSavedSearchSuccess(false));
-            });
+
+    api(config)
+      .then((response) => {
+        dispatch(newSavedSearchIsSaving(false));
+        dispatch(newSavedSearchHasErrored(false));
+        dispatch(newSavedSearchSuccess(
+          // if an ID was passed, we know to use the UPDATED message
+          id ?
+            SystemMessages.UPDATED_SAVED_SEARCH_SUCCESS(response.data.name) :
+            SystemMessages.NEW_SAVED_SEARCH_SUCCESS(response.data.name),
+        ));
+        dispatch(setCurrentSavedSearch(response.data));
+      })
+      .catch((err) => {
+        dispatch(newSavedSearchHasErrored(JSON.stringify(err.response.data) || 'An error occurred trying to save this search.'));
+        dispatch(newSavedSearchIsSaving(false));
+        dispatch(newSavedSearchSuccess(false));
+      });
   };
 }

--- a/src/actions/share.js
+++ b/src/actions/share.js
@@ -1,5 +1,3 @@
-import axios from 'axios';
-import { fetchUserToken } from '../utilities';
 import api from '../api';
 
 export function shareHasErrored(bool) {
@@ -7,37 +5,41 @@ export function shareHasErrored(bool) {
     type: 'SHARE_HAS_ERRORED',
     hasErrored: bool,
   };
-}
+};
+
 export function shareIsSending(bool) {
   return {
     type: 'SHARE_IS_SENDING',
     isLoading: bool,
   };
-}
+};
+
 export function shareSuccess(share) {
   return {
     type: 'SHARE_SUCCESS',
     share,
   };
-}
+};
 
 export function shareSendData(data) {
   return (dispatch) => {
     dispatch(shareIsSending(true));
     dispatch(shareSuccess(false));
     dispatch(shareHasErrored(false));
-    axios.post(`${api}/share/`, data, { headers: { Authorization: fetchUserToken() } })
-            .then((response) => {
-              dispatch(shareIsSending(false));
-              dispatch(shareHasErrored(false));
-              return response.data;
-            })
-            .then(share => dispatch(shareSuccess(share)))
-            .catch((err) => {
-              dispatch(shareHasErrored(err.response.data.message || 'An error occurred trying to share this position.'));
-              dispatch(shareIsSending(false));
-              dispatch(shareSuccess(false));
-              return err.response.data.message;
-            });
+    api.post('/share/', data)
+      .then((response) => {
+        dispatch(shareIsSending(false));
+        dispatch(shareHasErrored(false));
+        return response.data;
+      })
+      .then(share => dispatch(shareSuccess(share)))
+      .catch((err) => {
+        dispatch(shareHasErrored(
+          err.response.data.message || 'An error occurred trying to share this position.'
+        ));
+        dispatch(shareIsSending(false));
+        dispatch(shareSuccess(false));
+        return err.response.data.message;
+      });
   };
-}
+};

--- a/src/actions/share.js
+++ b/src/actions/share.js
@@ -5,21 +5,21 @@ export function shareHasErrored(bool) {
     type: 'SHARE_HAS_ERRORED',
     hasErrored: bool,
   };
-};
+}
 
 export function shareIsSending(bool) {
   return {
     type: 'SHARE_IS_SENDING',
     isLoading: bool,
   };
-};
+}
 
 export function shareSuccess(share) {
   return {
     type: 'SHARE_SUCCESS',
     share,
   };
-};
+}
 
 export function shareSendData(data) {
   return (dispatch) => {
@@ -35,11 +35,11 @@ export function shareSendData(data) {
       .then(share => dispatch(shareSuccess(share)))
       .catch((err) => {
         dispatch(shareHasErrored(
-          err.response.data.message || 'An error occurred trying to share this position.'
+          err.response.data.message || 'An error occurred trying to share this position.',
         ));
         dispatch(shareIsSending(false));
         dispatch(shareSuccess(false));
         return err.response.data.message;
       });
   };
-};
+}

--- a/src/actions/userProfile.js
+++ b/src/actions/userProfile.js
@@ -1,5 +1,4 @@
 import axios from 'axios';
-import { fetchUserToken } from '../utilities';
 import api from '../api';
 import { favoritePositionsFetchData } from './favoritePositions';
 
@@ -9,18 +8,21 @@ export function userProfileHasErrored(bool) {
     hasErrored: bool,
   };
 }
+
 export function userProfileIsLoading(bool) {
   return {
     type: 'USER_PROFILE_IS_LOADING',
     isLoading: bool,
   };
 }
+
 export function userProfileFetchDataSuccess(userProfile) {
   return {
     type: 'USER_PROFILE_FETCH_DATA_SUCCESS',
     userProfile,
   };
 }
+
 // when adding or removing a favorite
 export function userProfileFavoritePositionIsLoading(bool) {
   return {
@@ -28,6 +30,7 @@ export function userProfileFavoritePositionIsLoading(bool) {
     userProfileFavoritePositionIsLoading: bool,
   };
 }
+
 // when adding or removing a favorite has errored
 export function userProfileFavoritePositionHasErrored(bool) {
   return {
@@ -50,39 +53,35 @@ export function userProfileFetchData(bypass) {
       dispatch(userProfileHasErrored(false));
     }
 
-    // create functions to fetch user's profile and permissions
-
+    /**
+     * create functions to fetch user's profile and permissions
+     */
     // profile
-    function getUserAccount() {
-      return axios.get(`${api}/profile/`, { headers: { Authorization: fetchUserToken() } });
-    }
-
+    const getUserAccount = () => api.get('/profile/');
     // permissions
-    function getUserPermissions() {
-      return axios.get(`${api}/permission/user/`, { headers: { Authorization: fetchUserToken() } });
-    }
+    const getUserPermissions = () => api.get('/permission/user/');
 
-    // use axios' Promise.all to fetch the profile and permissions, and then combine them
+    // use api' Promise.all to fetch the profile and permissions, and then combine them
     // into one object
     axios.all([getUserAccount(), getUserPermissions()])
-            .then(axios.spread((acct, perms) => {
-              // form the userProfile object
-              const account = acct.data;
-              const permissions = perms.data;
-              const newProfileObject = { ...account, permission_groups: permissions.groups };
+      .then(axios.spread((acct, perms) => {
+        // form the userProfile object
+        const account = acct.data;
+        const permissions = perms.data;
+        const newProfileObject = { ...account, permission_groups: permissions.groups };
 
-              // then perform dispatches
-              dispatch(userProfileFetchDataSuccess(newProfileObject));
-              dispatch(userProfileIsLoading(false));
-              dispatch(userProfileHasErrored(false));
-              dispatch(userProfileFavoritePositionHasErrored(false));
-              dispatch(userProfileFavoritePositionIsLoading(false));
-            }))
-            .catch(() => {
-              dispatch(userProfileHasErrored(true));
-              dispatch(userProfileIsLoading(false));
-              dispatch(userProfileFavoritePositionIsLoading(false));
-            });
+        // then perform dispatches
+        dispatch(userProfileFetchDataSuccess(newProfileObject));
+        dispatch(userProfileIsLoading(false));
+        dispatch(userProfileHasErrored(false));
+        dispatch(userProfileFavoritePositionHasErrored(false));
+        dispatch(userProfileFavoritePositionIsLoading(false));
+      }))
+      .catch(() => {
+        dispatch(userProfileHasErrored(true));
+        dispatch(userProfileIsLoading(false));
+        dispatch(userProfileFavoritePositionIsLoading(false));
+      });
   };
 }
 
@@ -97,31 +96,26 @@ export function userProfileFetchData(bypass) {
 export function userProfileToggleFavoritePosition(id, remove, refreshFavorites = false) {
   const idString = id.toString();
   return (dispatch) => {
+    const config = {
+      method: remove ? 'delete' : 'put',
+      url: `/position/${idString}/favorite/`,
+    };
+
     dispatch(userProfileFavoritePositionIsLoading(true));
     dispatch(userProfileFavoritePositionHasErrored(false));
-    let action = 'put';
-    if (remove) {
-      action = 'delete';
-    }
-    const auth = { headers: { Authorization: fetchUserToken() } };
-    // Now we can patch our profile with the new favorites.
-    // Axios is a little weird here in that for PUTs, it expects a body as the second argument,
-    // whereas for DELETEs, it expects the headers object...
-    // so we have to conditionally decide what position to put the headers object in.
-    const firstArg = action === 'delete' ? auth : {};
-    const secondArg = action === 'put' ? auth : null;
-    axios[action](`${api}/position/${idString}/favorite/`, firstArg, secondArg)
-            .then(() => {
-              dispatch(userProfileFetchData(true));
-              dispatch(userProfileFavoritePositionIsLoading(false));
-              dispatch(userProfileFavoritePositionHasErrored(false));
-              if (refreshFavorites) {
-                dispatch(favoritePositionsFetchData());
-              }
-            })
-            .catch(() => {
-              dispatch(userProfileFavoritePositionHasErrored(true));
-              dispatch(userProfileFavoritePositionIsLoading(false));
-            });
+
+    api(config)
+      .then(() => {
+        dispatch(userProfileFetchData(true));
+        dispatch(userProfileFavoritePositionIsLoading(false));
+        dispatch(userProfileFavoritePositionHasErrored(false));
+        if (refreshFavorites) {
+          dispatch(favoritePositionsFetchData());
+        }
+      })
+      .catch(() => {
+        dispatch(userProfileFavoritePositionHasErrored(true));
+        dispatch(userProfileFavoritePositionIsLoading(false));
+      });
   };
 }

--- a/src/api.js
+++ b/src/api.js
@@ -1,2 +1,40 @@
-const api = 'http://localhost:8000/api/v1';
+import axios from 'axios';
+import { fetchUserToken, hasValidToken } from './utilities';
+import { logoutRequest } from './login/actions';
+
+export const config = {
+  baseURL: process.env.API_URL || 'http://localhost:8000/api/v1',
+};
+
+const api = axios.create(config);
+
+api.interceptors.request.use((request) => {
+  if (hasValidToken()) {
+    request.headers.Authorization = fetchUserToken();
+  }
+
+  return request;
+});
+
+api.interceptors.response.use(response => response, (error) => {
+  switch (error.response.status) {
+    case 401:
+      // Due to timing of import store before history is created, importing store here causes
+      // exports of api to be undefined. So this causes an error for `userProfile.js` when
+      // attempting to login. Went with the eslint quick re-enable to get around this.
+      /* eslint-disable global-require */
+      require('./store').dispatch(logoutRequest());
+      /* eslint-enable global-require */
+      break;
+
+    default:
+      // TODO:
+      // We don't want to stop the pipeline even if there's a problem with the dispatch
+      // and if there is, that should be resolved. This is just a placeholder until we
+      // actually need a default case to satisfy eslint.
+  }
+
+  return Promise.reject(error);
+});
+
 export default api;

--- a/src/api.js
+++ b/src/api.js
@@ -23,7 +23,7 @@ api.interceptors.response.use(response => response, (error) => {
       // exports of api to be undefined. So this causes an error for `userProfile.js` when
       // attempting to login. Went with the eslint quick re-enable to get around this.
       /* eslint-disable global-require */
-      require('./store').dispatch(logoutRequest());
+      require('./store').store.dispatch(logoutRequest());
       /* eslint-enable global-require */
       break;
 

--- a/src/api.js
+++ b/src/api.js
@@ -9,11 +9,12 @@ export const config = {
 const api = axios.create(config);
 
 api.interceptors.request.use((request) => {
+  const requestWithAuth = request;
   if (hasValidToken()) {
-    request.headers.Authorization = fetchUserToken();
+    requestWithAuth.headers.Authorization = fetchUserToken();
   }
 
-  return request;
+  return requestWithAuth;
 });
 
 api.interceptors.response.use(response => response, (error) => {

--- a/src/login/sagas.js
+++ b/src/login/sagas.js
@@ -1,8 +1,5 @@
 import { take, call, put, cancelled, race } from 'redux-saga/effects';
-import axios from 'axios';
-
 import { push } from 'react-router-redux';
-
 import api from '../api';
 
 // Our login constants
@@ -32,7 +29,7 @@ import {
   unsetNotificationsCount,
 } from '../actions/notifications';
 
-const loginUrl = `${api}/accounts/token/`;
+const loginUrl = '/accounts/token/';
 
 export const errorMessage = { message: null };
 
@@ -44,7 +41,7 @@ export function loginApi(username, password) {
   if (!username || !password) {
     return changeErrorMessage('Fields cannot be blank');
   }
-  return axios.post(loginUrl, { username, password })
+  return api.post(loginUrl, { username, password })
     .then(response => response.data.token)
     .catch((error) => { changeErrorMessage(error.message); });
 }

--- a/src/login/sagas.js
+++ b/src/login/sagas.js
@@ -1,6 +1,7 @@
 import { take, call, put, cancelled, race } from 'redux-saga/effects';
 import { push } from 'react-router-redux';
 import api from '../api';
+import isCurrentPath from '../Components/ProfileMenu/navigation';
 
 // Our login constants
 import {
@@ -62,8 +63,15 @@ function* logout() {
   // .. inform redux that our logout was successful
   yield put({ type: LOGOUT_SUCCESS });
 
+  // Check if the user is already on the login page. We don't want a race
+  // condition to infinitely loop them back to the login page, should
+  // any requests be made that result in 401
+  const isOnLoginPage = isCurrentPath(window.location.pathname, '/login');
+
   // redirect to the /login screen
-  yield put(push('/login'));
+  if (!isOnLoginPage) {
+    yield put(push('/login'));
+  }
 }
 
 function* loginFlow(username, password) {

--- a/src/login/sagas.test.js
+++ b/src/login/sagas.test.js
@@ -1,6 +1,6 @@
 import { expectSaga } from 'redux-saga-test-plan';
-import api from '../api';
 import MockAdapter from 'axios-mock-adapter';
+import api from '../api';
 import loginWatcher, { changeErrorMessage, errorMessage, loginApi } from './sagas';
 
 describe('login functions', () => {

--- a/src/login/sagas.test.js
+++ b/src/login/sagas.test.js
@@ -1,12 +1,12 @@
 import { expectSaga } from 'redux-saga-test-plan';
-import axios from 'axios';
+import api from '../api';
 import MockAdapter from 'axios-mock-adapter';
 import loginWatcher, { changeErrorMessage, errorMessage, loginApi } from './sagas';
 
 describe('login functions', () => {
   it('can log in and set the client', () => {
-    const mockAdapter = new MockAdapter(axios);
-    mockAdapter.onPost('http://localhost:8000/api/v1/accounts/token/').reply(200,
+    const mockAdapter = new MockAdapter(api);
+    mockAdapter.onPost('/accounts/token/').reply(200,
       { token: '12345' },
     );
     return expectSaga(loginWatcher)
@@ -20,8 +20,8 @@ describe('login functions', () => {
         password: 'admin',
       })
 
-      // Start the test. Returns a Promise.
-      .run();
+      // Start the test. Returns a Promise. [silent warnings]
+      .silentRun();
   });
 
   it('can log out and unset the client', () => expectSaga(loginWatcher)
@@ -33,12 +33,12 @@ describe('login functions', () => {
         type: 'LOGOUT_REQUESTING',
       })
 
-      // Start the test. Returns a Promise.
-      .run());
+      // Start the test. Returns a Promise. [silent warnings]
+      .silentRun());
 
   it('can can catch empty login fields', () => {
-    const mockAdapter = new MockAdapter(axios);
-    mockAdapter.onPost('http://localhost:8000/api/v1/accounts/token/').reply(200,
+    const mockAdapter = new MockAdapter(api);
+    mockAdapter.onPost('/accounts/token/').reply(200,
       { token: '12345' },
     );
     return expectSaga(loginWatcher)
@@ -52,13 +52,13 @@ describe('login functions', () => {
         password: '',
       })
 
-      // Start the test. Returns a Promise.
-      .run();
+      // Start the test. Returns a Promise. [silent warnings]
+      .silentRun();
   });
 
   it('can catch AJAX errors', () => {
-    const mockAdapter = new MockAdapter(axios);
-    mockAdapter.onPost('http://localhost:8000/api/v1/accounts/token/').reply(400,
+    const mockAdapter = new MockAdapter(api);
+    mockAdapter.onPost('/accounts/token/').reply(400,
       'error',
     );
     loginApi('user', 'pass');

--- a/src/testUtilities/testUtilities.js
+++ b/src/testUtilities/testUtilities.js
@@ -1,8 +1,8 @@
 import sinon from 'sinon';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
+import api from '../api';
 
 // Tests all functions within a mapDispatchToProps function.
 // We take two arguments, one is the entire mapDispatchToProps function, which
@@ -42,7 +42,7 @@ export function testDispatchFunctions(mapDispatchToProps, config = {}) {
 export function setupAsyncMocks() {
   const middlewares = [thunk];
   const mockStore = configureMockStore(middlewares);
-  const mockAdapter = new MockAdapter(axios);
+  const mockAdapter = new MockAdapter(api);
 
   return { mockStore, mockAdapter };
 }

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -3,6 +3,7 @@ import queryString from 'query-string';
 import distanceInWords from 'date-fns/distance_in_words';
 import format from 'date-fns/format';
 import numeral from 'numeral';
+import { get } from 'lodash';
 import { VALID_PARAMS } from './Constants/EndpointParams';
 
 const scroll = Scroll.animateScroll;
@@ -42,6 +43,21 @@ export function localStorageToggleValue(key, value) {
 
 export function validStateEmail(email) {
   return /.+@state.gov$/.test(email.trim());
+}
+
+export function hasValidToken() {
+  try {
+    /* eslint-disable no-unused-vars */
+    const token = JSON.parse(localStorage.getItem('token'));
+    /* eslint-enable no-unused-vars */
+    return true;
+  } catch (error) {
+    // If token exists and is bad (maybe user injected)
+    // Drop the token anyways just so we can have the container
+    // render login directly
+    localStorage.removeItem('token');
+    return false;
+  }
 }
 
 export function fetchUserToken() {
@@ -275,29 +291,8 @@ export const formatWaiverTitle = waiver => `${waiver.position} - ${waiver.catego
 // obj should be an object, such as { a: { b: 1, c: { d: 2 } } }
 // path should be a string to the desired path - "a.b.c.d"
 // defaultToReturn should be the default value you want to return if the traversal fails
-export const propOrDefault = (obj, path, defaultToReturn = null) => {
-  // split the path into individual strings
-  const args = path.split('.');
-
-  let valueToReturn = obj;
-
-  // function to determine if object contains the next i property
-  const returnSubProp = i => Object.prototype.hasOwnProperty.call(valueToReturn, args[i]);
-
-  // iterate through each arg and change valueToReturn to the next i property if it exists,
-  // otherwise return the defaultToReturn
-  for (let i = 0; i < args.length; i += 1) {
-    if (valueToReturn && returnSubProp(i)) {
-      valueToReturn = valueToReturn[args[i]];
-    } else if ((!valueToReturn && valueToReturn !== 0) || !returnSubProp(i)) {
-      return defaultToReturn;
-    }
-  }
-  // ensure that if valueToReturn is false, to set it as the defaultToReturn.
-  // also check for 0 equality, since we still want to return 0s
-  if (!valueToReturn && valueToReturn !== 0) { valueToReturn = defaultToReturn; }
-  return valueToReturn;
-};
+export const propOrDefault = (obj, path, defaultToReturn = null) =>
+  get(obj, path, defaultToReturn);
 
 // Return the correct object from the bidStatisticsArray.
 // If it doesn't exist, return an empty object.


### PR DESCRIPTION
- Added an `axios` response interceptor for `axios` to
drop stale tokens when recieving a 401 status code from the API
- Added an `axios` request interceptor for `axios` to  parse and verify token within a `try/catch` to catch injected tokens or invalid tokens, and if valid, `axios` will inject the auth headers before the request fires.
- Updated all files (including sagas mocks) to use an app specific instance of axios from `api.js`

```javascript
// Probably won't need `window`
window.localStorage.setItem('"aa3e0f420717dcf242831dc596d899af20c9d3f4"');
window.localStorage.setItem('"test"');
``` 
via console, would be a pretty accurate test