### PR TITLE
Page Title

### DIFF
--- a/src/Containers/PageMeta/PageMetaContainer.jsx
+++ b/src/Containers/PageMeta/PageMetaContainer.jsx
@@ -1,10 +1,11 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { matchPath, withRouter } from 'react-router';
+import { withRouter } from 'react-router';
 import Helmet from 'react-helmet';
 import PageTitle from '../../Components/PageTitle';
 import routes from '../../routes';
 import { getApplicationPath, getAssetPath, focusById } from '../../utilities';
+import getBestMatchPath from './helpers';
 
 class PageMetaContainer extends Component {
   constructor(props) {
@@ -17,16 +18,12 @@ class PageMetaContainer extends Component {
     this.getPageTitle();
   }
 
+  // Determine the route's page title and set it to state
   setPageTitle(historyObject) {
-    // loop through routes
-    routes.forEach((route) => {
-      if (matchPath(historyObject.pathname, { path: route.path, exact: false })) {
-        // set pageTitle if it exists
-        if (route.pageTitle) {
-          this.setState({ pageTitle: route.pageTitle });
-        }
-      }
-    });
+    const matchedPath = getBestMatchPath(routes, historyObject);
+    if (matchedPath && matchedPath.pageTitle) {
+      this.setState({ pageTitle: matchedPath.pageTitle });
+    }
   }
 
   getPageTitle() {

--- a/src/Containers/PageMeta/helpers.js
+++ b/src/Containers/PageMeta/helpers.js
@@ -1,0 +1,24 @@
+import { matchPath } from 'react-router';
+
+// Ensure the best route is matched, since multiple could match.
+// We can do this by taking the matched path with the longest path length.
+// For example, '/profile/dashboard/' might match '/', '/profile', and '/profile/dashboard',
+// therefore, we can be sure that the one with the longest length is the best match.
+// Takes an array of routes and a history object.
+const getBestMatchPath = (routes, historyObject) => {
+  // set initial object with properties we will check against
+  let result = { path: '', pageTitle: '' };
+
+  routes.forEach((route) => {
+    const matched = matchPath(historyObject.pathname, { path: route.path, exact: false });
+    // if the route matches, has a page title, and it's path is longer than the current value,
+    // then set result to that object.
+    if (matched && route.pageTitle && matched.path.length > result.path.length) {
+      result = Object.assign({}, matched, route);
+    }
+  });
+
+  return result;
+};
+
+export default getBestMatchPath;

--- a/src/Containers/PageMeta/helpers.test.js
+++ b/src/Containers/PageMeta/helpers.test.js
@@ -1,0 +1,20 @@
+import getBestMatchPath from './helpers';
+
+describe('local storage', () => {
+  const routes = [
+    { path: '/a/b/c', pageTitle: 'abc' },
+    { path: '/a', pageTitle: 'a' },
+    { path: '/a/b', pageTitle: 'ab' },
+    { path: '/a/b/c/d', pageTitle: 'abcd' },
+    { path: '/a/b/c/d/e/', pageTitle: 'abcde' },
+  ];
+
+  const historyObject = {
+    pathname: '/a/b/',
+  };
+
+  it('get the best matched path from an array of routes', () => {
+    const result = getBestMatchPath(routes, historyObject);
+    expect(result.pageTitle).toBe('ab');
+  });
+});

--- a/src/routes.js
+++ b/src/routes.js
@@ -3,7 +3,7 @@ const routesArray = [
   { path: '/', exact: true, componentName: 'Home', pageTitle: 'Home' },
   { path: '/profile', componentName: 'Profile', pageTitle: 'Profile' },
   { path: '/results', componentName: 'Results', pageTitle: 'Search Results' },
-  { path: '/details/:id', componentName: 'Position' },
+  { path: '/details/:id', componentName: 'Position', pageTitle: 'Position details' },
   { path: '/compare/:ids', componentName: 'Compare', pageTitle: 'Compare Positions' },
 ];
 


### PR DESCRIPTION
Abstracts the function to retrieve the page title, and ensures that it's the "best fit", since multiple routes can match a path (i.e., the "parent" routes).

Also adds a default "Position details" page title that is used until the position details load and the `title` can be used.