### PR TITLE
Remove scroll

### DIFF
--- a/src/sass/_results.scss
+++ b/src/sass/_results.scss
@@ -286,8 +286,6 @@
     background-color: $color-gray-lightest-alt;
     color: $color-black;
     font-size: 1.1em;
-    max-height: 400px;
-    overflow-y: scroll;
     padding: 1rem;
   }
 


### PR DESCRIPTION
I'm remembering why I didn't have overflow scroll initially. Browsers seem to capture the child element's scroll position, and apply that scroll position to the page upon refresh/filter change.