### PR TITLE
CodeClimate Issues

### DIFF
--- a/src/Components/PositionDetailsItem/ServiceNeededToggle/ServiceNeededToggle.jsx
+++ b/src/Components/PositionDetailsItem/ServiceNeededToggle/ServiceNeededToggle.jsx
@@ -35,15 +35,14 @@ export default class ServiceNeededToggle extends Component {
   }
 
   render() {
-    const props = this.props;
-    const user = props.userProfile;
+    const user = this.props.userProfile;
     const wrapper = {
       className: 'service-needed-toggle',
     };
 
     const isSuperuser = user.is_superuser;
     const options = {
-      className: ['usa-button', props.className],
+      className: ['usa-button', this.props.className],
       onClick: this.onClick,
     };
 
@@ -54,7 +53,7 @@ export default class ServiceNeededToggle extends Component {
     return isSuperuser ?
       (<div {...wrapper}>
         <InteractiveElement {...options}>
-          {!props.loading ?
+          {!this.props.loading ?
             (<FontAwesome name={this.icon} />) :
             (<div className="ds-c-spinner" />)
           } {this.text}
@@ -64,16 +63,14 @@ export default class ServiceNeededToggle extends Component {
 }
 
 ServiceNeededToggle.propTypes = {
-  as: PropTypes.string.isRequired,
   className: PropTypes.string,
   position: POSITION_DETAILS,
   userProfile: USER_PROFILE,
-  loading: PropTypes.bool.isRequired,
+  loading: PropTypes.bool,
   onChange: PropTypes.func,
 };
 
 ServiceNeededToggle.defaultProps = {
-  as: 'div',
   className: '',
   position: {},
   userProfile: {},

--- a/src/Components/PositionDetailsItem/__snapshots__/PositionDetailsItem.test.jsx.snap
+++ b/src/Components/PositionDetailsItem/__snapshots__/PositionDetailsItem.test.jsx.snap
@@ -150,7 +150,6 @@ exports[`PositionDetailsItem matches snapshot 1`] = `
         resetDescriptionEditMessages={[Function]}
       />
       <ServiceNeededToggle
-        as="div"
         className=""
         loading={false}
         onChange={[Function]}
@@ -373,7 +372,6 @@ exports[`PositionDetailsItem matches snapshot when there is an obc id 1`] = `
         resetDescriptionEditMessages={[Function]}
       />
       <ServiceNeededToggle
-        as="div"
         className=""
         loading={false}
         onChange={[Function]}
@@ -574,7 +572,6 @@ exports[`PositionDetailsItem matches snapshot when various data is missing from 
         resetDescriptionEditMessages={[Function]}
       />
       <ServiceNeededToggle
-        as="div"
         className=""
         loading={false}
         onChange={[Function]}


### PR DESCRIPTION
```
'as' PropType is defined but prop is never used OPEN
  as: PropTypes.string.isRequired,
Severity: MinorFound in src/Components/PositionDetailsItem/ServiceNeededToggle/ServiceNeededToggle.jsx by eslint
Read upRead upCreate a ticketCreate a ticketExclude checks
'className' PropType is defined but prop is never used OPEN
  className: PropTypes.string,
Severity: MinorFound in src/Components/PositionDetailsItem/ServiceNeededToggle/ServiceNeededToggle.jsx by eslint
'userProfile' PropType is defined but prop is never used OPEN
  userProfile: USER_PROFILE,
Severity: MinorFound in src/Components/PositionDetailsItem/ServiceNeededToggle/ServiceNeededToggle.jsx by eslint
'loading' PropType is defined but prop is never used OPEN
  loading: PropTypes.bool.isRequired,
Severity: MinorFound in src/Components/PositionDetailsItem/ServiceNeededToggle/ServiceNeededToggle.jsx by eslint
```
<img width="811" alt="screen shot 2018-05-07 at 10 40 17 pm" src="https://user-images.githubusercontent.com/661204/39735014-adef03b8-5247-11e8-8f4e-da63fa70d916.png">
