### PR TITLE
Set object success before isLoading

### DIFF
--- a/src/actions/savedSearch.js
+++ b/src/actions/savedSearch.js
@@ -120,8 +120,8 @@ export function savedSearchesFetchData(sortType) {
     api.get(url)
       .then(response => response.data)
       .then((results) => {
-        dispatch(savedSearchesIsLoading(false));
         dispatch(savedSearchesSuccess(results));
+        dispatch(savedSearchesIsLoading(false));
         dispatch(savedSearchesHasErrored(false));
       })
       .catch(() => {


### PR DESCRIPTION
Sets the object dispatcher before the isLoading dispatcher so that rendering doesn't attempt until the object actually exists.