### PR TITLE
Apply accessible focus colors

### DIFF
--- a/src/sass/_accessibility.scss
+++ b/src/sass/_accessibility.scss
@@ -1,0 +1,33 @@
+// Set focus color for most elements to color-black
+// Then, call out any specific containers with a darker background color,
+// and set its child elements to use a white focus color.
+
+*,
+input,
+a {
+  &:focus {
+    outline: $tm-focus-outline-default;
+    outline-offset: $tm-focus-outline-offset-default;
+  }
+}
+
+*:focus,
+.usa-focus {
+  outline: $tm-focus-outline-default;
+  outline-offset: $tm-focus-outline-offset-default;
+}
+
+.Select.is-focused,
+.tm-feedback,
+.tm-footer-nav,
+.bid-list-container,
+.tm-glossary,
+.condensed-card-top,
+.position-details-header-container,
+.react-paginate .active,
+.results-search-bar,
+.header-nav-link-container.is-highlighted {
+  *:focus {
+    outline-color: $tm-focus-outline-color-alt;
+  }
+}

--- a/src/sass/_results.scss
+++ b/src/sass/_results.scss
@@ -439,6 +439,10 @@ $results-container-width: 100% - $filter-container-width;
     width: 100%;
   }
 
+  [type=checkbox]:focus + label::before {
+    outline: $tm-focus-outline-default;
+  }
+
   fieldset {
     margin: 0 0 10px;
   }

--- a/src/sass/_select.scss
+++ b/src/sass/_select.scss
@@ -41,8 +41,15 @@
 }
 
 .Select.is-focused {
-  outline: 2px dotted $bg-gray-dark-2;
+  outline: 2px dotted $color-white;
   outline-offset: 3px;
+}
+
+.Select-option {
+  &.is-focused {
+    background-color: $blue-primary;
+    color: $color-white;
+  }
 }
 
 .Select.is-focused:not(.is-open) > .Select-control {

--- a/src/sass/_variables.scss
+++ b/src/sass/_variables.scss
@@ -150,6 +150,13 @@ $results-card-border: $color-gray-lighter;
 $scrollbar-width: 10px;
 
 //**
+//* Accessibility
+//*
+$tm-focus-outline-default: 2px dotted $color-black;
+$tm-focus-outline-color-alt: $color-white;
+$tm-focus-outline-offset-default: 3px;
+
+//**
 //* z-index
 //*
 // we'll use this section to keep track of and order them

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -76,3 +76,4 @@
 @import 'emptyListAlert';
 @import 'inputs';
 @import 'overrides';
+@import 'accessibility';


### PR DESCRIPTION
Sets default focus color to black, and calls out any containers that have a dark background and applies an alternate `outline` color for any contained, focused elements.