### PR TITLE
Use correct ordering query for “recently posted” positions on homepage

### DIFF
--- a/src/actions/homePagePositions.js
+++ b/src/actions/homePagePositions.js
@@ -6,8 +6,8 @@ RECENTLY_POSTED_POSITIONS, FAVORITED_POSITIONS } from '../Constants/PropTypes';
 export const HIGHLIGHTED_POSITIONS_QUERY = 'highlighted/?limit=3';
 export const GET_SKILL_CODE_POSITIONS_QUERY = skillCodes => `?skill__in=${skillCodes}&limit=3`;
 export const FAVORITE_POSITIONS_QUERY = 'favorites/?limit=3';
-export const GET_GRADE_POSITIONS_QUERY = grade => `?grade__code__in=${grade}&limit=3&ordering=description__date_created`;
-export const RECENTLY_POSTED_POSITIONS_QUERY = '?limit=3&ordering=description__date_created';
+export const GET_GRADE_POSITIONS_QUERY = grade => `?grade__code__in=${grade}&limit=3&ordering=-effective_date`;
+export const RECENTLY_POSTED_POSITIONS_QUERY = '?limit=3&ordering=-effective_date';
 
 export function homePagePositionsHasErrored(bool) {
   return {


### PR DESCRIPTION
Positions were not being ordered by the field associated with "recently posted".