### PR TITLE
Consolidate loading to single component

### DIFF
--- a/src/Containers/HomePage/HomePage.jsx
+++ b/src/Containers/HomePage/HomePage.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { USER_PROFILE, BID_RESULTS } from '../../Constants/PropTypes';
 import { ENDPOINT_PARAMS } from '../../Constants/EndpointParams';
 import HomePagePositionsContainer from '../HomePagePositionsContainer/HomePagePositionsContainer';
-import Spinner from '../../Components/Spinner';
 
 class HomePage extends Component {
   constructor(props) {
@@ -22,25 +21,19 @@ class HomePage extends Component {
   render() {
     const { userProfile, userProfileIsLoading, toggleFavorite, toggleBid, bidList,
       userProfileFavoritePositionIsLoading, onNavigateTo,
-      userProfileFavoritePositionHasErrored, homePagePositionsIsLoading } = this.props;
+      userProfileFavoritePositionHasErrored } = this.props;
     return (
       <div className="home content-container">
-        {
-          (userProfileIsLoading || homePagePositionsIsLoading) &&
-            <Spinner type="homepage-position-results" size="big" />
-        }
-        {
-          !userProfileIsLoading &&
-            <HomePagePositionsContainer
-              favorites={userProfile.favorite_positions}
-              toggleFavorite={toggleFavorite}
-              userProfileFavoritePositionIsLoading={userProfileFavoritePositionIsLoading}
-              userProfileFavoritePositionHasErrored={userProfileFavoritePositionHasErrored}
-              toggleBid={toggleBid}
-              bidList={bidList}
-              onNavigateTo={onNavigateTo}
-            />
-        }
+        <HomePagePositionsContainer
+          favorites={userProfile.favorite_positions}
+          toggleFavorite={toggleFavorite}
+          userProfileFavoritePositionIsLoading={userProfileFavoritePositionIsLoading}
+          userProfileFavoritePositionHasErrored={userProfileFavoritePositionHasErrored}
+          toggleBid={toggleBid}
+          bidList={bidList}
+          onNavigateTo={onNavigateTo}
+          userProfileIsLoading={userProfileIsLoading}
+        />
       </div>
     );
   }
@@ -55,14 +48,12 @@ HomePage.propTypes = {
   userProfileFavoritePositionHasErrored: PropTypes.bool.isRequired,
   toggleBid: PropTypes.func.isRequired,
   bidList: BID_RESULTS.isRequired,
-  homePagePositionsIsLoading: PropTypes.bool,
 };
 
 HomePage.defaultProps = {
   userProfile: {},
   userProfileIsLoading: false,
   filtersIsLoading: false,
-  homePagePositionsIsLoading: false,
 };
 
 export default HomePage;

--- a/src/Containers/HomePagePositionsContainer/HomePagePositionsContainer.jsx
+++ b/src/Containers/HomePagePositionsContainer/HomePagePositionsContainer.jsx
@@ -5,6 +5,7 @@ import { homePagePositionsFetchData } from '../../actions/homePagePositions';
 import HomePagePositions from '../../Components/HomePagePositions/HomePagePositions';
 import { EMPTY_FUNCTION, HOME_PAGE_POSITIONS, USER_PROFILE, BID_RESULTS } from '../../Constants/PropTypes';
 import { DEFAULT_HOME_PAGE_POSITIONS } from '../../Constants/DefaultProps';
+import Spinner from '../../Components/Spinner';
 
 class HomePagePositionsContainer extends Component {
 
@@ -14,24 +15,33 @@ class HomePagePositionsContainer extends Component {
   }
 
   render() {
-    const { homePagePositions,
+    const { homePagePositions, userProfileIsLoading,
       homePagePositionsHasErrored, homePagePositionsIsLoading,
       userProfile, userProfileFavoritePositionIsLoading,
       userProfileFavoritePositionHasErrored, onNavigateTo,
       toggleFavorite, toggleBid, bidList } = this.props;
     return (
-      <HomePagePositions
-        homePagePositions={homePagePositions}
-        homePagePositionsHasErrored={homePagePositionsHasErrored}
-        homePagePositionsIsLoading={homePagePositionsIsLoading}
-        userProfile={userProfile}
-        userProfileFavoritePositionIsLoading={userProfileFavoritePositionIsLoading}
-        userProfileFavoritePositionHasErrored={userProfileFavoritePositionHasErrored}
-        onNavigateTo={onNavigateTo}
-        toggleFavorite={toggleFavorite}
-        toggleBid={toggleBid}
-        bidList={bidList}
-      />
+      <div className="content-container">
+        {
+          (userProfileIsLoading || homePagePositionsIsLoading) &&
+            <Spinner type="homepage-position-results" size="big" />
+        }
+        {
+          !userProfileIsLoading && !homePagePositionsIsLoading &&
+          <HomePagePositions
+            homePagePositions={homePagePositions}
+            homePagePositionsHasErrored={homePagePositionsHasErrored}
+            homePagePositionsIsLoading={homePagePositionsIsLoading}
+            userProfile={userProfile}
+            userProfileFavoritePositionIsLoading={userProfileFavoritePositionIsLoading}
+            userProfileFavoritePositionHasErrored={userProfileFavoritePositionHasErrored}
+            onNavigateTo={onNavigateTo}
+            toggleFavorite={toggleFavorite}
+            toggleBid={toggleBid}
+            bidList={bidList}
+          />
+        }
+      </div>
     );
   }
 }
@@ -48,6 +58,7 @@ HomePagePositionsContainer.propTypes = {
   toggleFavorite: PropTypes.func.isRequired,
   toggleBid: PropTypes.func.isRequired,
   bidList: BID_RESULTS.isRequired,
+  userProfileIsLoading: PropTypes.bool,
 };
 
 HomePagePositionsContainer.defaultProps = {
@@ -58,6 +69,7 @@ HomePagePositionsContainer.defaultProps = {
   userProfileFavoritePositionIsLoading: false,
   userProfileFavoritePositionHasErrored: false,
   userProfile: {},
+  userProfileIsLoading: false,
 };
 
 const mapStateToProps = state => ({
@@ -65,6 +77,7 @@ const mapStateToProps = state => ({
   homePagePositions: state.homePagePositions,
   homePagePositionsHasErrored: state.homePagePositionsHasErrored,
   homePagePositionsIsLoading: state.homePagePositionsIsLoading,
+  userProfileIsLoading: state.userProfileIsLoading,
 });
 
 export const mapDispatchToProps = dispatch => ({


### PR DESCRIPTION
Small fix so that spinner doesn't appear to stutter on home page. Also avoids the "empty list" alert from appearing when data is loading.