### PR TITLE
Check prop equality to determine re-render of Alert components

### DIFF
--- a/src/Components/Alert/Alert.jsx
+++ b/src/Components/Alert/Alert.jsx
@@ -1,31 +1,39 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { isEqual } from 'lodash';
 
 const shortid = require('shortid');
 
-const Alert = ({ type, title, messages, isAriaLive }) => {
-  // 'type' is injected into the class name
-  // type 'error' requires an ARIA role
-  let ariaLiveProps = {};
-  if (isAriaLive) {
-    ariaLiveProps = {
-      'aria-live': 'polite',
-      'aria-atomic': 'true',
-    };
+class Alert extends Component {
+  // prevent unneeded rerenders, which can cause accessibility issues
+  shouldComponentUpdate(nextProps) {
+    return !isEqual(this.props, nextProps);
   }
-  return (
-    <div className={`usa-alert usa-alert-${type}`} role={(type === 'error') ? 'alert' : null} {...ariaLiveProps}>
-      <div className="usa-alert-body">
-        <h3 className="usa-alert-heading">{title}</h3>
-        {messages.map(message =>
-          (<p className="usa-alert-text" key={shortid.generate()}>
-            {message.body}
-          </p>),
-        )}
+  render() {
+    const { type, title, messages, isAriaLive } = this.props;
+    // 'type' is injected into the class name
+    // type 'error' requires an ARIA role
+    let ariaLiveProps = {};
+    if (isAriaLive) {
+      ariaLiveProps = {
+        'aria-live': 'polite',
+        'aria-atomic': 'true',
+      };
+    }
+    return (
+      <div className={`usa-alert usa-alert-${type}`} role={(type === 'error') ? 'alert' : null} {...ariaLiveProps}>
+        <div className="usa-alert-body">
+          <h3 className="usa-alert-heading">{title}</h3>
+          {messages.map(message =>
+            (<p className="usa-alert-text" key={shortid.generate()}>
+              {message.body}
+            </p>),
+          )}
+        </div>
       </div>
-    </div>
-  );
-};
+    );
+  }
+}
 
 Alert.propTypes = {
   type: PropTypes.oneOf(['info', 'warning', 'error', 'success']),

--- a/src/Components/Alert/AlertAlt/AlertAlt.jsx
+++ b/src/Components/Alert/AlertAlt/AlertAlt.jsx
@@ -1,47 +1,55 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { isEqual } from 'lodash';
 import FontAwesome from 'react-fontawesome';
 
-const AlertAlt = ({ type, title, message, isAriaLive }) => {
-  let icon;
-  switch (type) {
-    case 'warning':
-      icon = 'exclamation-triangle';
-      break;
-    case 'error':
-      icon = 'exclamation-triangle';
-      break;
-    case 'success':
-      icon = 'check-circle';
-      break;
+class AlertAlt extends Component {
+  // prevent unneeded rerenders, which can cause accessibility issues
+  shouldComponentUpdate(nextProps) {
+    return !isEqual(this.props, nextProps);
+  }
+  render() {
+    const { type, title, message, isAriaLive } = this.props;
+    let icon;
+    switch (type) {
+      case 'warning':
+        icon = 'exclamation-triangle';
+        break;
+      case 'error':
+        icon = 'exclamation-triangle';
+        break;
+      case 'success':
+        icon = 'check-circle';
+        break;
     // default to info
-    default:
-      icon = 'info-circle';
-      break;
-  }
-  let ariaLiveProps = {};
-  if (isAriaLive) {
-    ariaLiveProps = {
-      'aria-live': 'polite',
-      'aria-atomic': 'true',
-    };
-  }
-  return (
+      default:
+        icon = 'info-circle';
+        break;
+    }
+    let ariaLiveProps = {};
+    if (isAriaLive) {
+      ariaLiveProps = {
+        'aria-live': 'polite',
+        'aria-atomic': 'true',
+      };
+    }
+    return (
     // 'type' is injected into the class name
     // type 'error' requires an ARIA role
-    <div className={`tm-alert tm-alert-${type}`} role={(type === 'error') ? 'alert' : null} {...ariaLiveProps}>
-      <div className="usa-grid-full tm-alert-body">
-        <div className="usa-grid-full tm-alert-icon">
-          <FontAwesome size="lg" name={icon} />
-        </div>
-        <div className="usa-grid-full tm-alert-text">
-          <div className="tm-alert-heading">{title}</div>
-          <div className="tm-alert-message">{message}</div>
+      <div className={`tm-alert tm-alert-${type}`} role={(type === 'error') ? 'alert' : null} {...ariaLiveProps}>
+        <div className="usa-grid-full tm-alert-body">
+          <div className="usa-grid-full tm-alert-icon">
+            <FontAwesome size="lg" name={icon} />
+          </div>
+          <div className="usa-grid-full tm-alert-text">
+            <div className="tm-alert-heading">{title}</div>
+            <div className="tm-alert-message">{message}</div>
+          </div>
         </div>
       </div>
-    </div>
-  );
-};
+    );
+  }
+}
 
 AlertAlt.propTypes = {
   type: PropTypes.oneOf(['info', 'warning', 'error', 'success']),


### PR DESCRIPTION
Possibly fixes accessibility issue of alert message being repeatedly read, as I confirmed that this changed prevented the `Alert` component from being re-rendered when there were no changes. I believe this is due to the nested `message` property not passing equality checks by React.