### PR TITLE
Remove the Mission Filter

### DIFF
--- a/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.jsx
+++ b/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.jsx
@@ -6,7 +6,7 @@ import BooleanFilterContainer from '../BooleanFilterContainer/BooleanFilterConta
 import LanguageFilter from '../LanguageFilter/LanguageFilter';
 import AutoSuggest from '../../AutoSuggest';
 import SuggestionChoicePost from '../../AutoSuggest/SuggestionChoicePost';
-import { FILTER_ITEMS_ARRAY, ACCORDION_SELECTION_OBJECT, MISSION_DETAILS_ARRAY, POST_DETAILS_ARRAY } from '../../../Constants/PropTypes';
+import { FILTER_ITEMS_ARRAY, ACCORDION_SELECTION_OBJECT, POST_DETAILS_ARRAY } from '../../../Constants/PropTypes';
 import { propSort } from '../../../utilities';
 import { ENDPOINT_PARAMS } from '../../../Constants/EndpointParams';
 
@@ -42,7 +42,7 @@ class SearchFiltersContainer extends Component {
     this.props.setAccordion({ main: 'Language', sub: a });
   }
   render() {
-    const { fetchMissionAutocomplete, missionSearchResults, fetchPostAutocomplete,
+    const { fetchPostAutocomplete,
     postSearchResults, isCDO } = this.props;
 
     // Get our boolean filter names.
@@ -71,7 +71,7 @@ class SearchFiltersContainer extends Component {
     });
 
     // get our normal multi-select filters
-    const multiSelectFilterNames = ['skill', 'grade', 'post', 'region', 'tod', 'mission'];
+    const multiSelectFilterNames = ['skill', 'grade', 'post', 'region', 'tod'];
 
     // create map
     const multiSelectFilterMap = new Map();
@@ -135,12 +135,6 @@ class SearchFiltersContainer extends Component {
         displayProperty = 'location';
         suggestionTemplate = SuggestionChoicePost; // special template for posts
       }
-      if (n === 'mission') {
-        getSuggestions = fetchMissionAutocomplete;
-        suggestions = missionSearchResults;
-        placeholder = 'Start typing a mission';
-        onSuggestionSelected = this.onMissionSuggestionSelected;
-      }
       if (item) {
         sortedFilters.push(
           { content:
@@ -148,7 +142,7 @@ class SearchFiltersContainer extends Component {
               <div className="usa-grid-full">
                 {
                 // Only show the autosuggest for post and mission filters.
-                (n === 'post' || n === 'mission') ?
+                (n === 'post') ?
                   <AutoSuggest
                     getSuggestions={getSuggestions}
                     suggestions={suggestions}
@@ -210,8 +204,6 @@ SearchFiltersContainer.propTypes = {
   queryParamToggle: PropTypes.func.isRequired,
   selectedAccordion: ACCORDION_SELECTION_OBJECT.isRequired,
   setAccordion: PropTypes.func.isRequired,
-  fetchMissionAutocomplete: PropTypes.func.isRequired,
-  missionSearchResults: MISSION_DETAILS_ARRAY.isRequired,
   fetchPostAutocomplete: PropTypes.func.isRequired,
   postSearchResults: POST_DETAILS_ARRAY.isRequired,
   isCDO: PropTypes.bool.isRequired,

--- a/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.test.jsx
+++ b/src/Components/SearchFilters/SearchFiltersContainer/SearchFiltersContainer.test.jsx
@@ -24,10 +24,6 @@ describe('SearchFiltersContainerComponent', () => {
       data: [{ isSelected: true }],
     },
     {
-      item: { title: 'mission', description: 'mission', selectionRef: 'ref3' },
-      data: [{ isSelected: true }],
-    },
-    {
       item: { title: 'COLA', description: 'cola', selectionRef: 'ref4', bool: true },
       data: [{ isSelected: false }],
     },
@@ -191,7 +187,7 @@ describe('SearchFiltersContainerComponent', () => {
 
   it('orders the filters in the correct order', () => {
     // filter order defined in the component
-    const filterOrder = ['skill', 'grade', 'post', 'region', 'tod', 'mission'];
+    const filterOrder = ['skill', 'grade', 'post', 'region', 'tod'];
     const wrapper = shallow(
       <SearchFiltersContainer
         {...props}

--- a/src/Components/SearchFilters/SearchFiltersContainer/__snapshots__/SearchFiltersContainer.test.jsx.snap
+++ b/src/Components/SearchFilters/SearchFiltersContainer/__snapshots__/SearchFiltersContainer.test.jsx.snap
@@ -159,49 +159,6 @@ exports[`SearchFiltersContainerComponent matches snapshot 1`] = `
           "title": "tod",
         },
         Object {
-          "content": <div
-            className="usa-grid-full"
-          >
-            <AutoSuggest
-              customInputProps={Object {}}
-              debounceMillis={350}
-              displayProperty="short_name"
-              getSuggestions={[Function]}
-              id="mission-autosuggest-container"
-              inputId="mission-autosuggest-input"
-              label="mission name"
-              labelSrOnly={true}
-              onSuggestionSelected={[Function]}
-              onSuggestionsClearRequested={[Function]}
-              placeholder="Start typing a mission"
-              queryProperty="id"
-              suggestionTemplate={[Function]}
-              suggestions={Array []}
-            />
-            <MultiSelectFilter
-              item={
-                Object {
-                  "data": Array [
-                    Object {
-                      "isSelected": true,
-                    },
-                  ],
-                  "item": Object {
-                    "description": "mission",
-                    "selectionRef": "ref3",
-                    "title": "mission",
-                  },
-                }
-              }
-              queryParamToggle={[Function]}
-              queryProperty="_id"
-            />
-          </div>,
-          "expanded": false,
-          "id": "accordion-mission",
-          "title": "mission",
-        },
-        Object {
           "content": <LanguageFilter
             item={
               Object {

--- a/src/actions/filters/filters.js
+++ b/src/actions/filters/filters.js
@@ -84,20 +84,6 @@ export function filtersFetchData(items = { filters: [] }, queryParams = {}, save
             throw error;
           });
         }
-        if (item.selectionRef === ENDPOINT_PARAMS.mission) {
-          dispatch(filtersIsLoading(true));
-          return axios.get(`${api}/country/${item.codeRef}/`)
-          .then((response) => {
-            const obj = Object.assign(response.data, { type: 'mission', selectionRef: item.selectionRef, codeRef: item.codeRef });
-            // push the object to cache
-            responses.asyncFilterCache.push(obj);
-            // and return the object
-            return obj;
-          })
-          .catch((error) => {
-            throw error;
-          });
-        }
         return {};
       });
 

--- a/src/actions/filters/filters.test.js
+++ b/src/actions/filters/filters.test.js
@@ -72,20 +72,6 @@ const items = {
       data: [
       ],
     },
-    {
-      item: {
-        title: 'Mission',
-        sort: 1000,
-        bool: false,
-        description: 'mission',
-        endpoint: 'country/?limit=7',
-        selectionRef: ENDPOINT_PARAMS.mission,
-        choices: [
-        ],
-      },
-      data: [
-      ],
-    },
   ],
 };
 
@@ -151,14 +137,6 @@ describe('async actions', () => {
 
     mockAdapter.onGet('http://localhost:8000/api/v1/grade/').reply(200,
       grades,
-    );
-
-    mockAdapter.onGet('http://localhost:8000/api/v1/country/?limit=7').reply(200,
-      missions,
-    );
-
-    mockAdapter.onGet('http://localhost:8000/api/v1/country/1/').reply(200,
-      missions.results[0],
     );
 
     mockAdapter.onGet('http://localhost:8000/api/v1/orgpost/?limit=7').reply(200,

--- a/src/actions/filters/helpers.js
+++ b/src/actions/filters/helpers.js
@@ -23,8 +23,6 @@ export function getPillDescription(filterItemObject) {
 export function getPostOrMissionDescription(data) {
   if (data.type === 'post') {
     return `${data.location} (Post)`;
-  } else if (data.type === 'mission') {
-    return `${data.short_name} (Mission)`;
   }
   return false;
 }

--- a/src/actions/filters/helpers.test.js
+++ b/src/actions/filters/helpers.test.js
@@ -37,7 +37,6 @@ describe('filter helpers', () => {
   it('can return correct values for the getPostOrMissionDescription function', () => {
     // all valid properties should return a templated value
     expect(getPostOrMissionDescription({ type: 'post', location: 'Paris', short_name: 'PAR' })).toBe('Paris (Post)');
-    expect(getPostOrMissionDescription({ type: 'mission', location: 'Paris', short_name: 'PAR' })).toBe('PAR (Mission)');
     // but unmapped descriptions will return false
     expect(getPostOrMissionDescription({ type: 'invalid', location: 'Paris', short_name: 'PAR' })).toBe(false);
   });

--- a/src/reducers/filters/filters.js
+++ b/src/reducers/filters/filters.js
@@ -144,20 +144,6 @@ const items =
       },
       {
         item: {
-          title: 'Mission',
-          sort: 1000,
-          bool: false,
-          description: 'mission',
-          endpoint: 'country/?limit=7',
-          selectionRef: ENDPOINT_PARAMS.mission,
-          choices: [
-          ],
-        },
-        data: [
-        ],
-      },
-      {
-        item: {
           title: 'Post',
           sort: 1100,
           bool: false,


### PR DESCRIPTION
Removes the Mission filter from the Results page.

There are still functions that support mission-related data that we should eventually remove. I addressed some to keep code coverage up. I can make an issue to address the rest.