### PR TITLE
Ensure the search link container doesn’t change width when hovered

### DIFF
--- a/src/sass/_header.scss
+++ b/src/sass/_header.scss
@@ -17,7 +17,7 @@
 
   .search-text {
     cursor: pointer;
-    min-width: 88px;
+    min-width: 90px;
   }
 
   .navigation-container {


### PR DESCRIPTION
A past font change required this.