### PR TITLE
Homepage section link accessibility

### DIFF
--- a/src/sass/_home.scss
+++ b/src/sass/_home.scss
@@ -118,7 +118,7 @@
 
     a {
       color: inherit;
-      display: flex;
+      display: block;
       text-decoration: none;
     }
   }

--- a/src/sass/_home.scss
+++ b/src/sass/_home.scss
@@ -118,6 +118,7 @@
 
     a {
       color: inherit;
+      display: flex;
       text-decoration: none;
     }
   }


### PR DESCRIPTION
Homepage section titles were not receiving focus styles. Changes `a` tags in section headers to use `display: block` so that they have height and receive a `focus` border.