### PR TITLE
Results Filter Refactor

### DIFF
--- a/src/Components/CheckBox/CheckBox.jsx
+++ b/src/Components/CheckBox/CheckBox.jsx
@@ -10,6 +10,12 @@ class CheckBox extends Component {
     };
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.value !== this.props.value) {
+      this.setState({ checked: { value: nextProps.value } });
+    }
+  }
+
   onCheck() {
     const { checked } = this.state;
     checked.value = !checked.value;

--- a/src/Components/Favorite/Favorite.jsx
+++ b/src/Components/Favorite/Favorite.jsx
@@ -42,6 +42,7 @@ const getText$ = (state, type) => Texts[state][type];
 class Favorite extends Component {
   constructor(props) {
     super(props);
+    this.toggleSaved = this.toggleSaved.bind(this);
     this.state = {
       loading: props.isLoading,
     };
@@ -92,7 +93,7 @@ class Favorite extends Component {
     return getText$(state, Types.LONG);
   }
 
-  toggleSaved = () => {
+  toggleSaved() {
     const { onToggle, refKey } = this.props;
 
     this.setState({

--- a/src/Components/ResultsFilterContainer/ResultsFilterContainer.jsx
+++ b/src/Components/ResultsFilterContainer/ResultsFilterContainer.jsx
@@ -13,6 +13,13 @@ class ResultsFilterContainer extends Component {
     this.onQueryParamToggle = this.onQueryParamToggle.bind(this);
   }
 
+  shouldComponentUpdate(nextProps) {
+    if (this.props !== nextProps) {
+      return true;
+    }
+    return false;
+  }
+
   onQueryParamUpdate(e) {
     this.props.onQueryParamUpdate(e);
     this.props.onChildToggle();

--- a/src/Components/SearchFilters/MultiSelectFilter/MultiSelectFilter.jsx
+++ b/src/Components/SearchFilters/MultiSelectFilter/MultiSelectFilter.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import shortid from 'shortid';
 import groupBy from 'lodash/groupBy';
 import FieldSet from '../../FieldSet/FieldSet';
 import CheckBox from '../../CheckBox/CheckBox';
@@ -52,7 +51,7 @@ class MultiSelectFilter extends Component {
               return (<CheckBox
                 _id={itemData.id} /* when we need the original id */
                 id={`checkbox${itemLabel}-${item.item.description}`}
-                key={shortid.generate()}
+                key={`checkbox${itemLabel}-${item.item.description}`}
                 label={itemLabel}
                 title={itemLabel}
                 name={itemLabel}
@@ -76,7 +75,7 @@ class MultiSelectFilter extends Component {
                         <CheckBox
                           _id={itemData.id} /* when we need the original id */
                           id={`checkbox${itemLabel}-${item.item.description}`}
-                          key={shortid.generate()}
+                          key={`checkbox${itemLabel}-${item.item.description}`}
                           label={itemLabel}
                           title={itemLabel}
                           name={itemLabel}

--- a/src/Containers/Results/Results.test.jsx
+++ b/src/Containers/Results/Results.test.jsx
@@ -14,6 +14,7 @@ const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
 
 describe('Results', () => {
+  const debounceTimeInMs = 500;
   it('is defined', () => {
     const results = TestUtils.renderIntoDocument(<Provider store={mockStore({})}><MemoryRouter>
       <Results
@@ -118,36 +119,6 @@ describe('Results', () => {
     sinon.assert.calledOnce(spy);
   });
 
-  it('can call the resetFilters function', () => {
-    const wrapper = shallow(
-      <Results.WrappedComponent
-        results={resultsObject}
-        isAuthorized={() => true}
-        fetchData={() => {}}
-        onNavigateTo={() => {}}
-        fetchFilters={() => {}}
-        setAccordion={() => {}}
-        toggleFavorite={() => {}}
-        saveSearch={() => {}}
-        fetchMissionAutocomplete={() => {}}
-        missionSearchResults={[]}
-        missionSearchIsLoading={false}
-        missionSearchHasErrored={false}
-        fetchPostAutocomplete={() => {}}
-        postSearchResults={[]}
-        postSearchIsLoading={false}
-        postSearchHasErrored={false}
-      />,
-    );
-    // define the instance
-    const instance = wrapper.instance();
-    // spy the onQueryParamUpdate function
-    const handleUpdateSpy = sinon.spy(instance, 'resetFilters');
-    wrapper.instance().context.router = { history: { push: () => {} } };
-    wrapper.instance().resetFilters();
-    sinon.assert.calledOnce(handleUpdateSpy);
-  });
-
   it('can call the saveSearch function', () => {
     const savedSearch = { q: null, id: null };
     const wrapper = shallow(
@@ -175,7 +146,7 @@ describe('Results', () => {
     expect(savedSearch.id).toBe(1);
   });
 
-  it('can call the onQueryParamToggle function when removing a param', () => {
+  it('can call the onQueryParamToggle function when removing a param', (done) => {
     const wrapper = shallow(
       <Results.WrappedComponent
         results={resultsObject}
@@ -194,23 +165,27 @@ describe('Results', () => {
         postSearchResults={[]}
         postSearchIsLoading={false}
         postSearchHasErrored={false}
+        pageTitle="Results"
+        debounceTimeInMs={debounceTimeInMs}
       />,
     );
-    const history = { value: { search: null } };
     // define the instance
     const instance = wrapper.instance();
-    // spy the onQueryParamUpdate function
-    const handleUpdateSpy = sinon.spy(instance, 'onQueryParamToggle');
-    wrapper.instance().context.router = { history: { push: (h) => { history.value = h; } } };
-    wrapper.instance().state.query.value = 'language=1%2C2&ordering=bureau&q=German&skill=1';
+    instance.state.query.value = 'language=1&skill=2';
     // remove the skill
-    wrapper.instance().onQueryParamToggle('skill', '1', true);
-    sinon.assert.calledOnce(handleUpdateSpy);
-    // make sure the skill was removed
-    expect(history.value.search).toBe('language=1%2C2&ordering=bureau&q=German');
+    instance.onQueryParamToggle('language', '1', true);
+
+    const f = () => {
+      setTimeout(() => {
+        // make sure the skill was removed
+        expect(instance.state.query.value).toBe('skill=2');
+        done();
+      }, debounceTimeInMs + 100);
+    };
+    f();
   });
 
-  it('can call the onQueryParamToggle function when adding a param value and that param already exists', () => {
+  it('can call the onQueryParamToggle function when adding a param value and that param already exists', (done) => {
     const wrapper = shallow(
       <Results.WrappedComponent
         results={resultsObject}
@@ -229,23 +204,27 @@ describe('Results', () => {
         postSearchResults={[]}
         postSearchIsLoading={false}
         postSearchHasErrored={false}
+        pageTitle="Results"
+        debounceTimeInMs={debounceTimeInMs}
       />,
     );
-    const history = { value: { search: null } };
     // define the instance
     const instance = wrapper.instance();
-    // spy the onQueryParamUpdate function
-    const handleUpdateSpy = sinon.spy(instance, 'onQueryParamToggle');
-    wrapper.instance().context.router = { history: { push: (h) => { history.value = h; } } };
-    wrapper.instance().state.query.value = 'language=1%2C2&ordering=bureau&q=German&skill=1&page=2';
-    // add the skill
-    wrapper.instance().onQueryParamToggle('skill', '2', false);
-    sinon.assert.calledOnce(handleUpdateSpy);
-    // make sure the skill was added
-    expect(history.value.search).toBe('language=1%2C2&ordering=bureau&q=German&skill=1%2C2');
+    instance.state.query.value = 'language=1&skill=2';
+    // remove the skill
+    instance.onQueryParamToggle('language', '2', false);
+
+    const f = () => {
+      setTimeout(() => {
+        // make sure the skill was removed
+        expect(instance.state.query.value).toBe('language=1%2C2&skill=2');
+        done();
+      }, debounceTimeInMs + 100);
+    };
+    f();
   });
 
-  it('can call the onQueryParamToggle function when adding a param value and that param does not exist', () => {
+  it('can call the onQueryParamToggle function when adding a param value and that param does not exist', (done) => {
     const wrapper = shallow(
       <Results.WrappedComponent
         results={resultsObject}
@@ -264,20 +243,24 @@ describe('Results', () => {
         postSearchResults={[]}
         postSearchIsLoading={false}
         postSearchHasErrored={false}
+        pageTitle="Results"
+        debounceTimeInMs={debounceTimeInMs}
       />,
     );
-    const history = { value: { search: null } };
     // define the instance
     const instance = wrapper.instance();
-    // spy the onQueryParamUpdate function
-    const handleUpdateSpy = sinon.spy(instance, 'onQueryParamToggle');
-    wrapper.instance().context.router = { history: { push: (h) => { history.value = h; } } };
-    wrapper.instance().state.query.value = 'language=1%2C2&ordering=bureau&q=German&page=2';
-    // add the skill
-    wrapper.instance().onQueryParamToggle('skill', '2', false);
-    sinon.assert.calledOnce(handleUpdateSpy);
-    // make sure the skill was added
-    expect(history.value.search).toBe('language=1%2C2&ordering=bureau&q=German&skill=2');
+    instance.state.query.value = 'language=1&skill=2';
+    // remove the skill
+    instance.onQueryParamToggle('newFilter', '2', false);
+
+    const f = () => {
+      setTimeout(() => {
+        // make sure the skill was removed
+        expect(instance.state.query.value).toBe('language=1&newFilter=2&skill=2');
+        done();
+      }, debounceTimeInMs + 100);
+    };
+    f();
   });
 
   it('can call the onQueryParamToggle function and handle removing non-existent params', () => {

--- a/src/actions/results.js
+++ b/src/actions/results.js
@@ -1,5 +1,6 @@
 import { CancelToken } from 'axios';
 import api from '../api';
+import { propOrDefault } from '../utilities';
 
 let cancel;
 
@@ -61,7 +62,7 @@ export function resultsFetchSimilarPositions(id) {
 
 export function resultsFetchData(query) {
   return (dispatch) => {
-    if (cancel) { cancel(); }
+    if (cancel) { cancel(); dispatch(resultsIsLoading(true)); }
     dispatch(resultsIsLoading(true));
     api
       .get(`/position/?${query}`, {
@@ -73,9 +74,14 @@ export function resultsFetchData(query) {
         dispatch(resultsIsLoading(false));
         dispatch(resultsHasErrored(false));
       })
-      .catch(() => {
-        dispatch(resultsIsLoading(false));
-        dispatch(resultsHasErrored(true));
+      .catch((err) => {
+        if (propOrDefault(err, 'constructor.name') === 'Cancel') {
+          dispatch(resultsIsLoading(true));
+          dispatch(resultsHasErrored(false));
+        } else {
+          dispatch(resultsIsLoading(false));
+          dispatch(resultsHasErrored(true));
+        }
       });
   };
 }

--- a/src/api.js
+++ b/src/api.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { fetchUserToken, hasValidToken } from './utilities';
+import { fetchUserToken, hasValidToken, propOrDefault } from './utilities';
 import { logoutRequest } from './login/actions';
 
 export const config = {

--- a/src/api.js
+++ b/src/api.js
@@ -18,7 +18,7 @@ api.interceptors.request.use((request) => {
 });
 
 api.interceptors.response.use(response => response, (error) => {
-  switch (error.response.status) {
+  switch (propOrDefault(error, 'response.status')) {
     case 401:
       // Due to timing of import store before history is created, importing store here causes
       // exports of api to be undefined. So this causes an error for `userProfile.js` when

--- a/src/sass/_results.scss
+++ b/src/sass/_results.scss
@@ -270,6 +270,16 @@
   padding: 0 10px 15px;
   width: 20%;
 
+  [type=checkbox],
+  [type=radio] {
+    box-sizing: border-box;
+    margin: 0;
+    margin-left: 0;
+    opacity: 0;
+    padding: 0;
+    position: fixed;
+  }
+
   label {
     margin-top: 1rem;
   }
@@ -416,6 +426,8 @@
     background-color: $color-gray-lightest-alt;
     color: $color-black;
     font-size: 1.1em;
+    max-height: 300px;
+    overflow-y: auto;
     padding: 1rem;
   }
 


### PR DESCRIPTION
Makes our Results filter interaction much smoother, and avoids needless re-rendering. This is made possible by the use of `window.history.pushState` to update the browser history with new params, as this is the only way to avoid the container remounting while preserving search history in the URL.