### PR TITLE
Fix textLineTwo prop not displaying

### DIFF
--- a/src/Components/EmptyListAlert/EmptyListAlert.jsx
+++ b/src/Components/EmptyListAlert/EmptyListAlert.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 const EmptyListAlert = ({ textLineOne, textLineTwo }) => (
   <div className="usa-grid-full empty-list-alert">
     <p>{textLineOne}</p>
-    { textLineTwo.length && <p>{textLineTwo}</p> }
+    <p>{textLineTwo}</p>
   </div>
 );
 

--- a/src/Components/EmptyListAlert/__snapshots__/EmptyListAlert.test.jsx.snap
+++ b/src/Components/EmptyListAlert/__snapshots__/EmptyListAlert.test.jsx.snap
@@ -7,5 +7,10 @@ exports[`EmptyListAlertComponent matches snapshot 1`] = `
   <p>
     Here is some text
   </p>
+  <p>
+    <span>
+      And here is an element!
+    </span>
+  </p>
 </div>
 `;


### PR DESCRIPTION
Fix the second line of the empty list alert not displaying.