### PR TITLE
Add aria-live and aria-atomic to Alert components

### DIFF
--- a/src/Components/Alert/Alert.jsx
+++ b/src/Components/Alert/Alert.jsx
@@ -3,20 +3,29 @@ import PropTypes from 'prop-types';
 
 const shortid = require('shortid');
 
-const Alert = ({ type, title, messages }) => (
+const Alert = ({ type, title, messages, isAriaLive }) => {
   // 'type' is injected into the class name
   // type 'error' requires an ARIA role
-  <div className={`usa-alert usa-alert-${type}`} role={(type === 'error') ? 'alert' : null}>
-    <div className="usa-alert-body">
-      <h3 className="usa-alert-heading">{title}</h3>
-      {messages.map(message =>
-        (<p className="usa-alert-text" key={shortid.generate()}>
-          {message.body}
-        </p>),
-      )}
+  let ariaLiveProps = {};
+  if (isAriaLive) {
+    ariaLiveProps = {
+      'aria-live': 'polite',
+      'aria-atomic': 'true',
+    };
+  }
+  return (
+    <div className={`usa-alert usa-alert-${type}`} role={(type === 'error') ? 'alert' : null} {...ariaLiveProps}>
+      <div className="usa-alert-body">
+        <h3 className="usa-alert-heading">{title}</h3>
+        {messages.map(message =>
+          (<p className="usa-alert-text" key={shortid.generate()}>
+            {message.body}
+          </p>),
+        )}
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 Alert.propTypes = {
   type: PropTypes.oneOf(['info', 'warning', 'error', 'success']),
@@ -25,11 +34,13 @@ Alert.propTypes = {
     PropTypes.shape({
       body: PropTypes.string,
     })),
+  isAriaLive: PropTypes.bool,
 };
 
 Alert.defaultProps = {
   type: 'info', // should be one of the USWDS alert types - https://standards.usa.gov/components/alerts/
   messages: [{ body: '' }],
+  isAriaLive: false,
 };
 
 export default Alert;

--- a/src/Components/Alert/Alert.test.jsx
+++ b/src/Components/Alert/Alert.test.jsx
@@ -61,4 +61,10 @@ describe('Alert', () => {
     expect(alert.find('.usa-alert-heading').text()).toBe(title);
     expect(alert.find('.usa-alert-text').length).toBe(errorBody.length);
   });
+
+  it('matches snapshot when isAriaLive is true', () => {
+    const title = 'Success title';
+    alert = shallow(<Alert type="success" title={title} messages={alertBody} isAriaLive />);
+    expect(toJSON(alert)).toMatchSnapshot();
+  });
 });

--- a/src/Components/Alert/AlertAlt/AlertAlt.jsx
+++ b/src/Components/Alert/AlertAlt/AlertAlt.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import FontAwesome from 'react-fontawesome';
 
-const AlertAlt = ({ type, title, message }) => {
+const AlertAlt = ({ type, title, message, isAriaLive }) => {
   let icon;
   switch (type) {
     case 'warning':
@@ -19,10 +19,17 @@ const AlertAlt = ({ type, title, message }) => {
       icon = 'info-circle';
       break;
   }
+  let ariaLiveProps = {};
+  if (isAriaLive) {
+    ariaLiveProps = {
+      'aria-live': 'polite',
+      'aria-atomic': 'true',
+    };
+  }
   return (
     // 'type' is injected into the class name
     // type 'error' requires an ARIA role
-    <div className={`tm-alert tm-alert-${type}`} role={(type === 'error') ? 'alert' : null}>
+    <div className={`tm-alert tm-alert-${type}`} role={(type === 'error') ? 'alert' : null} {...ariaLiveProps}>
       <div className="usa-grid-full tm-alert-body">
         <div className="usa-grid-full tm-alert-icon">
           <FontAwesome size="lg" name={icon} />
@@ -40,11 +47,13 @@ AlertAlt.propTypes = {
   type: PropTypes.oneOf(['info', 'warning', 'error', 'success']),
   title: PropTypes.string.isRequired,
   message: PropTypes.string,
+  isAriaLive: PropTypes.bool,
 };
 
 AlertAlt.defaultProps = {
   type: 'info',
   message: '',
+  isAriaLive: false,
 };
 
 export default AlertAlt;

--- a/src/Components/Alert/AlertAlt/AlertAlt.test.jsx
+++ b/src/Components/Alert/AlertAlt/AlertAlt.test.jsx
@@ -58,4 +58,11 @@ describe('AlertAltComponent', () => {
     );
     expect(toJSON(wrapper)).toMatchSnapshot();
   });
+
+  it('matches snapshot when isAriaLive is true', () => {
+    const wrapper = shallow(
+      <AlertAlt title="title" isAriaLive />,
+    );
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
 });

--- a/src/Components/Alert/AlertAlt/__snapshots__/AlertAlt.test.jsx.snap
+++ b/src/Components/Alert/AlertAlt/__snapshots__/AlertAlt.test.jsx.snap
@@ -1,5 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`AlertAltComponent matches snapshot when isAriaLive is true 1`] = `
+<div
+  aria-atomic="true"
+  aria-live="polite"
+  className="tm-alert tm-alert-info"
+  role={null}
+>
+  <div
+    className="usa-grid-full tm-alert-body"
+  >
+    <div
+      className="usa-grid-full tm-alert-icon"
+    >
+      <FontAwesome
+        name="info-circle"
+        size="lg"
+      />
+    </div>
+    <div
+      className="usa-grid-full tm-alert-text"
+    >
+      <div
+        className="tm-alert-heading"
+      >
+        title
+      </div>
+      <div
+        className="tm-alert-message"
+      />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`AlertAltComponent matches snapshot when type equals error 1`] = `
 <div
   className="tm-alert tm-alert-error"

--- a/src/Components/Alert/__snapshots__/Alert.test.jsx.snap
+++ b/src/Components/Alert/__snapshots__/Alert.test.jsx.snap
@@ -92,3 +92,27 @@ exports[`Alert displays warning alert 1`] = `
   </div>
 </div>
 `;
+
+exports[`Alert matches snapshot when isAriaLive is true 1`] = `
+<div
+  aria-atomic="true"
+  aria-live="polite"
+  className="usa-alert usa-alert-success"
+  role={null}
+>
+  <div
+    className="usa-alert-body"
+  >
+    <h3
+      className="usa-alert-heading"
+    >
+      Success title
+    </h3>
+    <p
+      className="usa-alert-text"
+    >
+      Alert body
+    </p>
+  </div>
+</div>
+`;

--- a/src/Components/BidTracker/NotificationsSection/__snapshots__/NotificationsSection.test.jsx.snap
+++ b/src/Components/BidTracker/NotificationsSection/__snapshots__/NotificationsSection.test.jsx.snap
@@ -12,6 +12,7 @@ exports[`NotificationsSectionComponent matches snapshot 1`] = `
       onDismiss={[Function]}
     >
       <AlertAlt
+        isAriaLive={false}
         message="Your bid for [10035561] POLITICAL/ECONOMIC OFFICER (Curacao) has been approved by panel."
         title="Notification"
         type="success"

--- a/src/Components/BidderPortfolio/BidderPortfolioContainer/__snapshots__/BidderPortfolioContainer.test.jsx.snap
+++ b/src/Components/BidderPortfolio/BidderPortfolioContainer/__snapshots__/BidderPortfolioContainer.test.jsx.snap
@@ -231,6 +231,7 @@ exports[`BidderPortfolioContainerComponent matches snapshot when the all propert
     className="usa-width-two-thirds"
   >
     <Alert
+      isAriaLive={false}
       messages={
         Array [
           Object {

--- a/src/Components/GlossaryEditor/GlossaryEditorCardList/__snapshots__/GlossaryEditorCardList.test.jsx.snap
+++ b/src/Components/GlossaryEditor/GlossaryEditorCardList/__snapshots__/GlossaryEditorCardList.test.jsx.snap
@@ -109,6 +109,7 @@ exports[`GlossaryEditorCardListComponent matches snapshot when there are no term
     terms={Object {}}
   />
   <Alert
+    isAriaLive={false}
     messages={
       Array [
         Object {

--- a/src/Components/GlossaryEditor/GlossaryEditorPageHeader/GlossaryEditorPageHeader.jsx
+++ b/src/Components/GlossaryEditor/GlossaryEditorPageHeader/GlossaryEditorPageHeader.jsx
@@ -36,7 +36,7 @@ class GlossaryEditorPage extends Component {
           </div>
         </div>
         {
-          showPostSuccess && <Alert type="success" title="Success" messages={[{ body: 'Successfully added term!' }]} />
+          showPostSuccess && <Alert type="success" title="Success" messages={[{ body: 'Successfully added term!' }]} isAriaLive />
         }
         {
           showNewTerm &&

--- a/src/Components/GlossaryEditor/GlossaryEditorPageHeader/__snapshots__/GlossaryEditorPageHeader.test.jsx.snap
+++ b/src/Components/GlossaryEditor/GlossaryEditorPageHeader/__snapshots__/GlossaryEditorPageHeader.test.jsx.snap
@@ -56,6 +56,7 @@ exports[`GlossaryEditorPageHeaderComponent matches snapshot when glossaryPostSuc
     </div>
   </div>
   <Alert
+    isAriaLive={true}
     messages={
       Array [
         Object {

--- a/src/Components/SaveNewSearchAlert/SaveNewSearchAlert.jsx
+++ b/src/Components/SaveNewSearchAlert/SaveNewSearchAlert.jsx
@@ -4,7 +4,7 @@ import Alert from '../Alert/Alert';
 
 const SaveNewSearchAlert = ({ newSavedSearchSuccess }) => (
   <div className="usa-grid-full saved-search-alert">
-    <Alert type="success" title="Success" messages={[{ body: newSavedSearchSuccess }]} />
+    <Alert type="success" title="Success" messages={[{ body: newSavedSearchSuccess }]} isAriaLive />
   </div>
 );
 

--- a/src/Components/SaveNewSearchAlert/__snapshots__/SaveNewSearchAlert.test.jsx.snap
+++ b/src/Components/SaveNewSearchAlert/__snapshots__/SaveNewSearchAlert.test.jsx.snap
@@ -2,11 +2,10 @@
 
 exports[`SaveNewSearchAlertComponent matches snapshot 1`] = `
 <div
-  aria-atomic="true"
-  aria-live="polite"
   className="usa-grid-full saved-search-alert"
 >
   <Alert
+    isAriaLive={true}
     messages={
       Array [
         Object {

--- a/src/Components/SaveNewSearchAlert/__snapshots__/SaveNewSearchAlert.test.jsx.snap
+++ b/src/Components/SaveNewSearchAlert/__snapshots__/SaveNewSearchAlert.test.jsx.snap
@@ -2,6 +2,8 @@
 
 exports[`SaveNewSearchAlertComponent matches snapshot 1`] = `
 <div
+  aria-atomic="true"
+  aria-live="polite"
   className="usa-grid-full saved-search-alert"
 >
   <Alert

--- a/src/Components/SavedSearches/SavedSearches.jsx
+++ b/src/Components/SavedSearches/SavedSearches.jsx
@@ -64,6 +64,7 @@ const SavedSearches = (props) => {
             type="error"
             title="Error"
             messages={[{ body: deleteSavedSearchHasErrored }]}
+            isAriaLive
           />
       }
       {
@@ -73,6 +74,7 @@ const SavedSearches = (props) => {
             type="success"
             title="Success"
             messages={[{ body: deleteSavedSearchSuccess }]}
+            isAriaLive
           />
       }
       {
@@ -82,6 +84,7 @@ const SavedSearches = (props) => {
             type="error"
             title="Error"
             messages={[{ body: cloneSavedSearchHasErrored }]}
+            isAriaLive
           />
       }
       {
@@ -91,6 +94,7 @@ const SavedSearches = (props) => {
             type="success"
             title="Success"
             messages={[{ body: cloneSavedSearchSuccess }]}
+            isAriaLive
           />
       }
       {


### PR DESCRIPTION
Addresses accessibility feedback by adding an optional `isAriaLive` prop to the `Alert`/`AlertAlt` components and using it for Saved Search alerts.