### PR TITLE
Update width of position title in condensed cards

### DIFF
--- a/src/sass/_condensedCard.scss
+++ b/src/sass/_condensedCard.scss
@@ -86,7 +86,6 @@ $condensed-card-data-padding: 15px 20px 9px;
 
   .condensed-card-top-header-left {
     float: left;
-    width: auto;
 
     h3 {
       display: inline;


### PR DESCRIPTION
Ensures that longer titles break lines earlier so that Grade isn't pushed down.