### PR TITLE
SAML Login Loop Fix

### DIFF
--- a/src/login/Components/TokenValidation.jsx
+++ b/src/login/Components/TokenValidation.jsx
@@ -17,8 +17,8 @@ export class TokenValidation extends Component {
     let token = parsedQuery.tmApiToken;
     // If not, check if one exists in the cookies.
     if (!token) { token = auth.get(); }
-    // If neither criteria is met, set the token to a fake token which will cause a failure.
-    if (!token) { token = 'No token'; }
+    // If neither criteria is met, set the token to null which will cause a failure.
+    if (!token) { token = null; }
     // Finally, pass that token to the tokenValidationRequest function
     this.props.tokenValidationRequest(token);
   }


### PR DESCRIPTION
Checks that `credentials` exists in the `login` saga, and if not, performs logout. We won't pass `login` any credentials if it was called from the `TokenValidation` component, which should prevent most of the function from firing, and thus looping.