### PR TITLE
Use asset path in Results Page updates

### DIFF
--- a/src/Containers/Results/Results.jsx
+++ b/src/Containers/Results/Results.jsx
@@ -6,7 +6,7 @@ import { withRouter } from 'react-router';
 import queryString from 'query-string';
 import debounce from 'lodash/debounce';
 import queryParamUpdate from '../queryParams';
-import { scrollToTop, cleanQueryParams } from '../../utilities';
+import { scrollToTop, cleanQueryParams, getAssetPath } from '../../utilities';
 import { resultsFetchData } from '../../actions/results';
 import { filtersFetchData } from '../../actions/filters/filters';
 import { saveSearch, routeChangeResetState } from '../../actions/savedSearch';
@@ -162,7 +162,7 @@ class Results extends Component {
   // updates the history by passing a string of query params
   updateHistory(q) {
     this.setState({ query: { value: q } }, () => {
-      window.history.pushState('', '', `/results?${q}`);
+      window.history.pushState('', '', getAssetPath(`/results?${q}`));
       this.debounced.cancel();
       // add debounce so that quickly selecting multiple filters is smooth
       this.debounced = debounce(() => this.createQueryParams(), this.props.debounceTimeInMs);

--- a/src/sass/_accordion.scss
+++ b/src/sass/_accordion.scss
@@ -51,6 +51,11 @@ $accordion-content-small-padding-left: 2em;
 
 .tm-nested-accordion-button {
   padding-bottom: 0;
+
+  .accordion-item-title {
+    padding-right: 1.5em;
+    padding-top: .1em;
+  }
 }
 
 .tm-double-nested-accordion-button {


### PR DESCRIPTION
Adds `getAssetPath` to the `pushState` function in the Results Page so that the URL suffix is not lost on filter changes.

Also adds a CSS tweak to fix accordion text overflowing onto the "+".