### PR TITLE
Sort and update string transformation for regional bureaus

### DIFF
--- a/src/Components/ResultsMultiSearchHeader/ResultsMultiSearchHeader.jsx
+++ b/src/Components/ResultsMultiSearchHeader/ResultsMultiSearchHeader.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import FontAwesome from 'react-fontawesome';
+import { orderBy } from 'lodash';
 import { FILTER_ITEMS_ARRAY, USER_PROFILE, EMPTY_FUNCTION } from '../../Constants/PropTypes';
 import { ENDPOINT_PARAMS } from '../../Constants/EndpointParams';
 import SearchBar from '../SearchBar/SearchBar';
@@ -147,6 +148,8 @@ class ResultsMultiSearchHeader extends Component {
     const bureaus = filters.find(f => f.item && f.item.description === 'region');
     const mappedBureaus = bureaus && bureaus.data ?
       bureaus.data.slice().map(g => ({ ...g, value: g.code, text: g.short_description })) : [];
+    // sort the regional bureaus by their calculated label
+    const sortedBureuas = orderBy(mappedBureaus, ['text']);
 
     // set the default skills
     const defaultSkills = skills || userProfile.skills || [];
@@ -198,7 +201,7 @@ class ResultsMultiSearchHeader extends Component {
                     <SelectForm
                       id="bureau-searchbar-filter"
                       label="Bureau"
-                      options={mappedBureaus}
+                      options={sortedBureuas}
                       defaultSort={defaultBureau}
                       includeFirstEmptyOption
                       onSelectOption={this.onChangeBureau}

--- a/src/Components/SearchFilters/BureauFilter/BureauFilter.jsx
+++ b/src/Components/SearchFilters/BureauFilter/BureauFilter.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { orderBy } from 'lodash';
 import { FILTER_ITEM } from '../../../Constants/PropTypes';
 import Accordion, { AccordionItem } from '../../Accordion';
 import CheckBox from '../../CheckBox';
@@ -24,13 +25,15 @@ class BureauFilter extends Component {
   render() {
     const { item, functionalBureaus } = this.props;
     const regionalBureaus = item.data.slice().filter(b => b.is_regional);
+    // sort the regional bureaus by their calculated label
+    const sortedRegionalBureuas = orderBy(regionalBureaus, e => getItemLabel(e));
     return (
       <div className="usa-grid-full tm-nested-accordions">
         <Accordion>
           <AccordionItem className="accordion-content-small" id="regional-bureau-sub-accordion" title="Regional Bureaus" buttonClass="tm-nested-accordion-button">
             <div className="usa-grid-full">
               {
-                regionalBureaus.map((itemData) => {
+                sortedRegionalBureuas.map((itemData) => {
                   const itemLabel = getItemLabel(itemData);
                   return (<CheckBox
                     _id={itemData.id} /* when we need the original id */

--- a/src/actions/filters/helpers.js
+++ b/src/actions/filters/helpers.js
@@ -20,7 +20,7 @@ export function getCustomGradeDescription(gradeCode) {
 // create a custom description based on the filter type
 export function getFilterCustomDescription(filterItem, filterItemObject) {
   if (filterItem.item.description === 'region') {
-    return `${filterItemObject.long_description} (${filterItemObject.short_description})`;
+    return `(${filterItemObject.short_description}) ${filterItemObject.long_description}`;
   } else if (filterItem.item.description === 'skill') {
     return `${filterItemObject.description} (${filterItemObject.code})`;
   } else if (filterItem.item.description === 'post') {

--- a/src/actions/filters/helpers.test.js
+++ b/src/actions/filters/helpers.test.js
@@ -20,7 +20,7 @@ describe('filter helpers', () => {
     // templated strings are returned based on the description value
     expect(getFilterCustomDescription(
       { item: { description: 'region' } }, { short_description: 't', long_description: 'test' }),
-    ).toBe('test (t)');
+    ).toBe('(t) test');
     expect(getFilterCustomDescription(
       { item: { description: 'skill' } }, { description: 'test', code: 't' }),
     ).toBe('test (t)');


### PR DESCRIPTION
Ensures that regional bureaus in both the search filters and the multi-search header are sorted alphabetically. Also updates the string transformation so that the abbreviation comes before the full name.