### PR TITLE
Add the Bid Tracker back in, style fixes, "small" avatar prop

### DIFF
--- a/src/Components/Avatar/Avatar.jsx
+++ b/src/Components/Avatar/Avatar.jsx
@@ -7,6 +7,7 @@ const propTypes = {
   firstName: PropTypes.string,
   lastName: PropTypes.string,
   className: PropTypes.string,
+  small: PropTypes.bool,
   onClick: PropTypes.func,
 };
 
@@ -15,13 +16,14 @@ const defaultProps = {
   firstName: '',
   lastName: '',
   className: '',
+  small: false,
   onClick: EMPTY_FUNCTION,
 };
 
-const Avatar = ({ initials, firstName, lastName, className, onClick }) => (
+const Avatar = ({ initials, firstName, lastName, className, small, onClick }) => (
   /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
   /* eslint-disable jsx-a11y/no-static-element-interactions */
-  <div className={`tm-avatar ${className}`} onClick={onClick} role="img" aria-label={`${firstName} ${lastName}`}>
+  <div className={`tm-avatar ${small ? 'tm-avatar--small' : ''} ${className}`} onClick={onClick} role="img" aria-label={`${firstName} ${lastName}`}>
     {initials}
   </div>
   /* eslint-enable jsx-a11y/no-noninteractive-element-interactions */

--- a/src/Components/Avatar/Avatar.test.jsx
+++ b/src/Components/Avatar/Avatar.test.jsx
@@ -29,6 +29,11 @@ describe('Avatar', () => {
     expect(wrapper.find(`.${props.className}`).exists()).toBe(true);
   });
 
+  it('applies the class when the small prop is true', () => {
+    const wrapper = shallow(<Avatar {...props} small />);
+    expect(wrapper.find('.tm-avatar--small').exists()).toBe(true);
+  });
+
   it('matches snapshot', () => {
     const wrapper = shallow(<Avatar {...props} />);
     expect(toJSON(wrapper)).toMatchSnapshot();

--- a/src/Components/Avatar/__snapshots__/Avatar.test.jsx.snap
+++ b/src/Components/Avatar/__snapshots__/Avatar.test.jsx.snap
@@ -3,7 +3,7 @@
 exports[`Avatar matches snapshot 1`] = `
 <div
   aria-label="John Doe"
-  className="tm-avatar special-class"
+  className="tm-avatar  special-class"
   onClick={[Function]}
   role="img"
 >

--- a/src/Components/BidTracker/BidTracker.jsx
+++ b/src/Components/BidTracker/BidTracker.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { BID_LIST, NOTIFICATION_LIST, USER_PROFILE } from '../../Constants/PropTypes';
 import BidTrackerCardList from './BidTrackerCardList';
+import ProfileSectionTitle from '../ProfileSectionTitle';
 import Spinner from '../Spinner';
 import NotificationsSection from './NotificationsSection';
 import ContactCDOButton from './ContactCDOButton';
@@ -11,7 +12,7 @@ notifications, notificationsIsLoading, markBidTrackerNotification, userProfile,
 userProfileIsLoading }) => {
   const isLoading = bidListIsLoading || userProfileIsLoading;
   return (
-    <div className="bid-tracker-page">
+    <div className="usa-grid-full profile-content-inner-container bid-tracker-page">
       <NotificationsSection
         notifications={notifications}
         notificationsIsLoading={notificationsIsLoading}
@@ -19,8 +20,8 @@ userProfileIsLoading }) => {
       />
       <div className="usa-grid-full">
         <div className="usa-width-one-half bid-tracker-greeting-container">
-          <div className="hello-greeting bid-tracker-greeting">
-            Bid Tracker
+          <div className="usa-grid-full">
+            <ProfileSectionTitle title="Bid Tracker" />
           </div>
         </div>
         <div className="usa-width-one-half bid-tracker-cdo-email-container">

--- a/src/Components/BidTracker/__snapshots__/BidTracker.test.jsx.snap
+++ b/src/Components/BidTracker/__snapshots__/BidTracker.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`BidTrackerComponent matches snapshot 1`] = `
 <div
-  className="bid-tracker-page"
+  className="usa-grid-full profile-content-inner-container bid-tracker-page"
 >
   <NotificationsSection
     markBidTrackerNotification={[Function]}
@@ -66,9 +66,11 @@ exports[`BidTrackerComponent matches snapshot 1`] = `
       className="usa-width-one-half bid-tracker-greeting-container"
     >
       <div
-        className="hello-greeting bid-tracker-greeting"
+        className="usa-grid-full"
       >
-        Bid Tracker
+        <ProfileSectionTitle
+          title="Bid Tracker"
+        />
       </div>
     </div>
     <div
@@ -300,7 +302,7 @@ exports[`BidTrackerComponent matches snapshot 1`] = `
 
 exports[`BidTrackerComponent matches snapshot when bidListIsLoading is true 1`] = `
 <div
-  className="bid-tracker-page"
+  className="usa-grid-full profile-content-inner-container bid-tracker-page"
 >
   <NotificationsSection
     markBidTrackerNotification={[Function]}
@@ -364,9 +366,11 @@ exports[`BidTrackerComponent matches snapshot when bidListIsLoading is true 1`] 
       className="usa-width-one-half bid-tracker-greeting-container"
     >
       <div
-        className="hello-greeting bid-tracker-greeting"
+        className="usa-grid-full"
       >
-        Bid Tracker
+        <ProfileSectionTitle
+          title="Bid Tracker"
+        />
       </div>
     </div>
     <div

--- a/src/Components/ProfileDashboard/ExternalUserStatus/ExternalUserStatus.jsx
+++ b/src/Components/ProfileDashboard/ExternalUserStatus/ExternalUserStatus.jsx
@@ -9,7 +9,7 @@ const ExternalUserStatus = ({ initials, firstName, lastName, type, showMail, ema
   <div className="usa-grid-full cdo-container">
     <div className="usa-grid-full cdo-container-inner section-padded-inner-container">
       <div className="profile-picture-container">
-        <Avatar intiias={initials} firstName={firstName} lastName={lastName} />
+        <Avatar initials={initials} firstName={firstName} lastName={lastName} small />
         <div className="picture-status-container">
           <Status hideText />
         </div>

--- a/src/Components/ProfileDashboard/ExternalUserStatus/__snapshots__/ExternalUserStatus.test.jsx.snap
+++ b/src/Components/ProfileDashboard/ExternalUserStatus/__snapshots__/ExternalUserStatus.test.jsx.snap
@@ -13,10 +13,10 @@ exports[`ExternalUserStatusComponent matches snapshot 1`] = `
       <Avatar
         className=""
         firstName="John"
-        initials=""
-        intiias="JD"
+        initials="JD"
         lastName="Doe"
         onClick={[Function]}
+        small={true}
       />
       <div
         className="picture-status-container"

--- a/src/Components/ProfileDashboard/UserProfile/UserProfileGeneralInformation/__snapshots__/UserProfileGeneralInformation.test.jsx.snap
+++ b/src/Components/ProfileDashboard/UserProfile/UserProfileGeneralInformation/__snapshots__/UserProfileGeneralInformation.test.jsx.snap
@@ -14,6 +14,7 @@ exports[`UserProfileGeneralInformationComponent matches snapshot 1`] = `
       initials="JD"
       lastName="Doe"
       onClick={[Function]}
+      small={false}
     />
     <PositionInformation
       className="current-user-name"
@@ -39,6 +40,7 @@ exports[`UserProfileGeneralInformationComponent matches snapshot when showEditLi
       initials="JD"
       lastName="Doe"
       onClick={[Function]}
+      small={false}
     />
     <PositionInformation
       className="current-user-name"
@@ -64,6 +66,7 @@ exports[`UserProfileGeneralInformationComponent matches snapshot when useGroup i
       initials="JD"
       lastName="Doe"
       onClick={[Function]}
+      small={false}
     />
     <PositionInformation
       className="current-user-name"

--- a/src/Components/ProfileMenu/ProfileMenuExpanded/__snapshots__/ProfileMenuExpanded.test.jsx.snap
+++ b/src/Components/ProfileMenu/ProfileMenuExpanded/__snapshots__/ProfileMenuExpanded.test.jsx.snap
@@ -55,6 +55,12 @@ exports[`ProfileMenuExpandedComponent matches snapshot when isCDO is false 1`] =
         title="Saved Searches"
       />
       <withRouter(NavLink)
+        hidden={false}
+        link="/profile/bidtracker/"
+        search=""
+        title="Bid Tracker"
+      />
+      <withRouter(NavLink)
         hidden={true}
         link="/profile/cycles/"
         search=""
@@ -125,6 +131,12 @@ exports[`ProfileMenuExpandedComponent matches snapshot when isCDO is true 1`] = 
         link="/profile/searches/"
         search=""
         title="Saved Searches"
+      />
+      <withRouter(NavLink)
+        hidden={false}
+        link="/profile/bidtracker/"
+        search=""
+        title="Bid Tracker"
       />
       <withRouter(NavLink)
         hidden={true}
@@ -199,6 +211,12 @@ exports[`ProfileMenuExpandedComponent matches snapshot when isGlossaryEditor is 
         title="Saved Searches"
       />
       <withRouter(NavLink)
+        hidden={false}
+        link="/profile/bidtracker/"
+        search=""
+        title="Bid Tracker"
+      />
+      <withRouter(NavLink)
         hidden={true}
         link="/profile/cycles/"
         search=""
@@ -269,6 +287,12 @@ exports[`ProfileMenuExpandedComponent matches snapshot when user is bidcycle_adm
         link="/profile/searches/"
         search=""
         title="Saved Searches"
+      />
+      <withRouter(NavLink)
+        hidden={false}
+        link="/profile/bidtracker/"
+        search=""
+        title="Bid Tracker"
       />
       <withRouter(NavLink)
         hidden={false}

--- a/src/Components/ProfilePage/ProfilePage.jsx
+++ b/src/Components/ProfilePage/ProfilePage.jsx
@@ -4,6 +4,7 @@ import Dashboard from '../../Containers/Dashboard/Dashboard';
 import BidCycles from '../../Containers/BidCycles';
 import FavoritePositionsContainer from '../../Containers/Favorites/Favorites';
 import GlossaryEditor from '../../Containers/GlossaryEditor';
+import BidTracker from '../../Containers/BidTracker';
 import SavedSearchesWrapper from '../../Components/SavedSearches/SavedSearchesWrapper';
 import GLOSSARY_EDITOR_PERM from '../../Constants/Permissions';
 import { USER_PROFILE } from '../../Constants/PropTypes';
@@ -23,6 +24,7 @@ const ProfilePage = ({ user }) => (
         <Route path="/profile/cycles" component={BidCycles} />
         <Route path="/profile/favorites" component={FavoritePositionsContainer} />
         <Route path="/profile/searches" component={SavedSearchesWrapper} />
+        <Route path="/profile/bidtracker" component={BidTracker} />
         <Route path="/profile/glossaryeditor" component={GlossaryEditor} />
       </Switch>
     </div>

--- a/src/Components/ProfilePage/__snapshots__/ProfilePage.test.jsx.snap
+++ b/src/Components/ProfilePage/__snapshots__/ProfilePage.test.jsx.snap
@@ -30,6 +30,10 @@ exports[`ProfilePageComponent matches snapshot 1`] = `
       />
       <Route
         component={[Function]}
+        path="/profile/bidtracker"
+      />
+      <Route
+        component={[Function]}
         path="/profile/glossaryeditor"
       />
     </Switch>

--- a/src/Constants/Menu.js
+++ b/src/Constants/Menu.js
@@ -62,6 +62,10 @@ export const PROFILE_MENU = MenuConfig([
         route: '/profile/searches/',
       },
       {
+        text: 'Bid Tracker',
+        route: '/profile/bidtracker/',
+      },
+      {
         text: 'Bid Cycles',
         route: '/profile/cycles/',
         roles: [

--- a/src/Containers/Main/Main.test.jsx
+++ b/src/Containers/Main/Main.test.jsx
@@ -82,6 +82,12 @@ describe('Main', () => {
     </MemoryRouter>);
     expect(main).toBeDefined();
   });
+  it('handles a profile/bidtracker route', () => {
+    const main = TestUtils.renderIntoDocument(<MemoryRouter initialEntries={['/profile/bidtracker']}>
+      <Main />
+    </MemoryRouter>);
+    expect(main).toBeDefined();
+  });
   it('handles an about route', () => {
     const main = TestUtils.renderIntoDocument(<MemoryRouter initialEntries={['/about']}>
       <Main />

--- a/src/Containers/Routes/Routes.test.jsx
+++ b/src/Containers/Routes/Routes.test.jsx
@@ -78,6 +78,13 @@ describe('Routes', () => {
       </MemoryRouter></Provider>);
     expect(routes).toBeDefined();
   });
+  it('handles a profile/bidtracker route', () => {
+    const routes = TestUtils.renderIntoDocument(<Provider store={mockStore({})}>
+      <MemoryRouter initialEntries={['/profile/bidtracker']}>
+        <Routes isAuthorized={() => true} />
+      </MemoryRouter></Provider>);
+    expect(routes).toBeDefined();
+  });
   it('handles an about route', () => {
     const routes = TestUtils.renderIntoDocument(<Provider store={mockStore({})}>
       <MemoryRouter initialEntries={['/about']}>

--- a/src/sass/_avatar.scss
+++ b/src/sass/_avatar.scss
@@ -9,3 +9,10 @@
   text-align: center;
   width: $avatar-size;
 }
+
+.tm-avatar--small {
+  font-size: 19px;
+  height: 40px;
+  line-height: 40px;
+  width: 40px;
+}

--- a/src/sass/_bidTracker.scss
+++ b/src/sass/_bidTracker.scss
@@ -3,7 +3,6 @@ $card-width: 775px;
 $draft-icon-offset: 120px;
 
 .bid-tracker-page {
-  padding: 20px;
   position: relative;
 
   .bid-tracker-greeting {
@@ -277,7 +276,7 @@ $draft-icon-offset: 120px;
     border-radius: 35px;
     color: $color-white;
     font-size: 16px;
-    padding: 7px 13px;
+    padding: 7px 12px;
   }
 
   .number-icon-incomplete {
@@ -405,6 +404,7 @@ $draft-icon-offset: 120px;
     }
 
     .rc-steps-item-content {
+      margin-left: 2px;
       margin-top: 18px;
     }
 


### PR DESCRIPTION
Using `sprint-20-rc` to merge dev work into a copy of RC1. This starts that off by adding the Bid Tracker back in. Had to make some small style changes and add a `small` prop to `Avatar` to migrate the old avatars.

Make sure to use the dev API and not the RC1 API.